### PR TITLE
fix: remove unused imports F401 in tests/scripts (09:00 scan)

### DIFF
--- a/scripts/investigate_task_data.py
+++ b/scripts/investigate_task_data.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 from datetime import datetime
 from pathlib import Path
 

--- a/tests/e2e/tools/test_chatwork_cli_e2e.py
+++ b/tests/e2e/tools/test_chatwork_cli_e2e.py
@@ -6,12 +6,11 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from core.tools.chatwork import cli_main, ChatworkClient, MessageCache
+from core.tools.chatwork import cli_main, MessageCache
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/core/memory/test_retriever_importance_boost.py
+++ b/tests/unit/core/memory/test_retriever_importance_boost.py
@@ -19,7 +19,6 @@ from unittest.mock import patch
 from core.memory.rag.retriever import (
     WEIGHT_IMPORTANCE,
     MemoryRetriever,
-    RetrievalResult,
 )
 from core.memory.rag.store import Document, SearchResult
 

--- a/tests/unit/core/test_fd_limits.py
+++ b/tests/unit/core/test_fd_limits.py
@@ -6,7 +6,6 @@ import os
 from pathlib import Path
 from unittest import mock
 
-import pytest
 
 from core import fd_limits
 

--- a/tests/unit/core/tools/test_credential_resolver.py
+++ b/tests/unit/core/tools/test_credential_resolver.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 
 import pytest

--- a/tests/unit/core/tools/test_expression_generation.py
+++ b/tests/unit/core/tools/test_expression_generation.py
@@ -19,7 +19,6 @@ Tests cover:
 - builder.py EMOTION_INSTRUCTION: contains all 7 emotion names
 """
 
-import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 

--- a/tests/unit/core/tools/test_image_gen_vibe.py
+++ b/tests/unit/core/tools/test_image_gen_vibe.py
@@ -6,12 +6,12 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from core.config.models import ImageGenConfig
-from core.tools.image_gen import ImageGenPipeline, PipelineResult
+from core.tools.image_gen import ImageGenPipeline
 
 
 # ── Fixtures ──────────────────────────────────────────────

--- a/tests/unit/core/tools/test_novelai_vibe.py
+++ b/tests/unit/core/tools/test_novelai_vibe.py
@@ -8,18 +8,16 @@ from __future__ import annotations
 import base64
 import io
 import zipfile
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
 
-from core.tools._base import ToolConfigError
 from core.tools.image_gen import (
     NOVELAI_API_URL,
     NOVELAI_ENCODE_URL,
     NOVELAI_MODEL,
     NovelAIClient,
-    _retry,
 )
 
 

--- a/tests/unit/swe/test_runner.py
+++ b/tests/unit/swe/test_runner.py
@@ -1,16 +1,11 @@
 """Tests for swe/runner.py — unit tests for helpers and orchestration logic."""
 from __future__ import annotations
 
-import json
 import subprocess
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 
 from swe.runner import (
-    chat_sse,
-    clone_repo,
     create_test_instance,
     git_diff,
 )

--- a/tests/unit/swe/test_team_setup.py
+++ b/tests/unit/swe/test_team_setup.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
 

--- a/tests/unit/tools/test_asset_optimization.py
+++ b/tests/unit/tools/test_asset_optimization.py
@@ -8,9 +8,8 @@ from __future__ import annotations
 import argparse
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
-import pytest
 
 
 # ── _ensure_fbx2gltf ────────────────────────────────────────────

--- a/tests/unit/tools/test_aws_collector.py
+++ b/tests/unit/tools/test_aws_collector.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import json
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 

--- a/tests/unit/tools/test_chatwork.py
+++ b/tests/unit/tools/test_chatwork.py
@@ -5,10 +5,9 @@
 
 from __future__ import annotations
 
-import sqlite3
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 from pathlib import Path
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -21,7 +20,6 @@ from core.tools.chatwork import (
     _format_timestamp,
     _resolve_write_token,
     _sync_rooms,
-    JST,
 )
 
 

--- a/tests/unit/tools/test_fal_text_to_image.py
+++ b/tests/unit/tools/test_fal_text_to_image.py
@@ -5,10 +5,8 @@
 
 from __future__ import annotations
 
-import time
 from unittest.mock import MagicMock, patch
 
-import httpx
 import pytest
 
 from core.tools._base import ToolConfigError

--- a/tests/unit/tools/test_generate_bustup_expression.py
+++ b/tests/unit/tools/test_generate_bustup_expression.py
@@ -15,7 +15,6 @@ from core.tools.image_gen import (
     ImageGenPipeline,
     _EXPRESSION_GUIDANCE,
     _EXPRESSION_PROMPTS,
-    _VALID_EXPRESSION_NAMES,
 )
 
 

--- a/tests/unit/tools/test_github.py
+++ b/tests/unit/tools/test_github.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import json
 import subprocess
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 

--- a/tests/unit/tools/test_image_gen.py
+++ b/tests/unit/tools/test_image_gen.py
@@ -7,10 +7,9 @@ from __future__ import annotations
 
 import base64
 import io
-import json
 import zipfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest

--- a/tests/unit/tools/test_image_gen_expressions.py
+++ b/tests/unit/tools/test_image_gen_expressions.py
@@ -6,9 +6,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
-import pytest
 
 from core.tools.image_gen import (
     _EXPRESSION_PROMPTS,

--- a/tests/unit/tools/test_local_llm.py
+++ b/tests/unit/tools/test_local_llm.py
@@ -5,11 +5,8 @@
 
 from __future__ import annotations
 
-import json
-import os
 from unittest.mock import MagicMock, patch
 
-import httpx
 import pytest
 
 from core.tools.local_llm import (

--- a/tests/unit/tools/test_slack.py
+++ b/tests/unit/tools/test_slack.py
@@ -5,16 +5,13 @@
 
 from __future__ import annotations
 
-import sqlite3
-from datetime import datetime, timezone, timedelta
 from pathlib import Path
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from core.tools._base import ToolConfigError
 from core.tools.slack import (
-    JST,
     MessageCache,
     clean_slack_markup,
     format_slack_ts,

--- a/tests/unit/tools/test_slack_identity.py
+++ b/tests/unit/tools/test_slack_identity.py
@@ -5,10 +5,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
 
 from core.config.models import (
     AnimaWorksConfig,

--- a/tests/unit/tools/test_transcribe.py
+++ b/tests/unit/tools/test_transcribe.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 

--- a/tests/unit/tools/test_web_search.py
+++ b/tests/unit/tools/test_web_search.py
@@ -5,9 +5,7 @@
 
 from __future__ import annotations
 
-import json
-import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import httpx
 import pytest

--- a/tests/unit/tools/test_x_search.py
+++ b/tests/unit/tools/test_x_search.py
@@ -5,10 +5,7 @@
 
 from __future__ import annotations
 
-import json
-import os
-from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import httpx
 import pytest


### PR DESCRIPTION
## Summary

- ruff F401（unused import）57件を自動修正（`ruff --fix`）
- 対象: テストファイル23件 + スクリプト1件 = 計24ファイル
- 本番コードへの変更なし

## Changes

| ルール | 件数 | 対応 |
|--------|------|------|
| F401 unused-import | 57件→0件 | `ruff --fix` で自動修正 |
| F841 unused-variable | 159件 | unsafe-fix のためスキップ |
| F821 undefined-name | 48件 | 型アノテーション内局所インポートのため実害なし |

## Test plan
- [ ] CI pytest（前回: 9317 passed on main 2026-03-15T23:51）
- [ ] ruff check: F401 0件になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)