### PR TITLE
fix: use config-driven consolidation model for all internal LLM calls

### DIFF
--- a/core/asset_reconciler.py
+++ b/core/asset_reconciler.py
@@ -507,9 +507,14 @@ async def _synthesize_prompt_via_llm(
         system_prompt_name = "fragments/asset_synthesis_system"
         user_prompt_key = "asset_reconciler.llm_user_prompt"
 
-    api_key = model_config.api_key or os.environ.get(model_config.api_key_env)
+    # Internal LLM calls (asset synthesis prompts) always use the
+    # consolidation model — cheap and doesn't require the agent's own API key.
+    from core.memory._llm_utils import get_consolidation_llm_kwargs
+    llm_kw = get_consolidation_llm_kwargs()
+    llm_model = llm_kw["model"]
+    api_key = llm_kw.get("api_key") or os.environ.get(model_config.api_key_env)
     kwargs: dict[str, Any] = {
-        "model": model_config.model,
+        "model": llm_model,
         "messages": [
             {"role": "system", "content": load_prompt(system_prompt_name)},
             {

--- a/core/memory/_llm_utils.py
+++ b/core/memory/_llm_utils.py
@@ -1,0 +1,92 @@
+# AnimaWorks - Digital Anima Framework
+# Copyright (C) 2026 AnimaWorks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared LLM helper for memory-management modules.
+
+All internal LLM calls (episode summarization, consolidation, distillation,
+contradiction detection, etc.) use the *consolidation model* configured in
+``config.json``.  This module provides a thin wrapper that resolves the model
+and injects credentials so that individual memory modules don't need to
+duplicate this logic.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger("animaworks.memory._llm_utils")
+
+# Provider → env var mapping for LiteLLM auto-detection.
+_PROVIDER_ENV_MAP: dict[str, str] = {
+    "gemini": "GEMINI_API_KEY",
+    "google": "GEMINI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+}
+
+_credentials_exported = False
+
+
+def ensure_credentials_in_env() -> None:
+    """Export config.json credentials to environment variables.
+
+    LiteLLM reads API keys from environment variables (e.g. GEMINI_API_KEY).
+    If the server process was started without these vars, this function
+    reads them from ``config.json`` credentials and sets them once.
+
+    Safe to call multiple times — only runs the export logic once.
+    """
+    global _credentials_exported
+    if _credentials_exported:
+        return
+    _credentials_exported = True
+
+    try:
+        from core.config import load_config
+        cfg = load_config()
+    except Exception:
+        return
+
+    for provider, cred in cfg.credentials.items():
+        if not cred.api_key:
+            continue
+        env_key = _PROVIDER_ENV_MAP.get(provider)
+        if env_key and not os.environ.get(env_key):
+            os.environ[env_key] = cred.api_key
+            logger.debug("Exported %s from config credentials", env_key)
+
+
+def get_consolidation_llm_kwargs() -> dict[str, Any]:
+    """Return ``model`` and optional ``api_key`` for LiteLLM calls.
+
+    Reads ``consolidation.llm_model`` from the organisation config and
+    resolves the matching credential (if any) from ``credentials``.
+    Also ensures credentials are exported to environment variables.
+
+    Returns:
+        Dict with at least ``"model"`` key.  May also contain ``"api_key"``.
+    """
+    ensure_credentials_in_env()
+
+    from core.config import load_config
+
+    cfg = load_config()
+    model = cfg.consolidation.llm_model
+    kwargs: dict[str, Any] = {"model": model}
+
+    # Resolve API key: config credentials → env vars
+    provider = model.split("/")[0] if "/" in model else ""
+    cred = cfg.credentials.get(provider)
+    if cred and cred.api_key:
+        kwargs["api_key"] = cred.api_key
+    else:
+        env_key = _PROVIDER_ENV_MAP.get(provider)
+        if env_key:
+            val = os.environ.get(env_key)
+            if val:
+                kwargs["api_key"] = val
+
+    return kwargs

--- a/core/memory/contradiction.py
+++ b/core/memory/contradiction.py
@@ -425,8 +425,8 @@ class ContradictionDetector:
             List of detected contradiction pairs with resolution proposals
         """
         if not model:
-            from core.config.models import ConsolidationConfig
-            model = ConsolidationConfig().llm_model
+            from core.memory._llm_utils import get_consolidation_llm_kwargs
+            model = get_consolidation_llm_kwargs()["model"]
         logger.info(
             "Starting contradiction scan for anima=%s target=%s",
             self.anima_name,
@@ -535,8 +535,8 @@ class ContradictionDetector:
             Summary dict with counts: superseded, merged, coexisted, errors
         """
         if not model:
-            from core.config.models import ConsolidationConfig
-            model = ConsolidationConfig().llm_model
+            from core.memory._llm_utils import get_consolidation_llm_kwargs
+            model = get_consolidation_llm_kwargs()["model"]
         results = {"superseded": 0, "merged": 0, "coexisted": 0, "errors": 0}
 
         for pair in pairs:

--- a/core/memory/conversation.py
+++ b/core/memory/conversation.py
@@ -773,8 +773,13 @@ class ConversationMemory:
         """Common LLM helper using litellm for provider-agnostic calls."""
         import litellm
 
-        model = self.model_config.fallback_model or self.model_config.model
-        kwargs: dict[str, Any] = {}
+        # Internal LLM calls (episode summarization, memory management) always
+        # use the consolidation model — it's cheap and doesn't require the
+        # agent's own API key (which may not exist for Mode S/C agents).
+        from core.memory._llm_utils import get_consolidation_llm_kwargs
+        llm_kw = get_consolidation_llm_kwargs()
+        model = llm_kw.pop("model")
+        kwargs: dict[str, Any] = llm_kw
         self._apply_provider_kwargs(model, kwargs)
         response = cast(Any, await litellm.acompletion(
             model=model,

--- a/core/memory/distillation.py
+++ b/core/memory/distillation.py
@@ -84,8 +84,8 @@ class ProceduralDistiller:
               - ``raw_response``: raw LLM output string
         """
         if not model:
-            from core.config.models import ConsolidationConfig
-            model = ConsolidationConfig().llm_model
+            from core.memory._llm_utils import get_consolidation_llm_kwargs
+            model = get_consolidation_llm_kwargs()["model"]
 
         result = {
             "knowledge_items": [],
@@ -156,8 +156,8 @@ class ProceduralDistiller:
             ``tags``, and ``content``.
         """
         if not model:
-            from core.config.models import ConsolidationConfig
-            model = ConsolidationConfig().llm_model
+            from core.memory._llm_utils import get_consolidation_llm_kwargs
+            model = get_consolidation_llm_kwargs()["model"]
         if not procedural_episodes.strip():
             return []
 
@@ -222,8 +222,8 @@ class ProceduralDistiller:
             ``patterns_detected`` (int).
         """
         if not model:
-            from core.config.models import ConsolidationConfig
-            model = ConsolidationConfig().llm_model
+            from core.memory._llm_utils import get_consolidation_llm_kwargs
+            model = get_consolidation_llm_kwargs()["model"]
 
         # 1. Load activity entries
         entries = self._load_activity_entries(days=days)

--- a/core/memory/forgetting.py
+++ b/core/memory/forgetting.py
@@ -305,8 +305,8 @@ class ForgettingEngine:
         Action: LLM merge -> delete originals -> insert merged chunk
         """
         if not model:
-            from core.config.models import ConsolidationConfig
-            model = ConsolidationConfig().llm_model
+            from core.memory._llm_utils import get_consolidation_llm_kwargs
+            model = get_consolidation_llm_kwargs()["model"]
         logger.info("Starting neurogenesis reorganization for anima=%s", self.anima_name)
         store = self._get_vector_store()
         total_merged = 0

--- a/core/memory/reconsolidation.py
+++ b/core/memory/reconsolidation.py
@@ -122,8 +122,8 @@ class ReconsolidationEngine:
             Dict with counts: "updated", "skipped", "errors".
         """
         if not model:
-            from core.config.models import ConsolidationConfig
-            model = ConsolidationConfig().llm_model
+            from core.memory._llm_utils import get_consolidation_llm_kwargs
+            model = get_consolidation_llm_kwargs()["model"]
         results: dict[str, int] = {"updated": 0, "skipped": 0, "errors": 0}
 
         for proc_path in targets:
@@ -203,8 +203,8 @@ class ReconsolidationEngine:
             Dict with counts: ``created``, ``skipped``, ``errors``.
         """
         if not model:
-            from core.config.models import ConsolidationConfig
-            model = ConsolidationConfig().llm_model
+            from core.memory._llm_utils import get_consolidation_llm_kwargs
+            model = get_consolidation_llm_kwargs()["model"]
 
         results: dict[str, int] = {"created": 0, "skipped": 0, "errors": 0}
 
@@ -431,8 +431,8 @@ class ReconsolidationEngine:
             Dict with counts: "targets_found", "updated", "skipped", "errors".
         """
         if not model:
-            from core.config.models import ConsolidationConfig
-            model = ConsolidationConfig().llm_model
+            from core.memory._llm_utils import get_consolidation_llm_kwargs
+            model = get_consolidation_llm_kwargs()["model"]
         targets = await self.find_knowledge_reconsolidation_targets()
         results: dict[str, Any] = {
             "targets_found": len(targets),

--- a/core/memory/validation.py
+++ b/core/memory/validation.py
@@ -134,8 +134,8 @@ class KnowledgeValidator:
             field populated
         """
         if not model:
-            from core.config.models import ConsolidationConfig
-            model = ConsolidationConfig().llm_model
+            from core.memory._llm_utils import get_consolidation_llm_kwargs
+            model = get_consolidation_llm_kwargs()["model"]
         if self._nli_pipeline is None and self._nli_available:
             self._load_nli_model()
 


### PR DESCRIPTION
## Summary

- `ConsolidationConfig()` was instantiated directly in 10+ locations across memory modules, returning hardcoded defaults instead of reading `config.json` via `load_config()`
- All internal LLM calls (episode summarization, distillation, reconsolidation, etc.) ignored the configured `consolidation.llm_model` and always used `anthropic/claude-sonnet-4-6`
- This made it impossible to use alternative providers (e.g. Gemini free tier) for memory management

## Changes

- **New `core/memory/_llm_utils.py`**: shared helper that resolves consolidation model + credentials from `config.json`, with automatic env-var export for LiteLLM
- **`conversation.py`**: `_call_llm()` now always uses consolidation model (internal calls don't need the agent's own model/API key)
- **`asset_reconciler.py`**: same pattern via the shared helper
- **5 memory modules** (`reconsolidation`, `forgetting`, `contradiction`, `distillation`, `validation`): replaced `ConsolidationConfig().llm_model` with `get_consolidation_llm_kwargs()["model"]`

## Test plan

- [x] `get_consolidation_llm_kwargs()` returns correct model and API key from config
- [x] `ensure_credentials_in_env()` exports credentials to env vars for LiteLLM auto-detection
- [x] Heartbeat with episode summarization succeeds using configured consolidation model (tested with `gemini/gemini-2.5-flash`)
- [ ] Consolidation cron (daily/weekly) uses the correct model

🤖 Generated with [Claude Code](https://claude.com/claude-code)