### PR TITLE
feat: add novita provider defaults for mode a

### DIFF
--- a/core/config/models.py
+++ b/core/config/models.py
@@ -747,6 +747,7 @@ DEFAULT_MODEL_MODE_PATTERNS: dict[str, str] = {
     "codex/*": "C",
     # ── A: Cloud API providers (LiteLLM + tool_use) ──────
     "openai/*": "A",
+    "novita/*": "A",
     "azure/*": "A",
     "bedrock/*": "A",
     "google/*": "A",

--- a/core/execution/_litellm_context.py
+++ b/core/execution/_litellm_context.py
@@ -64,8 +64,9 @@ class ContextMixin:
         api_key = self._resolve_api_key()
         if api_key:
             kwargs["api_key"] = api_key
-        if self._model_config.api_base_url:
-            kwargs["api_base"] = self._model_config.api_base_url
+        api_base = self._resolve_api_base_url()
+        if api_base:
+            kwargs["api_base"] = api_base
         self._apply_provider_kwargs(kwargs)
         # Extended thinking / reasoning control
         if self._model_config.thinking is not None:

--- a/core/execution/assisted.py
+++ b/core/execution/assisted.py
@@ -346,8 +346,9 @@ class AssistedExecutor(BaseExecutor):
         api_key = self._resolve_api_key()
         if api_key:
             kwargs["api_key"] = api_key
-        if self._model_config.api_base_url:
-            kwargs["api_base"] = self._model_config.api_base_url
+        api_base = self._resolve_api_base_url()
+        if api_base:
+            kwargs["api_base"] = api_base
         self._apply_provider_kwargs(kwargs)
 
         # Extended thinking / reasoning control

--- a/core/execution/base.py
+++ b/core/execution/base.py
@@ -41,6 +41,7 @@ _active_interrupt_event: ContextVar[asyncio.Event | None] = ContextVar(
 # ── Adaptive Thinking helpers ─────────────────────────────────
 
 _ADAPTIVE_MODELS = frozenset({"claude-opus-4-6", "claude-sonnet-4-6"})
+_NOVITA_API_BASE = "https://api.novita.ai/openai"
 
 _PROVIDER_PREFIX_RE = re.compile(
     r"^(?:anthropic|bedrock|vertex_ai)/"
@@ -360,7 +361,17 @@ class BaseExecutor(ABC):
         """Resolve the actual API key (direct value from config, then env var)."""
         if self._model_config.api_key:
             return self._model_config.api_key
+        if self._model_config.model.startswith("novita/"):
+            return os.environ.get("NOVITA_API_KEY") or os.environ.get(self._model_config.api_key_env)
         return os.environ.get(self._model_config.api_key_env)
+
+    def _resolve_api_base_url(self) -> str | None:
+        """Resolve API base URL with provider defaults when applicable."""
+        if self._model_config.api_base_url:
+            return self._model_config.api_base_url
+        if self._model_config.model.startswith("novita/"):
+            return _NOVITA_API_BASE
+        return None
 
     def _read_replied_to_file(self) -> set[str]:
         """Read replied_to entries from persistent file."""

--- a/tests/unit/core/config/test_models.py
+++ b/tests/unit/core/config/test_models.py
@@ -563,6 +563,7 @@ class TestResolveExecutionModeWildcard:
     def test_cloud_api_providers_a(self):
         config = AnimaWorksConfig()
         assert resolve_execution_mode(config, "openai/gpt-4.1") == "A"
+        assert resolve_execution_mode(config, "novita/deepseek/deepseek-v3") == "A"
         assert resolve_execution_mode(config, "google/gemini-2.5-pro") == "A"
         assert resolve_execution_mode(config, "zai/zai-model") == "A"
         assert resolve_execution_mode(config, "minimax/some-model") == "A"

--- a/tests/unit/execution/test_base.py
+++ b/tests/unit/execution/test_base.py
@@ -96,6 +96,33 @@ class TestBaseExecutor:
         with patch.dict(os.environ, {"MY_TEST_KEY": "env-key"}):
             assert executor._resolve_api_key() == "config-key"
 
+    def test_resolve_api_key_uses_novita_env_for_novita_model(self, tmp_path: Path):
+        config = ModelConfig(
+            model="novita/deepseek/deepseek-v3",
+            api_key=None,
+            api_key_env="OPENAI_API_KEY",
+        )
+        executor = ConcreteExecutor(model_config=config, anima_dir=tmp_path)
+        with patch.dict(
+            os.environ,
+            {"NOVITA_API_KEY": "novita-key", "OPENAI_API_KEY": "openai-key"},
+            clear=False,
+        ):
+            assert executor._resolve_api_key() == "novita-key"
+
+    def test_resolve_api_base_url_uses_novita_default(self, tmp_path: Path):
+        config = ModelConfig(model="novita/deepseek/deepseek-v3")
+        executor = ConcreteExecutor(model_config=config, anima_dir=tmp_path)
+        assert executor._resolve_api_base_url() == "https://api.novita.ai/openai"
+
+    def test_resolve_api_base_url_prefers_explicit_config(self, tmp_path: Path):
+        config = ModelConfig(
+            model="novita/deepseek/deepseek-v3",
+            api_base_url="https://custom.novita.gateway/openai",
+        )
+        executor = ConcreteExecutor(model_config=config, anima_dir=tmp_path)
+        assert executor._resolve_api_base_url() == "https://custom.novita.gateway/openai"
+
     @pytest.mark.asyncio
     async def test_execute(self, executor: ConcreteExecutor):
         result = await executor.execute("hello")

--- a/tests/unit/execution/test_litellm_loop.py
+++ b/tests/unit/execution/test_litellm_loop.py
@@ -182,6 +182,27 @@ class TestBuildLlmKwargs:
         kwargs = ex._build_llm_kwargs()
         assert kwargs["api_base"] == "http://localhost:11434/v1"
 
+    def test_uses_novita_default_api_base(self, anima_dir: Path, memory: MagicMock):
+        model_config = ModelConfig(
+            model="novita/deepseek/deepseek-v3",
+            api_key="sk-test",
+            max_tokens=1024,
+            max_turns=5,
+            context_threshold=0.50,
+            max_chains=2,
+        )
+        th = ToolHandler(anima_dir=anima_dir, memory=memory, tool_registry=[])
+        from core.execution.litellm_loop import LiteLLMExecutor
+        ex = LiteLLMExecutor(
+            model_config=model_config,
+            anima_dir=anima_dir,
+            tool_handler=th,
+            tool_registry=[],
+            memory=memory,
+        )
+        kwargs = ex._build_llm_kwargs()
+        assert kwargs["api_base"] == "https://api.novita.ai/openai"
+
 
 # ── execute() — simple response ──────────────────────────────
 


### PR DESCRIPTION
Summary
- add novita wildcard model mapping to mode A
- add Novita API key and default base URL resolution
- wire LiteLLM execution paths to resolved api_base
- add focused unit tests for Novita routing/base URL behavior

Notes
- branch: novita-integration
- commit: 6064f8329615cce8bed47e2b293d6c58a61f360e