### PR TITLE
fix(ruff): remove unused imports and variables (F401/F841)

### DIFF
--- a/swe/runner.py
+++ b/swe/runner.py
@@ -23,7 +23,6 @@ import signal
 import subprocess
 import sys
 import tempfile
-import time
 from pathlib import Path
 
 import httpx

--- a/tests/e2e/core/test_heartbeat_dialogue_e2e.py
+++ b/tests/e2e/core/test_heartbeat_dialogue_e2e.py
@@ -138,8 +138,6 @@ class TestCrossContextFlow:
 
     def test_load_heartbeat_history_returns_entries(self, dp, anima_dir):
         """_load_heartbeat_history reads back persisted entries."""
-        # Write entries directly to heartbeat_history/ (legacy format)
-        history_dir = anima_dir / "shortterm" / "heartbeat_history"
         # Write heartbeat_end entries to unified activity log
         activity_dir = anima_dir / "activity_log"
         activity_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/e2e/core/test_heartbeat_message_episode_e2e.py
+++ b/tests/e2e/core/test_heartbeat_message_episode_e2e.py
@@ -32,7 +32,7 @@ class TestInboxMessageEpisodeE2E:
         mio_messenger = Messenger(shared_dir, "mio")
         mio_messenger.send("alice", "AWS監視タスクを追加しました。30分間隔で確認してください。")
 
-        with patch("core.anima.AgentCore") as MockAgent, \
+        with patch("core.anima.AgentCore"), \
              patch("core._anima_heartbeat.ConversationMemory") as MockConv, \
              patch("core._anima_heartbeat.load_prompt", return_value="prompt"):
             MockConv.return_value.load.return_value = MagicMock(turns=[])
@@ -83,7 +83,7 @@ class TestInboxMessageEpisodeE2E:
         inbox_dir = shared_dir / "inbox" / "alice"
         assert len(list(inbox_dir.glob("*.json"))) == 1
 
-        with patch("core.anima.AgentCore") as MockAgent, \
+        with patch("core.anima.AgentCore"), \
              patch("core._anima_heartbeat.ConversationMemory") as MockConv, \
              patch("core._anima_heartbeat.load_prompt", return_value="prompt"):
             MockConv.return_value.load.return_value = MagicMock(turns=[])
@@ -153,7 +153,7 @@ class TestInboxMessageEpisodeE2E:
         ack_file = inbox_dir / f"ack_{today_local().isoformat()}.json"
         ack_file.write_text(ack_msg.model_dump_json(), encoding="utf-8")
 
-        with patch("core.anima.AgentCore") as MockAgent, \
+        with patch("core.anima.AgentCore"), \
              patch("core._anima_heartbeat.ConversationMemory") as MockConv, \
              patch("core._anima_heartbeat.load_prompt", return_value="prompt"):
             MockConv.return_value.load.return_value = MagicMock(turns=[])
@@ -206,7 +206,7 @@ class TestInboxMessageEpisodeE2E:
         charlie_messenger = Messenger(shared_dir, "charlie")
         charlie_messenger.send("alice", "第三のタスク: パフォーマンス最適化")
 
-        with patch("core.anima.AgentCore") as MockAgent, \
+        with patch("core.anima.AgentCore"), \
              patch("core._anima_heartbeat.ConversationMemory") as MockConv, \
              patch("core._anima_heartbeat.load_prompt", return_value="prompt"):
             MockConv.return_value.load.return_value = MagicMock(turns=[])
@@ -255,7 +255,7 @@ class TestInboxMessageEpisodeE2E:
         mio_messenger = Messenger(shared_dir, "mio")
         mio_messenger.send("alice", "テストメッセージ")
 
-        with patch("core.anima.AgentCore") as MockAgent, \
+        with patch("core.anima.AgentCore"), \
              patch("core._anima_heartbeat.ConversationMemory") as MockConv, \
              patch("core._anima_heartbeat.load_prompt", return_value="prompt"):
             MockConv.return_value.load.return_value = MagicMock(turns=[])
@@ -299,7 +299,7 @@ class TestHeartbeatNoInboxProcessing:
         mio_messenger = Messenger(shared_dir, "mio")
         mio_messenger.send("alice", "テストメッセージ")
 
-        with patch("core.anima.AgentCore") as MockAgent, \
+        with patch("core.anima.AgentCore"), \
              patch("core._anima_heartbeat.ConversationMemory") as MockConv, \
              patch("core._anima_heartbeat.load_prompt", return_value="prompt"):
             MockConv.return_value.load.return_value = MagicMock(turns=[])


### PR DESCRIPTION
## Summary
- `swe/runner.py`: remove unused `import time` (F401) — `time` module not referenced anywhere in the file
- `tests/e2e/core/test_heartbeat_dialogue_e2e.py`: remove unused `history_dir` variable (F841) — legacy path leftover from refactoring to unified activity log
- `tests/e2e/core/test_heartbeat_message_episode_e2e.py`: remove unused `as MockAgent` captures from 6 `patch()` contexts (F841) — mock object never referenced inside the `with` blocks

## Test plan
- [ ] `ruff check swe/runner.py tests/e2e/core/test_heartbeat_dialogue_e2e.py tests/e2e/core/test_heartbeat_message_episode_e2e.py --select=F` → All checks passed
- [ ] `python3 -m pytest` full suite (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)