### PR TITLE
fix: correct invalid loop variable in schemas.py

### DIFF
--- a/tests/evaluation/framework/schemas.py
+++ b/tests/evaluation/framework/schemas.py
@@ -129,7 +129,7 @@ class GroundTruth:
     @property
     def all_relevant_files(self) -> list[Path]:
         """Get all relevant files regardless of relevance level."""
-        return [rm.file_path for rm.file_path in self.relevant_memories]
+        return [rm.file_path for rm in self.relevant_memories]
 
 
 @dataclass


### PR DESCRIPTION
## Summary

- `tests/evaluation/framework/schemas.py` L132: Fix F821 bug where list comprehension used `rm.file_path` as loop variable instead of `rm` (copy-paste error from adjacent property)

## 修正内容

```python
# Before（無効なループ変数 - F821）
return [rm.file_path for rm.file_path in self.relevant_memories]

# After
return [rm.file_path for rm in self.relevant_memories]
```

## 影響範囲

`GroundTruth.all_relevant_files` プロパティの戻り値が正しく `list[Path]` を返すようになる。修正は1ファイル1行のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)