### PR TITLE
fix(test): create identity.md fixtures in tree layout E2E test

### DIFF
--- a/tests/e2e/test_workspace_tree_layout_e2e.py
+++ b/tests/e2e/test_workspace_tree_layout_e2e.py
@@ -34,6 +34,16 @@ def _create_app_with_config(
     """
     animas_dir = tmp_path / "animas"
     animas_dir.mkdir(parents=True, exist_ok=True)
+
+    # Create identity.md for each anima so /api/animas route recognizes them
+    for anima_name in anima_names:
+        anima_dir = animas_dir / anima_name
+        anima_dir.mkdir(parents=True, exist_ok=True)
+        (anima_dir / "identity.md").write_text(
+            f"# {anima_name}\n\nTest identity for {anima_name}.\n",
+            encoding="utf-8",
+        )
+
     shared_dir = tmp_path / "shared"
     shared_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## Summary
- Add identity.md creation in `_create_app_with_config` fixture
- Same fix as canvas_layout, live_activity_cards, and character_scale_and_hierarchy E2E tests
- Fixes: test_sakura_based_tree_structure assert 0 == 3 failure

## Root cause
/api/animas route only recognizes anima directories that contain identity.md.
The helper was creating animas_dir but not the individual anima subdirs with identity.md.