### PR TITLE
Fix TaskBoard SQLite WAL fd leak

### DIFF
--- a/core/taskboard/store.py
+++ b/core/taskboard/store.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -100,11 +101,27 @@ class TaskBoardStore:
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self._ensure_schema()
 
-    def _connect(self) -> sqlite3.Connection:
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        """Open a short-lived SQLite connection and always close it.
+
+        ``sqlite3.Connection`` implements a context manager, but its ``__exit__``
+        only commits or rolls back the active transaction; it does not close the
+        connection.  TaskBoard opens many WAL-mode connections from long-running
+        Anima processes, so every call site must release the main DB/WAL/SHM file
+        descriptors deterministically.
+        """
         conn = sqlite3.connect(self.db_path)
-        conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA journal_mode=WAL")
-        return conn
+        try:
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA journal_mode=WAL")
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
 
     def _ensure_schema(self) -> None:
         with self._connect() as conn:

--- a/tests/unit/core/taskboard/test_store_sqlite.py
+++ b/tests/unit/core/taskboard/test_store_sqlite.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sqlite3
 from pathlib import Path
 
@@ -8,6 +9,68 @@ import pytest
 from core.paths import get_taskboard_db_path
 from core.taskboard.models import AttentionVisibility, BoardColumn
 from core.taskboard.store import TaskBoardStore
+
+
+def _count_open_taskboard_fds(db_path: Path) -> int:
+    fd_dir = Path("/proc/self/fd")
+    if not fd_dir.exists():
+        pytest.skip("/proc/self/fd is not available on this platform")
+
+    targets = {
+        str(db_path.resolve()),
+        str(db_path.with_name(f"{db_path.name}-wal").resolve()),
+        str(db_path.with_name(f"{db_path.name}-shm").resolve()),
+    }
+    count = 0
+    for fd in fd_dir.iterdir():
+        try:
+            if os.readlink(fd) in targets:
+                count += 1
+        except OSError:
+            continue
+    return count
+
+
+def test_store_closes_sqlite_connections(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    real_connect = sqlite3.connect
+    closed_connections = 0
+
+    class TrackingConnection(sqlite3.Connection):
+        def close(self) -> None:
+            nonlocal closed_connections
+            closed_connections += 1
+            super().close()
+
+    def tracking_connect(*args: object, **kwargs: object) -> sqlite3.Connection:
+        kwargs["factory"] = TrackingConnection
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr("core.taskboard.store.sqlite3.connect", tracking_connect)
+
+    store = TaskBoardStore(tmp_path / "taskboard.sqlite3")
+    store.upsert_metadata(anima_name="sakura", task_id="task-1", actor="alice")
+    store.get_metadata("sakura", "task-1")
+    store.list_metadata()
+    store.list_events(anima_name="sakura", task_id="task-1")
+
+    assert closed_connections == 5
+
+
+def test_store_releases_wal_file_descriptors_after_operations(tmp_path: Path) -> None:
+    db_path = tmp_path / "taskboard.sqlite3"
+    store = TaskBoardStore(db_path)
+
+    assert _count_open_taskboard_fds(db_path) == 0
+
+    for index in range(50):
+        task_id = f"task-{index}"
+        store.upsert_metadata(anima_name="kotoha", task_id=task_id, actor="fd-test")
+        store.get_metadata("kotoha", task_id)
+        store.record_surface(anima_name="kotoha", task_id=task_id, actor="fd-test")
+        store.list_metadata("kotoha")
+        store.list_events(anima_name="kotoha", task_id=task_id)
+
+    assert _count_open_taskboard_fds(db_path) == 0
 
 
 def test_get_taskboard_db_path_uses_shared_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Wrap `TaskBoardStore._connect()` in an explicit context manager that commits/rolls back and always calls `conn.close()`.
- Document why `sqlite3.Connection.__exit__` is insufficient for WAL-mode long-running Anima processes.
- Add regression coverage for explicit connection close calls and `/proc/self/fd` verification that `taskboard.sqlite3`, `taskboard.sqlite3-wal`, and `taskboard.sqlite3-shm` descriptors are released after repeated operations.

## Verification
- `python -m ruff check core/taskboard/store.py tests/unit/core/taskboard/test_store_sqlite.py`
- `pytest -q tests/unit/core/taskboard/test_store_sqlite.py` — 10 passed
- `pytest -q tests/unit/core/taskboard tests/unit/server/routes/test_taskboard.py tests/e2e/test_taskboard_api_e2e.py tests/e2e/test_taskboard_projection_e2e.py tests/e2e/test_taskboard_housekeeping_e2e.py` — 40 passed

## Operational note
This directly addresses the 2026-05-15 kotoha fd exhaustion incident by ensuring each TaskBoard SQLite operation deterministically closes WAL-mode file descriptors instead of relying on GC.
