### PR TITLE
fix(static): close template literals after basePath substitution

### DIFF
--- a/server/static/pages/settings.js
+++ b/server/static/pages/settings.js
@@ -198,7 +198,7 @@ async function _onModeChange(mode, container) {
   localStorage.removeItem("aw-workspace-view");
 
   try {
-    await fetch(`${basePath}/api/settings/display-mode", {
+    await fetch(`${basePath}/api/settings/display-mode`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ mode }),
@@ -222,7 +222,7 @@ async function _initActivityLevel(container) {
   let level = 100;
   let fromApi = false;
   try {
-    const res = await fetch(`${basePath}/api/settings/activity-level");
+    const res = await fetch(`${basePath}/api/settings/activity-level`);
     if (res.ok) {
       const data = await res.json();
       level = data.activity_level || 100;
@@ -310,7 +310,7 @@ function _updatePresetButtons(container, level) {
 async function _setActivityLevel(level, container) {
   _cacheActivityState(level, null);
   try {
-    const res = await fetch(`${basePath}/api/settings/activity-level", {
+    const res = await fetch(`${basePath}/api/settings/activity-level`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ activity_level: level }),
@@ -412,7 +412,7 @@ async function _saveNightMode(container, revertOnFail) {
   _cacheActivityState(dayLevel, schedule);
 
   try {
-    const res = await fetch(`${basePath}/api/settings/activity-schedule", {
+    const res = await fetch(`${basePath}/api/settings/activity-schedule`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ activity_schedule: schedule }),
@@ -442,7 +442,7 @@ async function _clearNightMode(container) {
   _cacheActivityState(curLevel, []);
 
   try {
-    const res = await fetch(`${basePath}/api/settings/activity-schedule", {
+    const res = await fetch(`${basePath}/api/settings/activity-schedule`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ activity_schedule: [] }),

--- a/server/static/pages/setup.js
+++ b/server/static/pages/setup.js
@@ -292,7 +292,7 @@ async function _loadAuthSettings() {
 
         try {
           const curPwEl = document.getElementById("currentPassword");
-          const res = await fetch(`${basePath}/api/users/me/password", {
+          const res = await fetch(`${basePath}/api/users/me/password`, {
             method: "PUT",
             headers: { "Content-Type": "application/json" },
             credentials: "same-origin",
@@ -353,7 +353,7 @@ async function _loadAuthSettings() {
         const result = document.getElementById("addUserResult");
 
         try {
-          const res = await fetch(`${basePath}/api/users", {
+          const res = await fetch(`${basePath}/api/users`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             credentials: "same-origin",
@@ -473,7 +473,7 @@ async function _loadAnthropicAuthSettings() {
       }
 
       try {
-        const saveRes = await fetch(`${basePath}/api/settings/anthropic-auth", {
+        const saveRes = await fetch(`${basePath}/api/settings/anthropic-auth`, {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
           credentials: "same-origin",
@@ -626,7 +626,7 @@ async function _loadOpenAIAuthSettings() {
 
       try {
         // Save directly (PUT endpoint validates internally)
-        const saveRes = await fetch(`${basePath}/api/settings/openai-auth", {
+        const saveRes = await fetch(`${basePath}/api/settings/openai-auth`, {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
           credentials: "same-origin",
@@ -750,7 +750,7 @@ async function _loadLocalLLMSettings() {
       };
 
       try {
-        const saveRes = await fetch(`${basePath}/api/settings/local-llm", {
+        const saveRes = await fetch(`${basePath}/api/settings/local-llm`, {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
           credentials: "same-origin",
@@ -781,7 +781,7 @@ async function _loadLocalLLMSettings() {
     applyButton?.addEventListener("click", async () => {
       const result = document.getElementById("localLlmResult");
       try {
-        const res = await fetch(`${basePath}/api/settings/local-llm/apply-role-presets", {
+        const res = await fetch(`${basePath}/api/settings/local-llm/apply-role-presets`, {
           method: "POST",
           credentials: "same-origin",
         });

--- a/server/static/setup/steps/confirm.js
+++ b/server/static/setup/steps/confirm.js
@@ -144,7 +144,7 @@ export async function completeSetup(data) {
   }
 
   try {
-    const res = await fetch(`${basePath}/api/setup/complete", {
+    const res = await fetch(`${basePath}/api/setup/complete`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),

--- a/server/static/setup/steps/environment.js
+++ b/server/static/setup/steps/environment.js
@@ -55,7 +55,7 @@ export function initEnvironmentStep(el) {
 
 async function fetchEnvironment() {
   try {
-    const res = await fetch(`${basePath}/api/setup/environment");
+    const res = await fetch(`${basePath}/api/setup/environment`);
     if (res.ok) {
       const data = await res.json();
       envData = { ...envData, ...data };
@@ -574,7 +574,7 @@ async function validateApiKey() {
   statusEl.innerHTML = `<div class="validation-status checking"><span class="loading-spinner"></span> ${t("btn.validating")}</div>`;
 
   try {
-    const res = await fetch(`${basePath}/api/setup/validate-key", {
+    const res = await fetch(`${basePath}/api/setup/validate-key`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ provider: selectedProvider, auth_mode: openaiAuthMode, api_key: apiKey }),
@@ -600,7 +600,7 @@ async function validateCodexLogin() {
   statusEl.innerHTML = `<div class="validation-status checking"><span class="loading-spinner"></span> ${t("btn.validating")}</div>`;
 
   try {
-    const res = await fetch(`${basePath}/api/setup/validate-key", {
+    const res = await fetch(`${basePath}/api/setup/validate-key`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ provider: "openai", auth_mode: "codex_login" }),
@@ -627,7 +627,7 @@ async function startCodexBrowserLogin() {
   infoEl.innerHTML = `<div class="validation-status checking"><span class="loading-spinner"></span> ${t("btn.validating")}</div>`;
 
   try {
-    const res = await fetch(`${basePath}/api/setup/codex/device-login", {
+    const res = await fetch(`${basePath}/api/setup/codex/device-login`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
     });
@@ -650,7 +650,7 @@ async function validateClaudeCodeLogin() {
   statusEl.innerHTML = `<div class="validation-status checking"><span class="loading-spinner"></span> ${t("btn.validating")}</div>`;
 
   try {
-    const res = await fetch(`${basePath}/api/setup/validate-key", {
+    const res = await fetch(`${basePath}/api/setup/validate-key`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ provider: "anthropic", auth_mode: "claude_code_login" }),
@@ -674,7 +674,7 @@ async function validateCursorAgent() {
   statusEl.innerHTML = `<div class="validation-status checking"><span class="loading-spinner"></span> ${t("btn.validating")}</div>`;
 
   try {
-    const res = await fetch(`${basePath}/api/setup/validate-key", {
+    const res = await fetch(`${basePath}/api/setup/validate-key`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ provider: "cursor_agent" }),
@@ -701,7 +701,7 @@ async function validateGeminiCli() {
   statusEl.innerHTML = `<div class="validation-status checking"><span class="loading-spinner"></span> ${t("btn.validating")}</div>`;
 
   try {
-    const res = await fetch(`${basePath}/api/setup/validate-key", {
+    const res = await fetch(`${basePath}/api/setup/validate-key`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ provider: "gemini_cli" }),
@@ -726,7 +726,7 @@ async function validateOllamaUrl() {
   statusEl.innerHTML = `<div class="validation-status checking"><span class="loading-spinner"></span> ${t("btn.validating")}</div>`;
 
   try {
-    const res = await fetch(`${basePath}/api/setup/validate-key", {
+    const res = await fetch(`${basePath}/api/setup/validate-key`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ provider: "ollama", ollama_url: ollamaUrl }),
@@ -749,7 +749,7 @@ async function validateImageKey(key) {
   statusEl.innerHTML = `<div class="validation-status checking"><span class="loading-spinner"></span> ${t("btn.validating")}</div>`;
 
   try {
-    const res = await fetch(`${basePath}/api/setup/validate-key", {
+    const res = await fetch(`${basePath}/api/setup/validate-key`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ provider: key, api_key: imageKeys[key] }),

--- a/server/static/setup/steps/language.js
+++ b/server/static/setup/steps/language.js
@@ -65,7 +65,7 @@ export function initLanguageStep(el) {
 
 async function detectLocale() {
   try {
-    const res = await fetch(`${basePath}/api/setup/detect-locale");
+    const res = await fetch(`${basePath}/api/setup/detect-locale`);
     if (res.ok) {
       const data = await res.json();
       if (data.detected && LANGUAGES.some((l) => l.code === data.detected)) {

--- a/server/static/workspace/modules/activity.js
+++ b/server/static/workspace/modules/activity.js
@@ -43,7 +43,7 @@ export async function loadActivityHistory() {
   _activityHistoryLoaded = true;
 
   try {
-    const res = await fetch(`${basePath}/api/activity/recent?hours=24&limit=50&offset=0");
+    const res = await fetch(`${basePath}/api/activity/recent?hours=24&limit=50&offset=0`);
     if (!res.ok) return;
     const data = await res.json();
     const events = data.events || [];

--- a/server/static/workspace/modules/board.js
+++ b/server/static/workspace/modules/board.js
@@ -76,8 +76,8 @@ async function loadBoardChannelList() {
 
   try {
     const [chRes, dmRes] = await Promise.all([
-      fetch(`${basePath}/api/channels"),
-      fetch(`${basePath}/api/dm"),
+      fetch(`${basePath}/api/channels`),
+      fetch(`${basePath}/api/dm`),
     ]);
 
     _boardChannels = chRes.ok ? await chRes.json() : [];

--- a/server/static/workspace/modules/org-dashboard.js
+++ b/server/static/workspace/modules/org-dashboard.js
@@ -753,14 +753,14 @@ let _kpiTasks = "-";
 
 async function _loadKpiStats() {
   try {
-    const resp = await fetch(`${basePath}/api/activity/recent?hours=1&limit=200");
+    const resp = await fetch(`${basePath}/api/activity/recent?hours=1&limit=200`);
     if (resp.ok) {
       const data = await resp.json();
       _kpiEventsH = String((data.events ?? []).length);
     }
   } catch { /* ignore */ }
   try {
-    const resp = await fetch(`${basePath}/api/tasks/summary");
+    const resp = await fetch(`${basePath}/api/tasks/summary`);
     if (resp.ok) {
       const data = await resp.json();
       _kpiTasks = String(data.total_active || 0);
@@ -844,7 +844,7 @@ async function _loadInitialStreams(animas) {
 
 async function _fetchActiveGroups() {
   try {
-    const resp = await fetch(`${basePath}/api/activity/recent?grouped=true&hours=1&group_limit=50");
+    const resp = await fetch(`${basePath}/api/activity/recent?grouped=true&hours=1&group_limit=50`);
     if (!resp.ok) return [];
     const data = await resp.json();
     return (data.groups ?? []).filter(g => g.is_open);


### PR DESCRIPTION
## Summary

Commit fc07af08 (base_path support) introduced a systematic typo in 28 `fetch()` call sites: when replacing `\"/api/...\"` with `` `${basePath}/api/...` ``, the closing `\"` was kept instead of being changed to a backtick. The result is JavaScript SyntaxError that breaks Settings, Setup, and the Workspace org-dashboard.

Example (before):
```js
await fetch(`${basePath}/api/settings/display-mode\", {
```

The trailing `\"` makes the template literal unterminated → `SyntaxError: missing ) after argument list`. The whole module fails to parse, the SPA router catches the import failure, and renders \"ページの読み込みに失敗しました\" / \"Page failed to load\".

## Reproduction

1. Run AnimaWorks at any version including fc07af08 (root deploy is enough — no reverse proxy needed).
2. Open the dashboard and click Settings or Setup, or open `/workspace/`.
3. DevTools console shows `SyntaxError: Invalid or unexpected token` at the affected file.
4. Page body shows the load-failed placeholder.

## Fix

Mechanical replacement: trailing `\"` → `` ` `` for every `fetch(\`\${basePath}/...\")` call site.

28 fixes across 8 files:

- `server/static/pages/settings.js` (5)
- `server/static/pages/setup.js` (6)
- `server/static/setup/steps/environment.js` (9)
- `server/static/setup/steps/confirm.js` (1)
- `server/static/setup/steps/language.js` (1)
- `server/static/workspace/modules/org-dashboard.js` (3)
- `server/static/workspace/modules/activity.js` (1)
- `server/static/workspace/modules/board.js` (2)

## Test plan

- [x] Manually verified: Settings, Setup, and Workspace render correctly after the fix
- [x] No false positives: regex used (`fetch\(\`\\$\{basePath\}[^\`\"\n]*\"(\s*[,);])`) is line-scoped and only matches inside `fetch(` template literals
- [x] `git diff` is symmetric (28 insertions / 28 deletions)