### PR TITLE
fix: resolve symlink mismatches in FileWatcher and harden test suite

### DIFF
--- a/core/memory/rag/watcher.py
+++ b/core/memory/rag/watcher.py
@@ -94,7 +94,7 @@ class FileWatcher:
             extra_watch_dirs: Additional (directory, memory_type) pairs to watch.
                 Used for common_knowledge/ watching with a shared indexer.
         """
-        self.anima_dir = anima_dir
+        self.anima_dir = anima_dir.resolve()
         self.indexer = indexer
         self.knowledge_graph = knowledge_graph
         self.anima_name = anima_name
@@ -183,8 +183,8 @@ class FileWatcher:
         Args:
             file_path: Path to file to index
         """
-        # Update queue with current timestamp
-        self._queue[file_path] = time.time()
+        # Update queue with current timestamp (resolve to avoid symlink mismatches)
+        self._queue[file_path.resolve()] = time.time()
         logger.debug("Queued file: %s (queue size: %d)", file_path, len(self._queue))
 
     async def _process_queue_loop(self) -> None:
@@ -288,6 +288,9 @@ class FileWatcher:
         Returns:
             Memory type or None if not recognized
         """
+        # Resolve to avoid symlink mismatches (e.g. /tmp vs /private/tmp on macOS)
+        file_path = file_path.resolve()
+
         # Check extra watch dirs first (e.g., common_knowledge/)
         for extra_dir, memory_type in self._extra_watch_dirs:
             try:

--- a/templates/ja/common_knowledge/communication/messaging-guide.md
+++ b/templates/ja/common_knowledge/communication/messaging-guide.md
@@ -9,6 +9,7 @@
 
 ### パラメータ一覧
 
+<!-- AUTO-GENERATED:START tool_parameters -->
 | パラメータ | 型 | 必須 | 説明 |
 |-----------|------|------|------|
 | `to` | string | MUST | 宛先。Anima 名（例: `alice`）または人間のエイリアス（例: `user`, `taka`）。人間エイリアスは外部チャネル（Slack/Chatwork）経由で配信される |
@@ -16,6 +17,7 @@
 | `intent` | string | MUST | メッセージの意図。許可値: `report`（進捗・結果報告）, `delegation`（タスク委譲）, `question`（質問・返答が必要な問い合わせ）のみ。acknowledgment・感謝・FYI は Board（post_channel）を使用すること |
 | `reply_to` | string | MAY | 返信先メッセージの ID（例: `20260215_093000_123456`） |
 | `thread_id` | string | MAY | スレッド ID。既存スレッドに参加する場合に指定 |
+<!-- AUTO-GENERATED:END -->
 
 ### DM の制限（1回の run あたり）
 

--- a/templates/ja/common_knowledge/operations/heartbeat-cron-guide.md
+++ b/templates/ja/common_knowledge/operations/heartbeat-cron-guide.md
@@ -180,6 +180,7 @@ type: llm
 
 各タスクは内部的に以下の `CronTask` モデルにパースされる:
 
+<!-- AUTO-GENERATED:START cron_fields -->
 | フィールド | 型 | デフォルト | 説明 |
 |-----------|------|-----------|------|
 | `name` | str | （必須） | タスク名。`##` 見出しから抽出される |
@@ -191,6 +192,7 @@ type: llm
 | `args` | dict \| None | `None` | tool の引数（YAML 形式） |
 | `skip_pattern` | str \| None | `None` | Command 型: stdout がこの正規表現にマッチしたら follow-up LLM をスキップ |
 | `trigger_heartbeat` | bool | `True` | Command 型: `False` ならコマンド出力後の follow-up cron LLM をスキップ |
+<!-- AUTO-GENERATED:END -->
 
 ## LLM 型 Cron タスク
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,8 @@ load_dotenv()
 try:
     import chromadb
     CHROMADB_AVAILABLE = True
-except ImportError:
+except Exception:
+    # Catch ImportError and also pydantic/compatibility errors (e.g. on Python 3.14)
     CHROMADB_AVAILABLE = False
 
 

--- a/tests/unit/cli/commands/test_server.py
+++ b/tests/unit/cli/commands/test_server.py
@@ -252,7 +252,7 @@ class TestCmdStart:
         mock_app = MagicMock()
         mock_create.return_value = mock_app
 
-        args = argparse.Namespace(host="0.0.0.0", port=18500)
+        args = argparse.Namespace(host="0.0.0.0", port=18500, foreground=True)
         cmd_start(args)
 
         mock_uvicorn.assert_called_once_with(
@@ -287,7 +287,7 @@ class TestCmdStart:
         mock_app = MagicMock()
         mock_create.return_value = mock_app
 
-        args = argparse.Namespace(host="0.0.0.0", port=18500)
+        args = argparse.Namespace(host="0.0.0.0", port=18500, foreground=True)
         cmd_start(args)
 
         call_kwargs = mock_uvicorn.call_args
@@ -314,7 +314,7 @@ class TestCmdStart:
         mock_app = MagicMock()
         mock_create.return_value = mock_app
 
-        args = argparse.Namespace(host="0.0.0.0", port=18500)
+        args = argparse.Namespace(host="0.0.0.0", port=18500, foreground=True)
         cmd_start(args)
 
         call_kwargs = mock_uvicorn.call_args
@@ -359,18 +359,18 @@ class TestCmdStop:
 
 
 class TestCmdRestart:
-    @patch("cli.commands.server.cmd_start")
+    @patch("cli.commands.server._spawn_daemon")
     @patch("cli.commands.server._clear_pycache", return_value=0)
     @patch("cli.commands.server._stop_server", return_value=True)
     @patch("time.sleep")
-    def test_restart_success(self, mock_sleep, mock_stop, mock_clear, mock_start):
+    def test_restart_success(self, mock_sleep, mock_stop, mock_clear, mock_spawn):
         from cli.commands.server import cmd_restart
 
         args = argparse.Namespace(host="0.0.0.0", port=18500)
         cmd_restart(args)
 
         mock_stop.assert_called_once()
-        mock_start.assert_called_once_with(args)
+        mock_spawn.assert_called_once_with(args)
 
     @patch("cli.commands.server._stop_server", return_value=False)
     def test_restart_stop_fails(self, mock_stop):

--- a/tests/unit/core/config/test_models.py
+++ b/tests/unit/core/config/test_models.py
@@ -493,10 +493,17 @@ class TestMatchPatternTable:
 
 class TestResolveExecutionModeWildcard:
     @pytest.fixture(autouse=True)
-    def _clear_models_json(self):
-        """Ensure models.json cache does not leak between tests."""
+    def _clear_models_json(self, monkeypatch):
+        """Ensure models.json cache does not leak between tests.
+
+        Also patches _load_models_json to return {} so the real
+        ~/.animaworks/models.json does not interfere with assertions
+        about config.json model_modes and code-default priorities.
+        """
+        import core.config.models as _m
         from core.config.models import invalidate_models_json_cache
         invalidate_models_json_cache()
+        monkeypatch.setattr(_m, "_load_models_json", lambda: {})
         yield
         invalidate_models_json_cache()
 

--- a/tests/unit/core/memory/test_access_frequency.py
+++ b/tests/unit/core/memory/test_access_frequency.py
@@ -326,10 +326,10 @@ class TestUpdateMetadataOnVectorStore:
         update_metadata to change a field, then queries back and verifies
         the metadata was updated.
         """
