### PR TITLE
fix: set data-theme attribute on body for dark themes

### DIFF
--- a/server/static/modules/app.js
+++ b/server/static/modules/app.js
@@ -31,11 +31,18 @@ const ALL_THEMES = [
   "rose", "lavender", "nord", "monokai", "midnight", "solarized"
 ];
 
+const DARK_THEMES = ["monokai", "midnight"];
+
 export function applyTheme(theme) {
   state.uiTheme = theme;
   ALL_THEMES.forEach(t => document.body.classList.remove(`theme-${t}`));
   if (theme !== "default") {
     document.body.classList.add(`theme-${theme}`);
+  }
+  if (DARK_THEMES.includes(theme)) {
+    document.body.setAttribute("data-theme", "dark");
+  } else {
+    document.body.removeAttribute("data-theme");
   }
   localStorage.setItem("aw-theme", theme);
 }


### PR DESCRIPTION
## Summary

Sets `data-theme="dark"` on `document.body` when a dark theme is active, enabling dark-specific CSS selectors in `chat.css` to work correctly.

## Changes

- Added `DARK_THEMES` constant listing dark theme variants (`monokai`, `midnight`)
- Updated `applyTheme()` in `server/static/modules/app.js` to:
  - Set `data-theme="dark"` on body when active theme is a dark variant
  - Remove the attribute when switching to a light theme

## Verification

1. Select monokai or midnight theme
2. Inspect `<body>` → should have `data-theme="dark"`
3. Switch to a light theme → attribute removed
4. `.thinking-summary` and `.thinking-content` dark styles in `chat.css` now apply correctly

Fixes #53