### PR TITLE
fix: initialize _read_paths in _FakeWriteHandler and pre-populate in overwrite test

### DIFF
--- a/tests/unit/core/tooling/test_handler_memory_fm_fallback.py
+++ b/tests/unit/core/tooling/test_handler_memory_fm_fallback.py
@@ -37,6 +37,7 @@ class _FakeWriteHandler(MemoryToolsMixin):
         self._state_file_lock: threading.Lock | None = None
         self._on_schedule_changed = None
         self._min_trust_seen = 2
+        self._read_paths: set[str] = set()
 
     def _is_state_file(self, path: Path) -> bool:
         return False
@@ -99,6 +100,7 @@ class TestParsefailedFrontmatterFallback:
             encoding="utf-8",
         )
 
+        handler._read_paths.add('knowledge/existing.md')
         broken_content = "---\n!!!broken!!!\n---\n\nNew content here."
         handler._handle_write_memory_file({
             "path": "knowledge/existing.md",


### PR DESCRIPTION
## Summary
- `_FakeWriteHandler.__init__` に `self._read_paths: set[str] = set()` を追加（AttributeError修正）
- `test_preserves_created_at_on_overwrite` で `handler._read_paths.add('knowledge/existing.md')` を追加（read-before-writeガード通過）

## Root Cause
`handler_memory.py` L213付近にread-before-writeガードが追加されたが、テスト用スタブ `_FakeWriteHandler` が `_read_paths` を初期化していなかった。また `test_preserves_created_at_on_overwrite` は既存ファイルへの上書きテストのため、事前readが必要。

## Test plan
- [x] `python3 -m pytest tests/unit/core/tooling/test_handler_memory_fm_fallback.py -v` → 5/5 PASS
- [ ] GitHub CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)