-        chromadb = pytest.importorskip(
-            "chromadb",
-            reason="ChromaDB not installed. Install with: pip install 'animaworks[rag]'",
-        )
+        try:
+            import chromadb  # noqa: F401
+        except Exception:
+            pytest.skip("chromadb not available (Python 3.14 pydantic incompatibility)")
 
         from core.memory.rag.store import ChromaVectorStore, Document
 

--- a/tests/unit/core/memory/test_knowledge_failure_tracking.py
+++ b/tests/unit/core/memory/test_knowledge_failure_tracking.py
@@ -444,7 +444,10 @@ class TestIndexerMetadataExtraction:
 
     def test_extracts_failure_tracking_fields(self, tmp_path: Path) -> None:
         """Verify that indexing picks up the new tracking fields in ChromaDB."""
-        pytest.importorskip("chromadb")
+        try:
+            import chromadb  # noqa: F401
+        except Exception:
+            pytest.skip("chromadb not available (Python 3.14 pydantic incompatibility)")
         pytest.importorskip("sentence_transformers")
 
         # Set up a full data dir structure for model loading

--- a/tests/unit/core/memory/test_watcher.py
+++ b/tests/unit/core/memory/test_watcher.py
@@ -82,7 +82,7 @@ async def test_file_creation_triggers_indexing(temp_anima_dir):
 
     # Check that file was indexed
     assert len(indexer.indexed_files) > 0
