### PR TITLE
feat: S3-2 重複チェック・冪等性ロジック

### DIFF
--- a/core/tools/gws_dedup.py
+++ b/core/tools/gws_dedup.py
@@ -1,0 +1,226 @@
+# AnimaWorks - Digital Anima Framework
+# Copyright (C) 2026 AnimaWorks Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file is part of AnimaWorks core/server, licensed under Apache-2.0.
+# See LICENSE for the full license text.
+
+"""GWS to Notion deduplication and idempotency module.
+
+Prevents duplicate registration of GWS-extracted development requests
+into Notion by checking source_id-based idempotency keys against
+the Notion DB and a local cache.
+
+Design: s3-2_dedup_design.md
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+logger = logging.getLogger("animaworks.tools")
+
+
+# -- Idempotency key generation (section 2.3) --
+
+
+def generate_idempotency_key(record: dict[str, Any]) -> str | None:
+    """Generate an idempotency key for a GWS record.
+
+    Priority:
+        1. source_id -> "sid:<source_id>"
+        2. SHA256(request_title + received_at) -> "hash:<16 hex chars>"
+        3. None (key generation impossible)
+    """
+    source_id = (record.get("source_id") or "").strip()
+    if source_id:
+        return f"sid:{source_id}"
+
+    title = (record.get("request_title") or "").strip()
+    date = (record.get("received_at") or "").strip()
+    if title and date:
+        raw = f"{title}|{date}"
+        hash_val = hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+        return f"hash:{hash_val}"
+
+    return None
+
+
+# -- Notion duplicate check (section 4.2) --
+
+
+def check_duplicate_in_notion(
+    client: Any,
+    database_id: str,
+    idempotency_key: str,
+) -> bool:
+    """Check if a record with the given idempotency key exists in Notion."""
+    result = client.query_database(
+        database_id=database_id,
+        filter={
+            "property": "冪等性キー",
+            "rich_text": {"equals": idempotency_key},
+        },
+        page_size=1,
+    )
+    return len(result.get("results", [])) > 0
+
+
+# -- Local cache (section 6) --
+
+
+class DedupCache:
+    """Local file-backed cache for idempotency keys."""
+
+    def __init__(self, cache_path: str, max_entries: int = 1000) -> None:
+        self._path = cache_path
+        self._max_entries = max_entries
+        self._entries: dict[str, dict[str, str]] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if not os.path.exists(self._path):
+            return
+        try:
+            with open(self._path, encoding="utf-8") as f:
+                data = json.load(f)
+            self._entries = data.get("entries", {})
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Cache file corrupted, initializing empty: %s", exc)
+            self._entries = {}
+
+    def save(self) -> None:
+        """Persist cache to disk atomically."""
+        tmp_path = self._path + ".tmp"
+        data = {
+            "version": 1,
+            "max_entries": self._max_entries,
+            "entries": self._entries,
+            "last_updated": datetime.now().isoformat(),
+        }
+        os.makedirs(os.path.dirname(self._path) or ".", exist_ok=True)
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        os.replace(tmp_path, self._path)
+
+    def contains(self, key: str) -> bool:
+        return key in self._entries
+
+    def add(self, key: str, notion_page_id: str) -> None:
+        self._entries[key] = {
+            "notion_page_id": notion_page_id,
+            "registered_at": datetime.now().isoformat(),
+        }
+        self._evict()
+
+    def _evict(self) -> None:
+        if len(self._entries) <= self._max_entries:
+            return
+        sorted_keys = sorted(
+            self._entries,
+            key=lambda k: self._entries[k].get("registered_at", ""),
+        )
+        excess = len(self._entries) - self._max_entries
+        for k in sorted_keys[:excess]:
+            del self._entries[k]
+
+
+# -- Lock mechanism (section 5.2) --
+
+_STALE_THRESHOLD = 3600  # 1 hour
+
+
+def acquire_lock(lock_path: str) -> bool:
+    """Acquire an exclusive lock file for pipeline execution."""
+    if os.path.exists(lock_path):
+        lock_age = time.time() - os.path.getmtime(lock_path)
+        if lock_age < _STALE_THRESHOLD:
+            return False
+        logger.warning("Stale lock detected (age: %.0fs), forcing release", lock_age)
+
+    os.makedirs(os.path.dirname(lock_path) or ".", exist_ok=True)
+    with open(lock_path, "w", encoding="utf-8") as f:
+        json.dump(
+            {"pid": os.getpid(), "started_at": datetime.now().isoformat()}, f
+        )
+    return True
+
+
+def release_lock(lock_path: str) -> None:
+    """Release the execution lock."""
+    if os.path.exists(lock_path):
+        os.remove(lock_path)
+
+
+# -- Dedup result --
+
+
+@dataclass
+class DedupResult:
+    """Result of the deduplication check."""
+
+    new: list[tuple[dict, dict]] = field(default_factory=list)
+    duplicates: list[tuple[dict, dict, str]] = field(default_factory=list)
+    no_key: list[tuple[dict, dict]] = field(default_factory=list)
+    api_errors: list[tuple[dict, dict, str]] = field(default_factory=list)
+
+
+# -- Main dedup function (section 4.1) --
+
+
+def deduplicate_records(
+    records: list[tuple[dict, dict]],
+    client: Any,
+    database_id: str,
+    cache: DedupCache,
+) -> DedupResult:
+    """Filter out duplicate records using cache and Notion DB.
+
+    Flow per record:
+        1. Generate idempotency key
+        2. Check local cache -> if hit, skip
+        3. Check Notion DB -> if hit, skip + add to cache
+        4. Otherwise, mark as new
+    """
+    result = DedupResult()
+
+    for rec, props in records:
+        key = generate_idempotency_key(rec)
+
+        if key is None:
+            logger.warning(
+                "Cannot generate idempotency key for record: %s",
+                rec.get("request_title", "?")[:50],
+            )
+            result.new.append((rec, props))
+            result.no_key.append((rec, props))
+            continue
+
+        if cache.contains(key):
+            logger.info("Cache hit (duplicate): %s", key)
+            result.duplicates.append((rec, props, key))
+            continue
+
+        try:
+            is_dup = check_duplicate_in_notion(client, database_id, key)
+        except Exception as exc:
+            logger.error("Notion API error during dedup check for %s: %s", key, exc)
+            result.new.append((rec, props))
+            result.api_errors.append((rec, props, str(exc)))
+            continue
+
+        if is_dup:
+            logger.info("Notion hit (duplicate): %s", key)
+            cache.add(key, "notion-existing")
+            result.duplicates.append((rec, props, key))
+        else:
+            result.new.append((rec, props))
+
+    return result

--- a/tests/unit/tooling/test_gws_dedup.py
+++ b/tests/unit/tooling/test_gws_dedup.py
@@ -1,0 +1,407 @@
+"""Tests for core.tools.gws_dedup — deduplication & idempotency module.
+
+TDD RED phase: T1–T13 from s3-2_dedup_design.md §7.
+"""
+# AnimaWorks - Digital Anima Framework
+# Copyright (C) 2026 AnimaWorks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from core.tools.gws_dedup import (
+    DedupCache,
+    DedupResult,
+    acquire_lock,
+    check_duplicate_in_notion,
+    deduplicate_records,
+    generate_idempotency_key,
+    release_lock,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_record(**overrides: object) -> dict:
+    """Build a valid GWS record with sensible defaults."""
+    base = {
+        "request_title": "ダッシュボードの表示速度改善",
+        "problem": "読み込みに10秒以上かかる",
+        "desired_outcome": "3秒以内に表示",
+        "product_area": "ダッシュボード",
+        "urgency": "高",
+        "evidence_quote": "複数顧客から同一報告あり",
+        "confidence": "high",
+        "source_id": "SRC-001",
+        "received_at": "2026-01-15T10:30:00+09:00",
+        "source_type": "メール",
+        "source_link": "https://support.example.com/ticket/123",
+        "product": "ProductA",
+        "type": "FEATURE",
+        "customer": "ABC株式会社",
+        "text_excerpt": "ダッシュボードが遅い",
+        "cluster_key": "dashboard-perf",
+        "source_row_url": "https://docs.google.com/spreadsheets/d/xxx/edit#gid=0&range=A15",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_notion_props(record: dict) -> dict:
+    """Build minimal Notion properties dict for testing."""
+    return {
+        "Name": {"title": [{"text": {"content": record["request_title"]}}]},
+        "Status": {"select": {"name": "新規"}},
+        "Label": {"multi_select": [{"name": "AI"}]},
+        "AIによる要約": {"rich_text": [{"text": {"content": "test summary"}}]},
+    }
+
+
+def _mock_client_no_duplicates() -> MagicMock:
+    """NotionClient mock that always returns no results (no duplicates)."""
+    client = MagicMock()
+    client.query_database.return_value = {"results": []}
+    return client
+
+
+def _mock_client_with_duplicate(page_id: str = "existing-page-123") -> MagicMock:
+    """NotionClient mock that returns one existing page (duplicate found)."""
+    client = MagicMock()
+    client.query_database.return_value = {"results": [{"id": page_id}]}
+    return client
+
+
+# ── generate_idempotency_key ─────────────────────────────────────────────────
+
+
+class TestGenerateIdempotencyKey:
+    """Key generation logic (§2.3)."""
+
+    def test_source_id_produces_sid_prefix(self):
+        rec = _make_record(source_id="TICKET-001")
+        key = generate_idempotency_key(rec)
+        assert key == "sid:TICKET-001"
+
+    def test_fallback_hash_when_no_source_id(self):
+        rec = _make_record(source_id="")
+        key = generate_idempotency_key(rec)
+        assert key is not None
+        assert key.startswith("hash:")
+        assert len(key) == 5 + 16  # "hash:" + 16 hex chars
+
+    def test_none_when_no_source_id_no_title(self):
+        rec = _make_record(source_id="", request_title="", received_at="")
+        key = generate_idempotency_key(rec)
+        assert key is None
+
+    def test_deterministic_hash(self):
+        rec1 = _make_record(source_id="", request_title="foo", received_at="2026-01-01")
+        rec2 = _make_record(source_id="", request_title="foo", received_at="2026-01-01")
+        assert generate_idempotency_key(rec1) == generate_idempotency_key(rec2)
+
+    def test_different_records_different_hash(self):
+        rec1 = _make_record(source_id="", request_title="foo", received_at="2026-01-01")
+        rec2 = _make_record(source_id="", request_title="bar", received_at="2026-01-01")
+        assert generate_idempotency_key(rec1) != generate_idempotency_key(rec2)
+
+
+# ── check_duplicate_in_notion ────────────────────────────────────────────────
+
+
+class TestCheckDuplicateInNotion:
+    """Notion DB duplicate check (§4.2)."""
+
+    def test_no_duplicate_returns_false(self):
+        client = _mock_client_no_duplicates()
+        assert check_duplicate_in_notion(client, "db-id", "sid:SRC-001") is False
+
+    def test_duplicate_found_returns_true(self):
+        client = _mock_client_with_duplicate()
+        assert check_duplicate_in_notion(client, "db-id", "sid:SRC-001") is True
+
+    def test_queries_correct_filter(self):
+        client = _mock_client_no_duplicates()
+        check_duplicate_in_notion(client, "db-id", "sid:SRC-001")
+        client.query_database.assert_called_once_with(
+            database_id="db-id",
+            filter={
+                "property": "冪等性キー",
+                "rich_text": {"equals": "sid:SRC-001"},
+            },
+            page_size=1,
+        )
+
+
+# ── DedupCache ───────────────────────────────────────────────────────────────
+
+
+class TestDedupCache:
+    """Local cache for dedup keys (§6)."""
+
+    def test_new_cache_is_empty(self, tmp_path: Path):
+        cache = DedupCache(cache_path=str(tmp_path / "cache.json"))
+        assert cache.contains("sid:SRC-001") is False
+
+    def test_add_and_contains(self, tmp_path: Path):
+        cache = DedupCache(cache_path=str(tmp_path / "cache.json"))
+        cache.add("sid:SRC-001", "page-123")
+        assert cache.contains("sid:SRC-001") is True
+
+    def test_persist_and_reload(self, tmp_path: Path):
+        path = str(tmp_path / "cache.json")
+        cache1 = DedupCache(cache_path=path)
+        cache1.add("sid:SRC-001", "page-123")
+        cache1.save()
+
+        cache2 = DedupCache(cache_path=path)
+        assert cache2.contains("sid:SRC-001") is True
+
+    def test_lru_eviction_at_max(self, tmp_path: Path):
+        """T11: Cache at max_entries evicts oldest."""
+        cache = DedupCache(cache_path=str(tmp_path / "cache.json"), max_entries=5)
+        for i in range(6):
+            cache.add(f"sid:SRC-{i:03d}", f"page-{i}")
+        # First entry should be evicted
+        assert cache.contains("sid:SRC-000") is False
+        assert cache.contains("sid:SRC-005") is True
+
+    def test_corrupted_file_initializes_empty(self, tmp_path: Path):
+        """T7: Corrupted cache file → empty cache, no error."""
+        path = tmp_path / "cache.json"
+        path.write_text("not valid json {{{", encoding="utf-8")
+        cache = DedupCache(cache_path=str(path))
+        assert cache.contains("sid:anything") is False
+
+
+# ── Lock mechanism ───────────────────────────────────────────────────────────
+
+
+class TestLockMechanism:
+    """Concurrency lock (§5.2)."""
+
+    def test_acquire_and_release(self, tmp_path: Path):
+        """T9: Lock acquire/release basics."""
+        lock_path = str(tmp_path / "test.lock")
+        assert acquire_lock(lock_path) is True
+        assert acquire_lock(lock_path) is False  # Second acquire fails
+        release_lock(lock_path)
+        assert acquire_lock(lock_path) is True  # Can acquire again
+        release_lock(lock_path)
+
+    def test_stale_lock_force_released(self, tmp_path: Path):
+        """T10: Lock older than 1 hour is force-released."""
+        lock_path = str(tmp_path / "test.lock")
+        # Create a stale lock
+        with open(lock_path, "w") as f:
+            json.dump({"pid": 99999, "started_at": "2026-01-01T00:00:00"}, f)
+        # Set mtime to 2 hours ago
+        old_time = time.time() - 7200
+        os.utime(lock_path, (old_time, old_time))
+
+        assert acquire_lock(lock_path) is True  # Stale lock is released
+        release_lock(lock_path)
+
+
+# ── deduplicate_records (main function) ──────────────────────────────────────
+
+
+class TestDeduplicateRecords:
+    """Main dedup function (§4.1 flow)."""
+
+    def test_t1_new_record_passes_through(self, tmp_path: Path):
+        """T1: New record → registered, cache updated."""
+        client = _mock_client_no_duplicates()
+        cache = DedupCache(cache_path=str(tmp_path / "cache.json"))
+        rec = _make_record(source_id="SRC-NEW")
+        props = _make_notion_props(rec)
+
+        result = deduplicate_records(
+            records=[(rec, props)],
+            client=client,
+            database_id="db-id",
+            cache=cache,
+        )
+
+        assert len(result.new) == 1
+        assert len(result.duplicates) == 0
+
+    def test_t2_cache_hit_skips(self, tmp_path: Path):
+        """T2: Cache hit → skip, no Notion API call."""
+        client = _mock_client_no_duplicates()
+        cache = DedupCache(cache_path=str(tmp_path / "cache.json"))
+        cache.add("sid:SRC-EXISTING", "page-existing")
+
+        rec = _make_record(source_id="SRC-EXISTING")
+        props = _make_notion_props(rec)
+
+        result = deduplicate_records(
+            records=[(rec, props)],
+            client=client,
+            database_id="db-id",
+            cache=cache,
+        )
+
+        assert len(result.new) == 0
+        assert len(result.duplicates) == 1
+        client.query_database.assert_not_called()
+
+    def test_t3_notion_hit_skips_and_caches(self, tmp_path: Path):
+        """T3: Cache miss, Notion hit → skip, add to cache."""
+        client = _mock_client_with_duplicate("page-notion-123")
+        cache = DedupCache(cache_path=str(tmp_path / "cache.json"))
+
+        rec = _make_record(source_id="SRC-NOTION")
+        props = _make_notion_props(rec)
+
+        result = deduplicate_records(
+            records=[(rec, props)],
+            client=client,
+            database_id="db-id",
+            cache=cache,
+        )
+
+        assert len(result.new) == 0
+        assert len(result.duplicates) == 1
+        assert cache.contains("sid:SRC-NOTION") is True
+
+    def test_t4_fallback_hash_key(self, tmp_path: Path):
+        """T4: No source_id → fallback hash key used for dedup."""
+        client = _mock_client_no_duplicates()
+        cache = DedupCache(cache_path=str(tmp_path / "cache.json"))
+
+        rec = _make_record(source_id="")
+        # source_id is empty, but V2 in gws_transform would skip this.
+        # For dedup, we test the key generation fallback directly.
+        rec["request_title"] = "テスト要望"
+        rec["received_at"] = "2026-01-15"
+        props = _make_notion_props(rec)
+
+        result = deduplicate_records(
+            records=[(rec, props)],
+            client=client,
+            database_id="db-id",
+            cache=cache,
+        )
+
+        assert len(result.new) == 1
+        # Verify hash key was used
+        client.query_database.assert_called_once()
+        call_filter = client.query_database.call_args[1]["filter"]
+        assert call_filter["property"] == "冪等性キー"
+        assert call_filter["rich_text"]["equals"].startswith("hash:")
+
+    def test_t5_mixed_batch(self, tmp_path: Path):
+        """T5: 3 new + 2 duplicate → 3 new, 2 skipped."""
+        cache = DedupCache(cache_path=str(tmp_path / "cache.json"))
+        cache.add("sid:DUP-001", "page-d1")
+        cache.add("sid:DUP-002", "page-d2")
+
+        client = _mock_client_no_duplicates()
+
+        records = []
+        for i in range(3):
+            rec = _make_record(source_id=f"NEW-{i}")
+            records.append((rec, _make_notion_props(rec)))
+        for sid in ("DUP-001", "DUP-002"):
+            rec = _make_record(source_id=sid)
+            records.append((rec, _make_notion_props(rec)))
+
+        result = deduplicate_records(
+            records=records,
+            client=client,
+            database_id="db-id",
+            cache=cache,
+        )
+
+        assert len(result.new) == 3
+        assert len(result.duplicates) == 2
+
+    def test_t6_key_generation_impossible(self, tmp_path: Path):
+        """T6: No source_id, no title → warning, register anyway."""
+        client = _mock_client_no_duplicates()
+        cache = DedupCache(cache_path=str(tmp_path / "cache.json"))
+
+        rec = _make_record(source_id="", request_title="", received_at="")
+        props = _make_notion_props(rec)
+
+        result = deduplicate_records(
+            records=[(rec, props)],
+            client=client,
+            database_id="db-id",
+            cache=cache,
+        )
+
+        # Cannot generate key → pass through (accept duplicate risk)
+        assert len(result.new) == 1
+        assert len(result.no_key) == 1
+
+    def test_t8_notion_api_failure_passes_through(self, tmp_path: Path):
+        """T8: Notion API error → pass through with warning."""
+        client = MagicMock()
+        client.query_database.side_effect = Exception("API error 500")
+        cache = DedupCache(cache_path=str(tmp_path / "cache.json"))
+
+        rec = _make_record(source_id="SRC-ERR")
+        props = _make_notion_props(rec)
+
+        result = deduplicate_records(
+            records=[(rec, props)],
+            client=client,
+            database_id="db-id",
+            cache=cache,
+        )
+
+        # API failure → register anyway (duplicate risk accepted)
+        assert len(result.new) == 1
+        assert len(result.api_errors) == 1
+
+    def test_t12_all_cache_hits_no_api_calls(self, tmp_path: Path):
+        """T12: All records in cache → zero Notion API calls."""
+        cache = DedupCache(cache_path=str(tmp_path / "cache.json"))
+        records = []
+        for i in range(20):
+            sid = f"CACHED-{i:03d}"
+            cache.add(f"sid:{sid}", f"page-{i}")
+            rec = _make_record(source_id=sid)
+            records.append((rec, _make_notion_props(rec)))
+
+        client = _mock_client_no_duplicates()
+
+        result = deduplicate_records(
+            records=records,
+            client=client,
+            database_id="db-id",
+            cache=cache,
+        )
+
+        assert len(result.new) == 0
+        assert len(result.duplicates) == 20
+        client.query_database.assert_not_called()
+
+    def test_t13_all_cache_misses_api_calls(self, tmp_path: Path):
+        """T13: No cache hits → Notion API called for each."""
+        client = _mock_client_no_duplicates()
+        cache = DedupCache(cache_path=str(tmp_path / "cache.json"))
+
+        records = []
+        for i in range(5):
+            rec = _make_record(source_id=f"MISS-{i:03d}")
+            records.append((rec, _make_notion_props(rec)))
+
+        result = deduplicate_records(
+            records=records,
+            client=client,
+            database_id="db-id",
+            cache=cache,
+        )
+
+        assert len(result.new) == 5
+        assert client.query_database.call_count == 5


### PR DESCRIPTION
## Summary

Sprint 3 S3-2: GWS→Notion登録パイプラインの重複チェック・冪等性ロジック。

### 実装内容
- `core/tools/gws_dedup.py` — 重複チェックモジュール
  - `generate_idempotency_key()` — source_idベース(優先) + SHA256フォールバック
  - `check_duplicate_in_notion()` — Notion DB「冪等性キー」プロパティ照合
  - `DedupCache` — ローカルキャッシュ（LRU, max 1000件, アトミック永続化）
  - `acquire_lock()` / `release_lock()` — ロックファイルで同時実行防止
  - `deduplicate_records()` — キャッシュ先行 → Notion照合のメインフロー

- `tests/unit/tooling/test_gws_dedup.py` — TDD T1-T13テスト
  - T1: 新規レコード通過
  - T2: キャッシュヒット → スキップ（API呼び出しなし）
  - T3: Notionヒット → スキップ + キャッシュ追加
  - T4: source_id空 → ハッシュフォールバック
  - T5: 混在バッチ（3新規+2重複）
  - T6: キー生成不能 → 登録実行（重複リスク受容）
  - T7: キャッシュ破損 → 空初期化
  - T8: Notion API障害 → 登録実行
  - T9/T10: ロック取得/デッドロック検出
  - T11: LRU eviction
  - T12: 全件キャッシュヒット（API 0回）
  - T13: 全件キャッシュミス

### テスト結果
- 新規テスト: 24件 全PASS
- 既存テスト: 460件 全PASS（リグレッションなし）
- 合計: 484件 全PASS

### 設計書
- `shared/tmp/s3-2_dedup_design.md` に準拠

### 未解決事項
- Notionに「冪等性キー」プロパティ追加: タロー確認待ち

## Test plan
- [x] T1-T13 全テストPASS
- [x] 既存テストリグレッションなし（484件全PASS）