### PR TITLE
runner側のextra_mcp_serversが欠損していた問題修正

### DIFF
--- a/core/memory/config_reader.py
+++ b/core/memory/config_reader.py
@@ -68,6 +68,7 @@ class ConfigReader:
                 llm_timeout=resolved.llm_timeout,
                 extra_keys=credential.keys or {},
                 mode_s_auth=resolved.mode_s_auth,
+                extra_mcp_servers=resolved.extra_mcp_servers,
             )
 
         # Legacy fallback: parse config.md


### PR DESCRIPTION
# Summary 

- WebUI側では読めていたが、Model側のConfig読み込みから抜けていたので修正しました。

# Tests

- 既存テストは ALL PASSを確認しました