-    assert any(fp == test_file for fp, _ in indexer.indexed_files)
+    assert any(fp == test_file.resolve() for fp, _ in indexer.indexed_files)
 
 
 @pytest.mark.asyncio
@@ -123,8 +123,8 @@ def test_queue_file(temp_anima_dir):
     # Queue file manually
     watcher.queue_file(test_file)
 
-    # Check that file is in queue
-    assert test_file in watcher._queue
+    # Check that file is in queue (resolved to match watcher's path normalization)
+    assert test_file.resolve() in watcher._queue
 
 
 def test_memory_type_detection(temp_anima_dir):

--- a/tests/unit/execution/test_streaming_executors.py
+++ b/tests/unit/execution/test_streaming_executors.py
@@ -364,6 +364,7 @@ class FakeStreamChunk:
         delta = MagicMock()
         delta.content = text
         delta.tool_calls = tool_calls
+        delta.reasoning_content = None  # prevent MagicMock from leaking into _reasoning_parts
 
         choice = MagicMock()
         choice.delta = delta

--- a/tests/unit/server/test_slack_socket.py
+++ b/tests/unit/server/test_slack_socket.py
@@ -10,6 +10,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+pytestmark = pytest.mark.skipif(
+    not __import__("importlib.util", fromlist=["find_spec"]).find_spec("slack_bolt"),
+    reason="slack_bolt not installed",
+)
+
 
 # ── SlackSocketModeManager ───────────────────────────────
 

--- a/tests/unit/test_runner_deferred_trigger.py
+++ b/tests/unit/test_runner_deferred_trigger.py
@@ -83,6 +83,8 @@ class TestTryDeferredTrigger:
         limiter._anima.messenger.has_unread.return_value = True
         limiter._anima._inbox_lock = MagicMock()
         limiter._anima._inbox_lock.locked.return_value = False
+        limiter._anima._background_lock = MagicMock()
+        limiter._anima._background_lock.locked.return_value = False
         limiter._deferred_timer = MagicMock()
 
         with patch.object(limiter, "is_in_cooldown", return_value=False), \

--- a/tests/unit/tools/test_asset_optimization.py
+++ b/tests/unit/tools/test_asset_optimization.py
@@ -362,8 +362,8 @@ class TestCreateAnimationTaskPostProcess:
     """Tests for create_animation_task extract_armature post_process parameter."""
 
     def _make_client(self):
-        with patch("core.tools.image_gen.get_credential", return_value="test-key"):
-            from core.tools.image_gen import MeshyClient
+        with patch("core.tools._image_clients.get_credential", return_value="test-key"):
+            from core.tools._image_clients import MeshyClient
             return MeshyClient()
 
     def test_includes_extract_armature(self):
@@ -395,8 +395,8 @@ class TestDownloadRiggingAnimations:
     """Tests for MeshyClient.download_rigging_animations armature preference."""
 
     def _make_client(self):
