### PR TITLE
fix: bootstrapループ防止（3つの構造的バグ修正）

### DIFF
--- a/core/_anima_messaging.py
+++ b/core/_anima_messaging.py
@@ -118,8 +118,7 @@ class MessagingMixin:
                         resolved_file = bootstrap_file.with_suffix(".md.auto_resolved")
                         bootstrap_file.rename(resolved_file)
                         logger.warning(
-                            "[%s] bootstrap.md was NOT deleted by agent; "
-                            "auto-renamed to %s to prevent loop",
+                            "[%s] bootstrap.md was NOT deleted by agent; auto-renamed to %s to prevent loop",
                             self.name,
                             resolved_file.name,
                         )

--- a/core/supervisor/_mgr_health.py
+++ b/core/supervisor/_mgr_health.py
@@ -22,6 +22,10 @@ logger = logging.getLogger(__name__)
 class HealthMixin:
     """Health-check loop, failure handling, and hang detection."""
 
+    def is_bootstrapping(self, anima_name: str) -> bool:
+        """Return True if the anima is currently in bootstrap mode."""
+        return anima_name in getattr(self, "_bootstrapping", set())
+
     async def _health_check_loop(self) -> None:
         """Periodically pings all processes and handles failures."""
         logger.info("Health check loop started")

--- a/core/supervisor/manager.py
+++ b/core/supervisor/manager.py
@@ -152,12 +152,9 @@ class ProcessSupervisor(HealthMixin, ReconcileMixin, SchedulerMixin):
         """Load persisted bootstrap retry counts from disk."""
         try:
             if self._bootstrap_retries_file.exists():
-                import json
                 data = json.loads(self._bootstrap_retries_file.read_text())
                 if isinstance(data, dict):
-                    self._bootstrap_retry_counts = {
-                        k: int(v) for k, v in data.items()
-                    }
+                    self._bootstrap_retry_counts = {k: int(v) for k, v in data.items()}
                     logger.info(
                         "Loaded bootstrap retry counts: %s",
                         self._bootstrap_retry_counts,
@@ -168,10 +165,7 @@ class ProcessSupervisor(HealthMixin, ReconcileMixin, SchedulerMixin):
     def _save_bootstrap_retries(self) -> None:
         """Persist bootstrap retry counts to disk."""
         try:
-            import json
-            self._bootstrap_retries_file.write_text(
-                json.dumps(self._bootstrap_retry_counts, indent=2)
-            )
+            self._bootstrap_retries_file.write_text(json.dumps(self._bootstrap_retry_counts, indent=2))
         except Exception:
             logger.warning("Failed to save bootstrap retries file", exc_info=True)
 
@@ -316,10 +310,6 @@ class ProcessSupervisor(HealthMixin, ReconcileMixin, SchedulerMixin):
         finally:
             self._starting.discard(anima_name)
 
-    def is_bootstrapping(self, anima_name: str) -> bool:
-        """Check if an anima is currently bootstrapping."""
-        return anima_name in self._bootstrapping
-
     async def _run_bootstrap(self, anima_name: str) -> None:
         """Run bootstrap for an anima in the background.
 
@@ -428,10 +418,9 @@ class ProcessSupervisor(HealthMixin, ReconcileMixin, SchedulerMixin):
             self._bootstrapping.discard(anima_name)
             if success:
                 self._bootstrap_retry_counts.pop(anima_name, None)
-                self._save_bootstrap_retries()
             else:
                 self._bootstrap_retry_counts[anima_name] = retry_count + 1
-                self._save_bootstrap_retries()
+            self._save_bootstrap_retries()
             if was_bootstrapping:
                 handle = self.processes.get(anima_name)
                 if not handle or handle.state != ProcessState.RUNNING:


### PR DESCRIPTION
## Summary
- bootstrap.md安全策: run_cycle後にLLMが削除しなかった場合、自動的にauto_resolvedにリネームしてループを防止
- retry_counts永続化: サーバー再起動でリトライカウンタがリセットされる問題を.bootstrap_retries.jsonで解決
- ハング検知スキップ: bootstrap中のプロセスを誤ってSIGKILLして再起動ループになる問題を防止

## 背景
- bootstrap.mdがLLMによって削除されず残存し、サーバー再起動のたびにブートストラップAPIコールが再実行されるループが発生
- エージェントが全サイクルで"(no response)"を返し、ツール実行ゼロのため自己削除が実行されなかった
- retry_countsがメモリ内のみ（揮発性）のため、サーバー再起動で常にリセットされ実質無限ループ

## 変更ファイル
- `core/_anima_messaging.py` - bootstrap安全策追加
- `core/supervisor/manager.py` - retry_counts永続化
- `core/supervisor/_mgr_health.py` - bootstrap中のハング検知スキップ