### PR TITLE
fix: add HEALTHCHECK to Dockerfile and docker-compose files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,8 @@ COPY templates/ templates/
 COPY main.py .
 
 EXPOSE 18500
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:18500/api/system/health')" || exit 1
+
 CMD ["python", "main.py", "start", "--host", "0.0.0.0", "--port", "18500"]

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -11,6 +11,12 @@ services:
       TZ: ${TZ:-Asia/Tokyo}
     volumes:
       - animaworks-demo-data:/root/.animaworks
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:18501/api/system/health')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 
 volumes:
   animaworks-demo-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,12 @@ services:
       TZ: Asia/Tokyo
     volumes:
       - animaworks-data:/root/.animaworks
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:18500/api/system/health')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 
 volumes:
   animaworks-data:


### PR DESCRIPTION
## Summary

Adds Docker HEALTHCHECK so container orchestrators can detect when the AnimaWorks server is unhealthy.

## Changes

- **Dockerfile**: Added `HEALTHCHECK` instruction using Python urllib (no extra deps needed in slim image) targeting `/api/system/health`
- **docker-compose.yml**: Added `healthcheck` section with 30s interval, 5s timeout, 3 retries, 10s start period
- **demo/docker-compose.yml**: Same healthcheck config, targeting port 18501

## Notes

- Uses `python -c` instead of `curl`/`wget` since `python:3.12-slim` already has Python available
- Targets the existing `/api/system/health` endpoint
- `start_period` gives the app 10s to initialize before health checks begin

Fixes #52