### PR TITLE
fix: remove extraneous f-prefix from f-strings without placeholders (F541)

### DIFF
--- a/scripts/analyze_heartbeat_tools.py
+++ b/scripts/analyze_heartbeat_tools.py
@@ -151,7 +151,7 @@ def main() -> None:
             print(f"\n  [{s['anima']}] {s['date']} | {s['duration_min']}分")
             print(f"    開始: {s['start']}")
             print(f"    終了: {s['end']}")
-            print(f"    ツール呼び出し:")
+            print("    ツール呼び出し:")
             for tool, cnt in sorted(s["tool_counts"].items(), key=lambda x: -x[1])[:15]:
                 heavy = " (重い)" if tool in HEAVY_TOOLS else ""
                 print(f"      - {tool}: {cnt}回{heavy}")

--- a/scripts/debug_important_tag_e2e.py
+++ b/scripts/debug_important_tag_e2e.py
@@ -160,9 +160,9 @@ def main() -> None:
 
         full_text = (result.related_knowledge or "") + (result.episodes or "")
         if "[IMPORTANT]" in full_text or "インシデント" in full_text or "SQL" in full_text:
-            print(f"\n  ✅ Priming successfully recalled [IMPORTANT]-tagged knowledge!")
+            print("\n  ✅ Priming successfully recalled [IMPORTANT]-tagged knowledge!")
         else:
-            print(f"\n  ❌ [IMPORTANT] knowledge was NOT found in priming output")
+            print("\n  ❌ [IMPORTANT] knowledge was NOT found in priming output")
 
     asyncio.run(test_priming())
 
@@ -174,7 +174,7 @@ def main() -> None:
     print(f"  Step 2 (Metadata):    {len(important_chunks)} chunks with importance=important")
     print(f"  Step 3 (Boost):       {'✅' if boosted_found else '❌'} +{WEIGHT_IMPORTANCE} score boost")
     print(f"  Step 4 (Forgetting):  {'✅' if protected_count > 0 else '❌'} {protected_count} protected")
-    print(f"  Step 5 (Priming):     (see above)")
+    print("  Step 5 (Priming):     (see above)")
     print()
 
 


### PR DESCRIPTION
## Summary
- `scripts/analyze_heartbeat_tools.py`: `f"    ツール呼び出し:"` → `"    ツール呼び出し:"`
- `scripts/debug_important_tag_e2e.py`: 3箇所のプレースホルダーなしf文字列を通常文字列に変更

## Motivation
ruff F541: f-string without any placeholders。プレースホルダー`{}`を含まないf文字列は不要な`f`プレフィックス。機能的な違いはないが、lintクリーンアップとして修正。

## Test plan
- [ ] `ruff check . --select=F541` → 0 errors
- [ ] scripts files のみの変更（本番コアロジックに影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)