### PR TITLE
fix(schedule_parser): handle day-of-week ranges that wrap around Sunday

### DIFF
--- a/core/schedule_parser.py
+++ b/core/schedule_parser.py
@@ -232,6 +232,54 @@ def _parse_section(name: str, lines: list[str]) -> CronTask:
     )
 
 
+def _posix_range_to_iso_values(start: int, end: int, step: int = 1) -> list[int]:
+    """Expand a POSIX DOW range to a list of ISO APScheduler values.
+
+    POSIX values in [start, end] (inclusive) are sampled by *step* and each
+    converted via ``(posix - 1) % 7`` to the ISO numbering used by APScheduler.
+
+    Args:
+        start: First POSIX day value (0/7=Sun, 1=Mon, …, 6=Sat).
+        end:   Last POSIX day value (inclusive).
+        step:  Step size (default 1).
+
+    Returns:
+        Ordered list of ISO day values in the same order as the POSIX range.
+    """
+    return [(x - 1) % 7 for x in range(start, end + 1, step)]
+
+
+def _iso_values_to_parts(values: list[int]) -> list[str]:
+    """Compress a list of consecutive ISO DOW values into range-notation parts.
+
+    Runs of consecutive integers (diff == 1) are collapsed to ``"a-b"``;
+    isolated values are emitted as plain strings.
+
+    Args:
+        values: Ordered list of ISO day integers.
+
+    Returns:
+        List of string parts ready to be joined with commas.
+    """
+    if not values:
+        return []
+
+    parts: list[str] = []
+    group_start = values[0]
+    prev = values[0]
+
+    for v in values[1:]:
+        if v == prev + 1:
+            prev = v
+        else:
+            parts.append(str(group_start) if prev == group_start else f"{group_start}-{prev}")
+            group_start = v
+            prev = v
+
+    parts.append(str(group_start) if prev == group_start else f"{group_start}-{prev}")
+    return parts
+
+
 def _posix_dow_to_apsched(dow: str) -> str:
     """Convert POSIX cron day_of_week field to APScheduler CronTrigger format.
 
@@ -239,13 +287,18 @@ def _posix_dow_to_apsched(dow: str) -> str:
     APScheduler CronTrigger uses ISO 8601: 0=Monday, 1=Tuesday, ..., 6=Sunday.
     Conversion formula: apscheduler_value = (posix_value - 1) % 7
 
+    Ranges that cross Sunday (POSIX 0) are expanded to individual ISO values
+    and re-compressed with range notation so that APScheduler never receives an
+    invalid ``start > end`` range (e.g. POSIX ``"0-4"`` → ISO ``"6,0-3"``).
+
     Handles:
     - Wildcard: ``*`` → ``*`` (no change)
     - Single values: ``1`` → ``0``, ``4`` → ``3``
     - Comma-separated: ``1,4`` → ``0,3``
-    - Ranges: ``1-5`` → ``0-4``
+    - Ranges (non-wrapping): ``1-5`` → ``0-4``
+    - Ranges (Sunday-wrapping): ``0-4`` → ``6,0-3``
     - Step with wildcard base: ``*/2`` → ``*/2`` (no day conversion)
-    - Step with range base: ``1-5/2`` → ``0-4/2``
+    - Step with range base: ``1-5/2`` → ``0-4/2`` (wrapping case: expanded)
 
     Args:
         dow: The day_of_week field string from a POSIX cron expression.
@@ -264,16 +317,21 @@ def _posix_dow_to_apsched(dow: str) -> str:
                 result_parts.append(part)  # */n — no day index conversion needed
             elif "-" in base:
                 start, end = base.split("-", 1)
-                new_start = str((int(start) - 1) % 7)
-                new_end = str((int(end) - 1) % 7)
-                result_parts.append(f"{new_start}-{new_end}/{step}")
+                iso_values = _posix_range_to_iso_values(int(start), int(end), int(step))
+                result_parts.extend(_iso_values_to_parts(iso_values))
             else:
                 result_parts.append(f"{(int(base) - 1) % 7}/{step}")
         elif "-" in part:
             start, end = part.split("-", 1)
-            new_start = str((int(start) - 1) % 7)
-            new_end = str((int(end) - 1) % 7)
-            result_parts.append(f"{new_start}-{new_end}")
+            iso_values = _posix_range_to_iso_values(int(start), int(end))
+            new_start_int = (int(start) - 1) % 7
+            new_end_int = (int(end) - 1) % 7
+            if new_start_int <= new_end_int:
+                # No wrap-around: keep compact range notation
+                result_parts.append(f"{new_start_int}-{new_end_int}")
+            else:
+                # Wrap-around (e.g. 0-4 → 6,0-3): expand and re-compress
+                result_parts.extend(_iso_values_to_parts(iso_values))
         else:
             result_parts.append(str((int(part) - 1) % 7))
 

--- a/tests/unit/test_schedule_parser.py
+++ b/tests/unit/test_schedule_parser.py
@@ -7,10 +7,13 @@ from __future__ import annotations
 
 from apscheduler.triggers.cron import CronTrigger
 
+import pytest
+
 from core.schedule_parser import (
     parse_heartbeat_config,
     parse_cron_md,
     parse_schedule,
+    _posix_dow_to_apsched,
 )
 
 
@@ -160,3 +163,81 @@ class TestParseSchedule:
         """Old Japanese format is not supported by the new parser."""
         trigger = parse_schedule("毎日 9:00 JST")
         assert trigger is None
+
+    def test_sunday_start_range_does_not_raise(self):
+        """parse_schedule('30 17 * * 0-4') must not raise ValueError.
+
+        Regression test for the wrap-around bug: POSIX '0-4' (Sun-Thu) was
+        naively converted to APScheduler '6-3' which is an invalid range.
+        """
+        trigger = parse_schedule("30 17 * * 0-4")
+        assert trigger is not None
+        assert isinstance(trigger, CronTrigger)
+
+
+class TestPosixDowToApsched:
+    """Unit tests for _posix_dow_to_apsched() conversion logic."""
+
+    def test_wildcard_passthrough(self):
+        assert _posix_dow_to_apsched("*") == "*"
+
+    def test_single_value(self):
+        """POSIX 4 (Thu) → ISO 3."""
+        assert _posix_dow_to_apsched("4") == "3"
+
+    def test_single_value_monday(self):
+        """POSIX 1 (Mon) → ISO 0."""
+        assert _posix_dow_to_apsched("1") == "0"
+
+    def test_single_value_sunday_posix0(self):
+        """POSIX 0 (Sun) → ISO 6."""
+        assert _posix_dow_to_apsched("0") == "6"
+
+    def test_single_value_sunday_posix7(self):
+        """POSIX 7 (Sun alias) → ISO 6."""
+        assert _posix_dow_to_apsched("7") == "6"
+
+    def test_comma_separated(self):
+        """POSIX '1,4' (Mon,Thu) → ISO '0,3'."""
+        assert _posix_dow_to_apsched("1,4") == "0,3"
+
+    def test_normal_range_no_wrap(self):
+        """POSIX '1-5' (Mon–Fri) → ISO '0-4' (no wrap-around)."""
+        assert _posix_dow_to_apsched("1-5") == "0-4"
+
+    def test_sunday_start_range(self):
+        """POSIX '0-4' (Sun–Thu) → ISO '6,0-3' (wrap-around fix).
+
+        This is the primary regression test for the bug introduced in commit
+        020367d9: previously '0-4' produced '6-3' which raises ValueError in
+        APScheduler because the minimum of a range must not exceed the maximum.
+        """
+        assert _posix_dow_to_apsched("0-4") == "6,0-3"
+
+    def test_full_week_range(self):
+        """POSIX '0-6' (all days) → APScheduler representation covering all days."""
+        result = _posix_dow_to_apsched("0-6")
+        # '6,0-5' covers all 7 ISO days; verify APScheduler accepts it
+        trigger = parse_schedule(f"0 9 * * {result}")
+        assert trigger is not None
+
+    def test_range_ending_at_sunday(self):
+        """POSIX '5-7' (Fri–Sun) → ISO '4-6' (consecutive, no wrap)."""
+        assert _posix_dow_to_apsched("5-7") == "4-6"
+
+    def test_step_normal_range(self):
+        """POSIX '1-5/2' (Mon,Wed,Fri) → ISO values without wrap."""
+        result = _posix_dow_to_apsched("1-5/2")
+        # POSIX [1,3,5] → ISO [0,2,4]; no consecutive pairs → individual values
+        assert result == "0,2,4"
+
+    @pytest.mark.parametrize("expr", [
+        "30 17 * * 0-4",   # sec's broken schedule — the main bug
+        "0 9 * * 0",       # Sunday only
+        "0 9 * * 0-6",     # All days via full POSIX range
+        "0 9 * * 5-7",     # Fri–Sun via POSIX 5-7
+    ])
+    def test_parse_schedule_accepts_sunday_ranges(self, expr: str):
+        """parse_schedule must return a valid CronTrigger for Sunday-containing ranges."""
+        trigger = parse_schedule(expr)
+        assert trigger is not None, f"parse_schedule({expr!r}) returned None"


### PR DESCRIPTION
## 背景・バグ再現条件

POSIX cron の曜日範囲 `0-4`（日〜木）を APScheduler の `day_of_week` に渡すと、`_posix_dow_to_apsched()` が端点を独立に `(x-1)%7` で変換し、`"6-3"` という start > end な無効な範囲を生成していた。APScheduler はこれを受け取ると次の例外を上げる：

```
ValueError: The minimum value in a range must not be higher than the maximum
```

実際のサーバーログで確認済み（2026-04-24 09:35:07, 19:08:00, 19:11:48）：
```
Failed to create CronTrigger from '30 17 * * 0-4': The minimum value in a range must not be higher than the maximum
```

バグ混入コミット: `020367d9`（2026-03-30 10:22 JST）

## 影響範囲

- **sec の「日次タスク記録・日報更新（Notion）」タスク** (`30 17 * * 0-4`) が 2026-04-03 以降ずっと登録失敗
- 日曜日（POSIX 0 または 7）を range の開始または内包する cron 式が全て影響する

## 修正内容

`core/schedule_parser.py` の `_posix_dow_to_apsched()` を修正。

### 追加したヘルパー関数

**`_posix_range_to_iso_values(start, end, step=1)`**  
POSIX 範囲の各値を `(x-1)%7` で ISO 値リストに変換（step 対応）。

**`_iso_values_to_parts(values)`**  
ISO 値リストを連続グループはレンジ記法 `"a-b"`、非連続は個別値にまとめる。

### 変換例

| POSIX 入力 | 修正前 | 修正後 |
|-----------|--------|--------|
| `0-4` (Sun–Thu) | `6-3` ❌ ValueError | `6,0-3` ✅ |
| `1-5` (Mon–Fri) | `0-4` ✅ | `0-4` ✅ (回帰なし) |
| `5-7` (Fri–Sun) | `4-6` ✅ | `4-6` ✅ (回帰なし) |
| `1-5/2` | `0-4/2` | `0,2,4` (step展開) |
| `0-6` (all) | `6-5` ❌ | `6,0-5` ✅ |

## 追加テスト

`tests/unit/test_schedule_parser.py` に `TestPosixDowToApsched` クラスを追加（16 テスト）。

**ローカルテスト結果: 35 passed in 1.36s**（既存 19 + 新規 16）

```
tests/unit/test_schedule_parser.py::TestPosixDowToApsched::test_sunday_start_range PASSED  # 主回帰テスト
tests/unit/test_schedule_parser.py::TestParseSchedule::test_sunday_start_range_does_not_raise PASSED
tests/unit/test_schedule_parser.py::TestPosixDowToApsched::test_parse_schedule_accepts_sunday_ranges[30 17 * * 0-4] PASSED
... (35 passed)
```

## 次のステップ

このPRがマージされた後、サーバーを再起動すると sec の `30 17 * * 0-4` スケジュールが正常に登録されます（再起動は boss 側で判断）。