### PR TITLE
fix: replace silent except Exception with specific exception types in _anima_inbox.py

### DIFF
--- a/core/_anima_inbox.py
+++ b/core/_anima_inbox.py
@@ -589,8 +589,8 @@ class InboxMixin:
                         try:
                             if _rc_path.exists():
                                 _rc = json.loads(_rc_path.read_text(encoding="utf-8"))
-                        except Exception:
-                            pass
+                        except (json.JSONDecodeError, OSError):
+                            logger.warning("[%s] Failed to read inbox_read_counts.json, using empty counts", self.name)
                         _all_exhausted = (
                             all(_rc.get(item.path.name, 0) > _MAX_INBOX_RETRIES for item in inbox_result.inbox_items)
                             if inbox_result.inbox_items


### PR DESCRIPTION
## 概要

CI e2e test `test_no_except_exception_pass_in_core` が5件連続で失敗していたため修正。

## 変更内容

- `core/_anima_inbox.py:592` の `except Exception: pass` を具体的な例外型に変更
  - `except (json.JSONDecodeError, OSError):` に変更
  - `pass` を `logger.warning(...)` でログ出力に変更

## 修正前後

```python
# Before
except Exception:
    pass

# After
except (json.JSONDecodeError, OSError):
    logger.warning("[%s] Failed to read inbox_read_counts.json, using empty counts", self.name)
```

## 関連

- CI失敗: https://github.com/xuiltul/animaworks/actions/runs/25465971279
- テスト: `test_no_except_exception_pass_in_core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)