### PR TITLE
fix(chat): fallback to getRandomValues when randomUUID unavailable

### DIFF
--- a/server/static/shared/chat/thread-logic.js
+++ b/server/static/shared/chat/thread-logic.js
@@ -32,7 +32,16 @@ export function defaultThreadLabel(threadId, lastTs, timeStr) {
  * @returns {{ updatedList: Array, newThreadId: string, newEntry: object }}
  */
 export function createThread(threadList, _animaName) {
-  const threadId = crypto.randomUUID().slice(0, 8);
+  // crypto.randomUUID requires secure context (HTTPS or localhost).
+  // Fall back to crypto.getRandomValues for HTTP + LAN IP access.
+  let threadId;
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    threadId = crypto.randomUUID().slice(0, 8);
+  } else {
+    const arr = new Uint8Array(4);
+    crypto.getRandomValues(arr);
+    threadId = Array.from(arr, b => b.toString(16).padStart(2, '0')).join('');
+  }
   const newEntry = { id: threadId, label: t("thread.new"), unread: false };
   const updatedList = [...threadList, newEntry];
   return { updatedList, newThreadId: threadId, newEntry };


### PR DESCRIPTION
## 問題

`crypto.randomUUID()` はセキュアコンテキスト（HTTPS または localhost）でのみ利用可能です。
LAN の IP アドレス経由で HTTP アクセスした場合、`randomUUID` が `undefined` になりスレッド作成が失敗します。

## 修正内容

`crypto.randomUUID` が使えない環境では `crypto.getRandomValues` にフォールバックし、8文字の hex ID を生成するようにしました。

`crypto.getRandomValues` は非セキュアコンテキストでも動作するため、HTTP + LAN IP 環境でも正常に機能します。

## 再現条件

- AnimaWorks サーバーを HTTP で起動
- LAN の IP アドレス（例: `http://192.168.x.x:port`）でアクセス
- 新しいスレッドを作成しようとすると失敗する