### PR TITLE
feat: Slackチャネル投稿・更新ツール追加

### DIFF
--- a/core/mcp/server.py
+++ b/core/mcp/server.py
@@ -181,8 +181,8 @@ def _build_mcp_tools() -> tuple[list[Tool], frozenset[str]]:
     from core.tooling.schemas import (
         KNOWLEDGE_TOOLS,
         MEMORY_TOOLS,
-        SUBMIT_TASKS_TOOLS,
         PROCEDURE_TOOLS,
+        SUBMIT_TASKS_TOOLS,
         _background_task_tools,
         _channel_tools,
         _check_permissions_tools,

--- a/core/tooling/handler.py
+++ b/core/tooling/handler.py
@@ -195,6 +195,8 @@ class ToolHandler(
             "archive_memory_file": self._handle_archive_memory_file,
             "send_message": self._handle_send_message,
             "post_channel": self._handle_post_channel,
+            "slack_channel_post": self._handle_slack_channel_post,
+            "slack_channel_update": self._handle_slack_channel_update,
             "read_channel": self._handle_read_channel,
             "manage_channel": self._handle_manage_channel,
             "read_dm_history": self._handle_read_dm_history,
@@ -430,6 +432,8 @@ class ToolHandler(
 
     _ACTIVITY_TYPE_MAP: dict[str, str] = {
         "post_channel": "channel_post",
+        "slack_channel_post": "channel_post",
+        "slack_channel_update": "channel_post",
         "read_channel": "channel_read",
         "read_dm_history": "channel_read",
         "call_human": "human_notify",

--- a/core/tooling/handler_comms.py
+++ b/core/tooling/handler_comms.py
@@ -264,6 +264,68 @@ class CommsToolsMixin:
 
         return f"Posted to #{channel}"
 
+    def _handle_slack_channel_post(self, args: dict[str, Any]) -> str:
+        """Post a message to an actual Slack channel via Bot Token API."""
+        channel_id = args.get("channel_id", "")
+        text = args.get("text", "")
+        if not channel_id or not text:
+            return _error_result("InvalidArguments", "channel_id and text are required")
+
+        try:
+            from core.tools._base import get_credential
+            from core.tools.slack import SlackClient, md_to_slack_mrkdwn
+
+            token = get_credential("slack", "notification", env_var="SLACK_BOT_TOKEN")
+            client = SlackClient(token=token)
+            slack_text = md_to_slack_mrkdwn(text)
+            response = client.post_message(channel_id, slack_text, username=self._anima_name)
+            ts = response.get("ts", "") if isinstance(response, dict) else ""
+            if not ts and hasattr(response, "data"):
+                ts = response.data.get("ts", "")
+            logger.info(
+                "slack_channel_post: channel=%s ts=%s anima=%s",
+                channel_id,
+                ts,
+                self._anima_name,
+            )
+            return _json.dumps(
+                {"status": "ok", "channel": channel_id, "ts": ts},
+                ensure_ascii=False,
+            )
+        except Exception as e:
+            logger.exception("slack_channel_post failed")
+            return _error_result("SlackError", f"Failed to post: {e}")
+
+    def _handle_slack_channel_update(self, args: dict[str, Any]) -> str:
+        """Update an existing Slack message (silent, no notification)."""
+        channel_id = args.get("channel_id", "")
+        ts = args.get("ts", "")
+        text = args.get("text", "")
+        if not channel_id or not ts or not text:
+            return _error_result("InvalidArguments", "channel_id, ts, and text are required")
+
+        try:
+            from core.tools._base import get_credential
+            from core.tools.slack import SlackClient, md_to_slack_mrkdwn
+
+            token = get_credential("slack", "notification", env_var="SLACK_BOT_TOKEN")
+            client = SlackClient(token=token)
+            slack_text = md_to_slack_mrkdwn(text)
+            client.update_message(channel_id, ts, slack_text)
+            logger.info(
+                "slack_channel_update: channel=%s ts=%s anima=%s",
+                channel_id,
+                ts,
+                self._anima_name,
+            )
+            return _json.dumps(
+                {"status": "ok", "channel": channel_id, "ts": ts},
+                ensure_ascii=False,
+            )
+        except Exception as e:
+            logger.exception("slack_channel_update failed")
+            return _error_result("SlackError", f"Failed to update: {e}")
+
     def _fanout_board_mentions(self, channel: str, text: str) -> None:
         """Send DM notifications to mentioned Animas when posting to a board channel."""
         if not self._messenger:

--- a/core/tooling/schemas.py
+++ b/core/tooling/schemas.py
@@ -255,6 +255,54 @@ def _channel_tools() -> list[dict[str, Any]]:
                 "required": ["action", "channel"],
             },
         },
+        {
+            "name": "slack_channel_post",
+            "description": (
+                "Post a message to an actual Slack channel via Bot Token API. "
+                "Returns the message ts for future updates. "
+                "Use this for external Slack channels (not internal Board)."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "channel_id": {
+                        "type": "string",
+                        "description": "Slack channel ID (e.g. C0AJ4J5KK46)",
+                    },
+                    "text": {
+                        "type": "string",
+                        "description": "Message text (Markdown will be converted to Slack mrkdwn)",
+                    },
+                },
+                "required": ["channel_id", "text"],
+            },
+        },
+        {
+            "name": "slack_channel_update",
+            "description": (
+                "Update an existing Slack message by ts. "
+                "The message is silently replaced (no notification). "
+                "Use this for live dashboards like task-board."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "channel_id": {
+                        "type": "string",
+                        "description": "Slack channel ID",
+                    },
+                    "ts": {
+                        "type": "string",
+                        "description": "Message timestamp to update (from slack_channel_post result)",
+                    },
+                    "text": {
+                        "type": "string",
+                        "description": "New message text",
+                    },
+                },
+                "required": ["channel_id", "ts", "text"],
+            },
+        },
     ]
 
 

