### PR TITLE
fix: add .dockerignore for smaller Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+tests/
+archive/
+site-docs/
+.git/
+.github/
+*.egg-info/
+docs/
+scripts/
+.ruff_cache/
+.pytest_cache/
+*.md
+!README.md


### PR DESCRIPTION
## Summary

Adds a `.dockerignore` file to exclude non-runtime files from the Docker build context, reducing build time and image size.

## Changes

- Created `.dockerignore` with entries for `.venv/`, `__pycache__/`, test files, docs, and other non-runtime artifacts
- Preserves `README.md` via negation pattern

## Verification

```bash
docker build -t animaworks-test .
# Should succeed with a smaller build context
```

Fixes #51