### PR TITLE
feat: add slack_react tool for emoji reactions

### DIFF
--- a/core/tools/slack.py
+++ b/core/tools/slack.py
@@ -390,6 +390,17 @@ class SlackClient:
         response = self._call("chat_postMessage", **kwargs)
         return response
 
+    def add_reaction(
+        self, channel_id: str, emoji: str, ts: str
+    ) -> dict:
+        """Add an emoji reaction to a message via reactions.add."""
+        return self._call(
+            "reactions_add",
+            channel=channel_id,
+            name=emoji,
+            timestamp=ts,
+        )
+
     def users_list(self) -> list[dict]:
         """Get all workspace users."""
         all_users = self._paginate("users_list", "members", limit=200)
@@ -1265,6 +1276,14 @@ def dispatch(name: str, args: dict[str, Any]) -> Any:
     if name == "slack_channels":
         client = SlackClient(token=_resolve_slack_token(args))
         return client.channels()
+    if name == "slack_react":
+        client = SlackClient(token=_resolve_slack_token(args))
+        channel_id = client.resolve_channel(args["channel"])
+        return client.add_reaction(
+            channel_id,
+            args["emoji"],
+            args["message_ts"],
+        )
     raise ValueError(f"Unknown tool: {name}")
 
 


### PR DESCRIPTION
## Summary

- Adds `SlackClient.add_reaction()` method wrapping `reactions.add` API
- Adds `slack_react` tool dispatch entry for use by animas
- Enables animas to acknowledge messages with emoji reactions (e.g., 👍 for 了解) without posting a text reply

## Motivation

In our multi-agent deployment, animas frequently need to acknowledge messages from humans (e.g., the CEO posting instructions). Currently the only option is `slack_send`, which creates a new message and adds noise to the channel. A simple emoji reaction is more appropriate for acknowledgments like "了解" or "承認".

## Changes

- `SlackClient.add_reaction(channel_id, emoji, ts)` — new method
- `dispatch("slack_react", ...)` — resolves channel name to ID, then calls `add_reaction`
- Requires the `reactions:write` bot scope (already included in standard Slack app setup)

## Usage

```python
dispatch("slack_react", {
    "channel": "#general",
    "message_ts": "1234567890.123456",
    "emoji": "thumbsup"
})
```

## Test plan

- [x] Verified reaction appears on target message in Slack
- [x] Works with both channel ID and channel name

🤖 Generated with [Claude Code](https://claude.com/claude-code)