--- a/tests/e2e/test_a2_enhancement.py
+++ b/tests/e2e/test_a2_enhancement.py
@@ -229,9 +229,9 @@ class TestBaseToolCount:
     """Verify the base tool set matches the design spec."""
 
     def test_base_tool_count(self, executor):
-        """Base tools should be 30 (use_tool is Mode B only, not in Mode A)."""
+        """Base tools should be 32 (use_tool is Mode B only, not in Mode A)."""
         tools = executor._build_base_tools()
-        assert len(tools) == 30
+        assert len(tools) == 32
         names = {t["function"]["name"] for t in tools}
         assert "search_code" in names
         assert "list_directory" in names


### PR DESCRIPTION
## 概要

Slackチャネルへの直接投稿・メッセージ更新を行うビルトインツール `slack_channel_post` / `slack_channel_update` を追加しました。

## 背景・課題

- エージェントがSlackチャネルにメッセージを投稿する手段がなく、タスクボードやステータスの共有をSlack上でリアルタイムに行えなかった
- 既存の `post_channel` は内部Board向けで、実際のSlackチャネルへの投稿には対応していなかった
- 例：タスクボード（markdown形式）をSlackチャネルに定期同期したいが、投稿・更新手段がなく実現できなかった

## 変更内容

- `slack_channel_post`: Bot Token API経由でSlackチャネルにメッセージを投稿。投稿後のタイムスタンプ（ts）を返却
- `slack_channel_update`: 既存メッセージをts指定でサイレント更新。ライブダッシュボード等の定期更新に対応
- Markdown→Slack mrkdwn自動変換を適用
- ハンドラ・ディスパッチ・スキーマ定義・テストを統合的に更新

## テスト

- 既存テスト全件パス（mainで既に落ちている1件を除く）
- ベースツール数の期待値を更新（30→32）

🤖 Generated with [Claude Code](https://claude.com/claude-code)