### PR TITLE
feat: Support prefers-color-scheme for default theme

### DIFF
--- a/server/static/modules/app.js
+++ b/server/static/modules/app.js
@@ -41,21 +41,36 @@ export function applyTheme(theme) {
 }
 
 async function initTheme() {
+  const mql = window.matchMedia("(prefers-color-scheme: dark)");
+
+  mql.addEventListener("change", (e) => {
+    if (!localStorage.getItem("aw-theme")) {
+      applyTheme(e.matches ? "midnight" : "default");
+    }
+  });
+
   const stored = localStorage.getItem("aw-theme");
   if (stored) {
     applyTheme(stored);
     return;
   }
+
+  let serverTheme = "default";
   try {
     const resp = await fetch("/api/system/config");
     if (resp.ok) {
       const cfg = await resp.json();
-      const theme = cfg?.ui?.theme || "default";
-      applyTheme(theme);
-      return;
+      if (cfg?.ui?.theme) {
+        serverTheme = cfg.ui.theme;
+      }
     }
   } catch { /* ignore */ }
-  applyTheme("default");
+
+  if (serverTheme === "default" && mql.matches) {
+    applyTheme("midnight");
+  } else {
+    applyTheme(serverTheme);
+  }
 }
 import { checkAuth, logout, showLoginScreen, hideLoginScreen, setStartDashboard } from "./login.js";
 import { initRouter } from "./router.js";


### PR DESCRIPTION
This PR implements #56 by respecting the OS-level dark mode preference via `prefers-color-scheme`.

It updates `initTheme()` in `server/static/modules/app.js` to:
- Check `window.matchMedia("(prefers-color-scheme: dark)")` when no stored theme exists.
- Default to the `midnight` theme if dark mode is preferred and the server returns the default theme.
- Listen for OS dark mode toggles and dynamically apply `midnight` or `default` if the user has not explicitly set a theme.

Fixes #56.