### PR TITLE
fix: add runtime template fallback

### DIFF
--- a/core/paths.py
+++ b/core/paths.py
@@ -149,6 +149,25 @@ def resolve_template_path(
     shared = TEMPLATES_DIR / "_shared" / category / filename
     if shared.exists():
         return shared
+
+    # Runtime prompt fallback.
+    # Some deployed/background worker environments may set ANIMAWORKS_TEMPLATES_DIR
+    # to the runtime data directory (e.g. ~/.animaworks) or to ~/.animaworks/prompts.
+    # Runtime prompts are stored without locale directories:
+    #   ~/.animaworks/prompts/builder/task_in_progress.md
+    # Keep the locale-first packaged-template behavior above, but accept this
+    # runtime layout as a compatibility fallback so heartbeat/cron prompt
+    # construction does not fail when the file exists in the runtime prompt tree.
+    runtime_candidates = [
+        get_data_dir() / category / filename,
+        TEMPLATES_DIR / category / filename,
+    ]
+    if category == "prompts":
+        runtime_candidates.append(get_data_dir() / "prompts" / filename)
+        runtime_candidates.append(TEMPLATES_DIR / filename)
+    for path in runtime_candidates:
+        if path.exists():
+            return path
     raise FileNotFoundError(f"Template not found: {category}/{filename} (tried locales: {loc}, en, ja and _shared)")
 
 


### PR DESCRIPTION
## Summary
- Add runtime template fallback to `core.paths.resolve_template_path()` after the existing locale and `_shared` lookup chain.
- Preserve packaged template resolution order: locale -> en -> ja -> `_shared` -> runtime fallback.
- Fixes Heartbeat prompt loading when runtime/background environments point `ANIMAWORKS_TEMPLATES_DIR` at `/home/main/.animaworks` and prompts exist under `/home/main/.animaworks/prompts/...` without locale directories.

## Root cause
`resolve_template_path()` only searched locale-scoped packaged template paths and `_shared`. Runtime prompt layout such as `/home/main/.animaworks/prompts/builder/task_in_progress.md` was not considered, so `load_prompt('builder/task_in_progress')` could raise `FileNotFoundError` even though the runtime prompt file existed.

## Verification
```bash
ANIMAWORKS_TEMPLATES_DIR=/home/main/.animaworks python - <<'PY'
from core.paths import load_prompt
print(load_prompt('builder/task_in_progress', state='X')[:80])
PY
# => printed the first 80 chars of the runtime task_in_progress prompt

ANIMAWORKS_TEMPLATES_DIR=/home/main/dev/animaworks-bak/templates python - <<'PY'
from core.paths import load_prompt
print(load_prompt('builder/task_in_progress', state='X')[:80])
PY
# => printed the first 80 chars of the packaged task_in_progress prompt

pytest tests/unit/core/test_paths.py -v
# => 20 passed, 2 warnings

python -m ruff check core/paths.py
# => All checks passed!

git diff --check
# => no output
```

## Risk
Low. The new runtime fallback runs only after the existing locale and `_shared` candidates fail, so packaged template behavior remains unchanged when packaged templates exist.
