### PR TITLE
fix: remove misleading offset/limit hint from read_memory_file truncation

### DIFF
--- a/core/tooling/handler_memory.py
+++ b/core/tooling/handler_memory.py
@@ -135,7 +135,7 @@ class MemoryToolsMixin:
                 truncated = "".join(lines[:MAX_LINES])
                 return (
                     truncated
-                    + f"\n[Truncated: showing {MAX_LINES} of {len(lines)} lines. Use offset/limit to read more.]"
+                    + f"\n[Truncated: showing {MAX_LINES} of {len(lines)} lines. Use read_file tool or narrow your search to access more.]"
                 )
             return content
         logger.debug("read_memory_file NOT FOUND path=%s", rel)


### PR DESCRIPTION
## Summary

- `read_memory_file` does not support `offset/limit` parameters
- The old truncation message told agents to `Use offset/limit to read more.` which is incorrect and causes confusion — agents following this instruction are silently ignored
- Replace with: `Use read_file tool or narrow your search to access more.`

## Change

```diff
-  + f"\n[Truncated: showing {MAX_LINES} of {len(lines)} lines. Use offset/limit to read more.]"
+  + f"\n[Truncated: showing {MAX_LINES} of {len(lines)} lines. Use read_file tool or narrow your search to access more.]"
```

## Test plan

- [x] `ruff check core/tooling/handler_memory.py` — PASS
- [x] `ruff format --check core/tooling/handler_memory.py` — PASS
- [x] `pytest tests/unit/ -x -q --timeout=30 -m 'not live and not azure and not ollama' -k 'memory'` — 1527 passed, 19 skipped

🤖 Generated with Claude Opus 4.6