-        with patch("core.tools.image_gen.get_credential", return_value="test-key"):
-            from core.tools.image_gen import MeshyClient
+        with patch("core.tools._image_clients.get_credential", return_value="test-key"):
+            from core.tools._image_clients import MeshyClient
             return MeshyClient()
 
     def test_prefers_armature_glb_url(self):

--- a/uv.lock
+++ b/uv.lock
@@ -131,7 +131,7 @@ wheels = [
 
 [[package]]
 name = "animaworks"
-version = "0.4.1"
+version = "0.4.7"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -142,7 +142,9 @@ dependencies = [
     { name = "httpx" },
     { name = "json-repair" },
     { name = "litellm" },
+    { name = "markdownify" },
     { name = "numpy" },
+    { name = "openai-codex-sdk" },
     { name = "orjson" },
     { name = "pwdlib", extra = ["argon2"] },
     { name = "pydantic" },
@@ -163,6 +165,7 @@ all-tools = [
     { name = "google-auth-oauthlib" },
     { name = "line-bot-sdk" },
     { name = "networkx" },
+    { name = "openai-codex-sdk" },
     { name = "requests" },
     { name = "slack-bolt" },
     { name = "slack-sdk" },
@@ -170,6 +173,9 @@ all-tools = [
 ]
 aws = [
     { name = "boto3" },
+]
+codex = [
+    { name = "openai-codex-sdk" },
 ]
 communication = [
     { name = "aiohttp" },
@@ -222,7 +228,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", marker = "extra == 'communication'", specifier = ">=3.9" },
-    { name = "animaworks", extras = ["communication", "gmail", "transcribe", "aws", "rag", "notification"], marker = "extra == 'all-tools'" },
+    { name = "animaworks", extras = ["communication", "gmail", "transcribe", "aws", "rag", "notification", "codex"], marker = "extra == 'all-tools'" },
     { name = "anthropic", specifier = ">=0.42.0" },
     { name = "apscheduler", specifier = ">=3.10.0" },
     { name = "boto3", marker = "extra == 'aws'", specifier = ">=1.34" },
@@ -237,9 +243,12 @@ requires-dist = [
     { name = "json-repair", specifier = ">=0.30.0" },
     { name = "line-bot-sdk", marker = "extra == 'notification'", specifier = ">=3.0" },
     { name = "litellm", specifier = ">=1.55.0" },
+    { name = "markdownify", specifier = ">=0.14.1" },
     { name = "matplotlib", marker = "extra == 'evaluation'", specifier = ">=3.8.0" },
     { name = "networkx", marker = "extra == 'rag'", specifier = ">=3.0" },
     { name = "numpy", specifier = ">=1.24.0" },
+    { name = "openai-codex-sdk", specifier = ">=0.1.11,<0.2" },
+    { name = "openai-codex-sdk", marker = "extra == 'codex'", specifier = ">=0.1.11,<0.2" },
     { name = "orjson", specifier = ">=3.9.0" },
     { name = "pandas", marker = "extra == 'evaluation'", specifier = ">=2.1.0" },
     { name = "psutil", marker = "extra == 'test'", specifier = ">=5.9.0" },
@@ -263,7 +272,7 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
     { name = "watchdog", marker = "extra == 'rag'", specifier = ">=3.0.0" },
 ]
-provides-extras = ["communication", "notification", "gmail", "transcribe", "aws", "rag", "all-tools", "redis", "test", "evaluation"]
+provides-extras = ["communication", "notification", "gmail", "transcribe", "aws", "rag", "codex", "all-tools", "redis", "test", "evaluation"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -504,6 +513,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
     { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
     { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
 ]
 
 [[package]]
@@ -1792,6 +1814,19 @@ wheels = [
 ]
 
 [[package]]
+name = "markdownify"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/bc/c8c8eea5335341306b0fa7e1cb33c5e1c8d24ef70ddd684da65f41c49c92/markdownify-1.2.2.tar.gz", hash = "sha256:b274f1b5943180b031b699b199cbaeb1e2ac938b75851849a31fd0c3d6603d09", size = 18816, upload-time = "2025-11-16T19:21:18.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ce/f1e3e9d959db134cedf06825fae8d5b294bd368aacdd0831a3975b7c4d55/markdownify-1.2.2-py3-none-any.whl", hash = "sha256:3f02d3cc52714084d6e589f70397b6fc9f2f3a8531481bf35e8cc39f975e186a", size = 15724, upload-time = "2025-11-16T19:21:17.622Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2393,6 +2428,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/92/e5/3d197a0947a166649f566706d7a4c8f7fe38f1fa7b24c9bcffe4c7591d44/openai-2.21.0.tar.gz", hash = "sha256:81b48ce4b8bbb2cc3af02047ceb19561f7b1dc0d4e52d1de7f02abfd15aa59b7", size = 644374, upload-time = "2026-02-14T00:12:01.577Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cc/56/0a89092a453bb2c676d66abee44f863e742b2110d4dbb1dbcca3f7e5fc33/openai-2.21.0-py3-none-any.whl", hash = "sha256:0bc1c775e5b1536c294eded39ee08f8407656537ccc71b1004104fe1602e267c", size = 1103065, upload-time = "2026-02-14T00:11:59.603Z" },
+]
+
+[[package]]
+name = "openai-codex-sdk"
+version = "0.1.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/d9/601134e94b83017252d29bbffff85ed86b302ded014165edee8bf70c8558/openai_codex_sdk-0.1.11.tar.gz", hash = "sha256:2cb1ad6bc6318b419802f6f87e1cef2f3987580953d218933def281ff98929ab", size = 20609, upload-time = "2026-01-19T09:59:46.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/2e/72ce1e801d0ad668096c7a9250b23d0325a26fe9e6d63788ccf8ddfe3d81/openai_codex_sdk-0.1.11-py3-none-any.whl", hash = "sha256:0575fd99ad3310ead661d8c6d54f5c3bb6b45a6ff99f57377f30f19ea34a3cc0", size = 19743, upload-time = "2026-01-19T09:59:44.866Z" },
 ]
 
 [[package]]
@@ -3762,6 +3810,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **FileWatcher のシンボリックリンク問題を修正**: macOS では `/tmp` が `/private/tmp` のシンボリックリンクになっており、パス比較が失敗するケースがあった。`anima_dir`・`queue_file()`・`_detect_memory_type()` に `.resolve()` を追加して正規化
- **テストスイートの堅牢化**: Python 3.14 + 最新依存関係環境での不安定テストを修正
- **テンプレートへの AUTO-GENERATED マーカー追加**

## 変更詳細

### `core/memory/rag/watcher.py`
- `self.anima_dir = anima_dir.resolve()` — 初期化時にシンボリックリンクを展開
- `_queue[file_path.resolve()]` — キュー登録時のパス正規化
- `_detect_memory_type()` 先頭で `file_path.resolve()` を実行

### テストスイート
| ファイル | 修正内容 |
|---------|---------|
| `test_watcher.py` | パス比較を `.resolve()` に統一 |
| `conftest.py` | `except ImportError` → `except Exception`（Python 3.14 pydantic 互換対応） |
| `test_models.py` | `_load_models_json` モンキーパッチで実環境 models.json を隔離 |
| `test_access_frequency.py` / `test_knowledge_failure_tracking.py` | chromadb importorskip を try/except に変更 |
| `test_server.py` | `foreground=True` 追加、restart テストを `_spawn_daemon` に修正 |
| `test_streaming_executors.py` | `delta.reasoning_content = None` で MagicMock リーク防止 |
| `test_slack_socket.py` | `slack_bolt` 未インストール時のスキップ対応 |
| `test_runner_deferred_trigger.py` | `_background_lock` モック追加 |
| `test_asset_optimization.py` | インポートパスを `core.tools._image_clients` に修正 |

## Test plan

- [x] `uv run pytest tests/unit/ -x -q` — 6618 passed, 36 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)