### PR TITLE
Fix main CI ruff formatting

### DIFF
--- a/cli/commands/import_cmd.py
+++ b/cli/commands/import_cmd.py
@@ -22,7 +22,9 @@ def register_import_command(subparsers: argparse._SubParsersAction) -> None:
     hermes = sub.add_parser("hermes", help="Import Hermes Agent data")
     _common_args(hermes)
     hermes.add_argument("--common-skills", action="store_true", help="Import skills into common_skills/community")
-    hermes.add_argument("--target-anima", default=None, help="Target anima for personal skills, usage, tasks, and drafts")
+    hermes.add_argument(
+        "--target-anima", default=None, help="Target anima for personal skills, usage, tasks, and drafts"
+    )
     hermes.set_defaults(func=cmd_import_hermes)
 
     openclaw = sub.add_parser("openclaw", help="Import OpenClaw data")
@@ -36,7 +38,9 @@ def _common_args(parser: argparse.ArgumentParser) -> None:
     mode = parser.add_mutually_exclusive_group()
     mode.add_argument("--dry-run", action="store_true", help="Preview without changing the runtime filesystem")
     mode.add_argument("--apply", action="store_true", help="Apply importable items and write migration report")
-    parser.add_argument("--replace", action="store_true", help="Replace existing generated targets after backup manifest")
+    parser.add_argument(
+        "--replace", action="store_true", help="Replace existing generated targets after backup manifest"
+    )
     parser.add_argument("--json", action="store_true", dest="json_output", help="Output JSON instead of Markdown")
 
 

--- a/core/_anima_lifecycle.py
+++ b/core/_anima_lifecycle.py
@@ -637,8 +637,7 @@ class LifecycleMixin:
 
                     # Record cron execution result
                     rejection_dicts = [
-                        {"ref": rejection.ref, "reason": rejection.reason}
-                        for rejection in cron_skill_rejections
+                        {"ref": rejection.ref, "reason": rejection.reason} for rejection in cron_skill_rejections
                     ]
                     warning_dicts = [
                         {

--- a/core/goals/judge.py
+++ b/core/goals/judge.py
@@ -25,7 +25,9 @@ from core.goals.models import GoalJudgment, GoalState
 
 logger = logging.getLogger("animaworks.goals.judge")
 
-JudgeFn = Callable[[str, dict[str, Any]], GoalJudgment | dict[str, Any] | str | Awaitable[GoalJudgment | dict[str, Any] | str]]
+JudgeFn = Callable[
+    [str, dict[str, Any]], GoalJudgment | dict[str, Any] | str | Awaitable[GoalJudgment | dict[str, Any] | str]
+]
 
 _VALID_VERDICTS: set[str] = {"done", "continue", "blocked"}
 _JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
@@ -197,8 +199,8 @@ def _render_prompt(payload: dict[str, Any]) -> str:
     return (
         "Judge this goal using only the supplied evidence.\n"
         "Allowed verdicts: done, continue, blocked.\n"
-        "JSON schema: {\"verdict\":\"done|continue|blocked\",\"reason\":\"...\","
-        "\"continuation_prompt\":\"only when verdict is continue\"}\n\n"
+        'JSON schema: {"verdict":"done|continue|blocked","reason":"...",'
+        '"continuation_prompt":"only when verdict is continue"}\n\n'
         f"{json.dumps(payload, ensure_ascii=False, indent=2)}"
     )
 

--- a/core/skills/curator.py
+++ b/core/skills/curator.py
@@ -245,10 +245,14 @@ class SkillCurator:
             patch_count = stats.patch_count if stats else meta.patch_count
             total = success + failure
             if total and failure / total >= 0.7:
-                suggestions.append(LifecycleSuggestion(meta.name, SkillLifecycleState.review, "failure_rate_high", failure / total))
+                suggestions.append(
+                    LifecycleSuggestion(meta.name, SkillLifecycleState.review, "failure_rate_high", failure / total)
+                )
                 continue
             if patch_count >= 5:
-                suggestions.append(LifecycleSuggestion(meta.name, SkillLifecycleState.review, "patch_count_consolidation", patch_count))
+                suggestions.append(
+                    LifecycleSuggestion(meta.name, SkillLifecycleState.review, "patch_count_consolidation", patch_count)
+                )
                 continue
             if meta.pinned or meta.protected:
                 continue
@@ -257,7 +261,9 @@ class SkillCurator:
                 continue
             age_days = (now - last_used.astimezone(UTC)).days
             if age_days >= archive_days:
-                suggestions.append(LifecycleSuggestion(meta.name, SkillLifecycleState.archived, "unused_180d", age_days))
+                suggestions.append(
+                    LifecycleSuggestion(meta.name, SkillLifecycleState.archived, "unused_180d", age_days)
+                )
             elif age_days >= stale_days:
                 suggestions.append(LifecycleSuggestion(meta.name, SkillLifecycleState.stale, "unused_90d", age_days))
         return suggestions
@@ -355,7 +361,9 @@ class SkillCurator:
                 return meta
         return None
 
-    def _create_reference_rewrite_proposal(self, skill_name: str, *, absorbed_into: str | None, actor: str) -> str | None:
+    def _create_reference_rewrite_proposal(
+        self, skill_name: str, *, absorbed_into: str | None, actor: str
+    ) -> str | None:
         from core.skills.reference_rewriter import generate_reference_rewrite_proposal
 
         proposal = generate_reference_rewrite_proposal(

--- a/core/skills/index.py
+++ b/core/skills/index.py
@@ -270,9 +270,7 @@ class SkillIndex:
             )
 
         matches = [
-            meta
-            for meta in entries
-            if meta.name == value or (meta.path is not None and meta.path.parent.name == value)
+            meta for meta in entries if meta.name == value or (meta.path is not None and meta.path.parent.name == value)
         ]
         if len(matches) > 1:
             logger.warning(

--- a/core/skills/migration/_common.py
+++ b/core/skills/migration/_common.py
@@ -15,7 +15,9 @@ from typing import Any
 from core.time_utils import now_iso
 
 _SECRET_PATTERNS = [
-    re.compile(r"(?i)['\"]?\b(api[_-]?key|token|secret|password)\b['\"]?\s*[:=]\s*['\"]?([A-Za-z0-9._~+\-/=]{8,})['\"]?"),
+    re.compile(
+        r"(?i)['\"]?\b(api[_-]?key|token|secret|password)\b['\"]?\s*[:=]\s*['\"]?([A-Za-z0-9._~+\-/=]{8,})['\"]?"
+    ),
     re.compile(r"\b(sk-[A-Za-z0-9]{8,})\b"),
 ]
 
@@ -70,7 +72,9 @@ def load_import_lock(path: Path) -> set[str]:
     return fingerprints
 
 
-def append_import_lock(path: Path, *, fingerprint: str, source_system: str, action: str, target_path: str, batch_id: str) -> None:
+def append_import_lock(
+    path: Path, *, fingerprint: str, source_system: str, action: str, target_path: str, batch_id: str
+) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     entry = {
         "ts": now_iso(),

--- a/core/skills/migration/hermes.py
+++ b/core/skills/migration/hermes.py
@@ -108,7 +108,9 @@ def _migrate_skills(
         fp = source_fingerprint("hermes_skill", skill_dir, target_path)
         if fp in seen and not options.replace:
             report.add_item(
-                MigrationItem("hermes_skill", str(skill_dir), target_path, "skill_import", "skipped", fp, "already imported")
+                MigrationItem(
+                    "hermes_skill", str(skill_dir), target_path, "skill_import", "skipped", fp, "already imported"
+                )
             )
             continue
 
@@ -185,7 +187,9 @@ def _migrate_usage(
         report.add_warning(f"usage_missing_from_source:{len(missing)} skills")
 
     for index, event in enumerate(events):
-        fp = source_fingerprint("hermes_usage", usage_path, target_path, extra=f"{index}:{event['skill_name']}:{event['event_type']}")
+        fp = source_fingerprint(
+            "hermes_usage", usage_path, target_path, extra=f"{index}:{event['skill_name']}:{event['event_type']}"
+        )
         if fp in seen and not options.replace:
             report.add_item(MigrationItem("hermes_usage", str(usage_path), target_path, "usage_import", "skipped", fp))
             continue
@@ -235,7 +239,9 @@ def _migrate_hub_lock(
         skill_name = str(raw.get("skill_name") or raw.get("name") or raw.get("id") or "unknown")
         fp = source_fingerprint("hermes_hub_lock", lock_path, target_path, extra=f"{index}:{skill_name}")
         if fp in seen and not options.replace:
-            report.add_item(MigrationItem("hermes_hub_lock", str(lock_path), target_path, "hub_lock_import", "skipped", fp))
+            report.add_item(
+                MigrationItem("hermes_hub_lock", str(lock_path), target_path, "hub_lock_import", "skipped", fp)
+            )
             continue
         entry = {
             "ts": raw.get("ts") or raw.get("created_at") or now_iso(),
@@ -490,7 +496,9 @@ def _hermes_skill_names(source: Path) -> set[str]:
     skills_dir = source / "skills"
     if not skills_dir.is_dir():
         return set()
-    return {p.name for p in skills_dir.iterdir() if p.is_dir() and not p.name.startswith(".") and (p / "SKILL.md").is_file()}
+    return {
+        p.name for p in skills_dir.iterdir() if p.is_dir() and not p.name.startswith(".") and (p / "SKILL.md").is_file()
+    }
 
 
 def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:

--- a/core/skills/migration/hermes_format.py
+++ b/core/skills/migration/hermes_format.py
@@ -131,7 +131,9 @@ def _counter_usage_event(
     import_time: str,
     index: int,
 ) -> dict[str, Any]:
-    ts = str(record.get(f"{event_type.value}_at") or record.get("last_used_at") or record.get("created_at") or import_time)
+    ts = str(
+        record.get(f"{event_type.value}_at") or record.get("last_used_at") or record.get("created_at") or import_time
+    )
     notes = "source_usage_completeness:sparse"
     if ts == import_time:
         notes = _join_notes(notes, "imported_without_original_timestamp")

--- a/core/skills/migration/openclaw.py
+++ b/core/skills/migration/openclaw.py
@@ -166,7 +166,9 @@ def _propose_tasks(
         body += provenance_header("openclaw", path, report.batch_id)
         body += redact_credentials(path.read_text(encoding="utf-8")) + "\n\n"
     source_for_fingerprint = existing[0]
-    _write_item(source_for_fingerprint, target, body, "taskboard_import_proposal", options, report, import_lock_path, seen)
+    _write_item(
+        source_for_fingerprint, target, body, "taskboard_import_proposal", options, report, import_lock_path, seen
+    )
 
 
 def _write_item(

--- a/core/skills/promotion.py
+++ b/core/skills/promotion.py
@@ -209,10 +209,7 @@ class ProcedureToSkillConverter:
             raise FileExistsError(f"Quarantine skill already exists: {quarantine_skill_dir}")
         candidate = self.candidate_from_path(source_path)
         if enforce_policy and candidate is not None and not candidate.eligible:
-            raise ValueError(
-                "Procedure is not eligible for skill promotion: "
-                + ", ".join(candidate.reasons)
-            )
+            raise ValueError("Procedure is not eligible for skill promotion: " + ", ".join(candidate.reasons))
 
         meta = self._build_skill_metadata(
             skill_name=final_skill_name,
@@ -309,13 +306,9 @@ class ProcedureToSkillConverter:
         if not approval_callback_id:
             raise SkillPromotionApprovalRequiredError("approval_callback_id is required")
         if not stored_callback_id:
-            raise SkillPromotionApprovalRequiredError(
-                "Quarantine skill has no registered approval_callback_id"
-            )
+            raise SkillPromotionApprovalRequiredError("Quarantine skill has no registered approval_callback_id")
         if stored_callback_id != approval_callback_id:
-            raise SkillPromotionApprovalMismatchError(
-                "approval_callback_id does not match quarantine skill metadata"
-            )
+            raise SkillPromotionApprovalMismatchError("approval_callback_id does not match quarantine skill metadata")
         approval = verify_skill_promotion_approval(
             approval_callback_id,
             owner_anima=self._owner_anima,
@@ -417,7 +410,9 @@ class ProcedureToSkillConverter:
             or procedure_metadata.get("negative_phrases")
             or procedure_metadata.get("do_not_use_when")
         )
-        domains = as_list(overrides.get("domains") or procedure_metadata.get("domains") or procedure_metadata.get("tags"))
+        domains = as_list(
+            overrides.get("domains") or procedure_metadata.get("domains") or procedure_metadata.get("tags")
+        )
         if not domains:
             domains = ["general"]
         tags = as_list(overrides.get("tags") or procedure_metadata.get("tags"))

--- a/core/skills/promotion_approval.py
+++ b/core/skills/promotion_approval.py
@@ -70,20 +70,14 @@ def verify_skill_promotion_approval(
 
     resolved = run_coroutine_sync(get_interaction_router().lookup_resolved(callback_id))
     if resolved is None:
-        raise SkillPromotionApprovalRequiredError(
-            "Human approval has not been resolved for this skill promotion"
-        )
+        raise SkillPromotionApprovalRequiredError("Human approval has not been resolved for this skill promotion")
 
     req, approval_result = resolved
     expected_name = str(req.metadata.get("skill_name") or "")
     if req.category != "skill_promotion" or req.anima_name != owner_anima or expected_name != skill_name:
-        raise SkillPromotionApprovalMismatchError(
-            "approval_callback_id does not match this skill promotion"
-        )
+        raise SkillPromotionApprovalMismatchError("approval_callback_id does not match this skill promotion")
     if approval_result.decision.lower() not in {"approve", "approved", "yes"}:
-        raise SkillPromotionApprovalRejectedError(
-            f"Skill promotion was not approved: {approval_result.decision}"
-        )
+        raise SkillPromotionApprovalRejectedError(f"Skill promotion was not approved: {approval_result.decision}")
     return VerifiedSkillPromotionApproval(
         actor=approval_result.actor,
         source=approval_result.source,

--- a/core/skills/reference_rewriter.py
+++ b/core/skills/reference_rewriter.py
@@ -110,9 +110,7 @@ def _candidate_files(anima_dir: Path) -> list[Path]:
     goals_dir = anima_dir / "goals"
     if goals_dir.is_dir():
         candidates.extend(
-            path
-            for path in goals_dir.rglob("*")
-            if path.suffix.lower() in {".md", ".json", ".jsonl", ".yaml", ".yml"}
+            path for path in goals_dir.rglob("*") if path.suffix.lower() in {".md", ".json", ".jsonl", ".yaml", ".yml"}
         )
     state_dir = anima_dir / "state"
     candidates.extend(

--- a/core/skills/router.py
+++ b/core/skills/router.py
@@ -119,9 +119,7 @@ class SkillRouter:
             return []
 
         records = [
-            _SkillRecord.from_metadata(meta, include_body=self.include_body)
-            for meta in skills
-            if _router_visible(meta)
+            _SkillRecord.from_metadata(meta, include_body=self.include_body) for meta in skills if _router_visible(meta)
         ]
         if not records:
             return []


### PR DESCRIPTION
## Summary
- Apply `ruff format` to the 13 files causing the main CI lint step to fail.
- Keep the change limited to formatting/import-order lint targets; no behavior changes intended.

## Verification
- `ruff check core/ cli/ server/` — PASS (`All checks passed!`)
- `ruff format --check core/ cli/ server/` — PASS (`451 files already formatted`)
- `python -m pytest tests/unit/test_hermes_migration.py tests/unit/test_openclaw_migration.py tests/unit/test_skill_curator.py tests/unit/test_skill_promotion.py tests/unit/test_skill_reference_rewriter.py tests/unit/test_skill_router.py tests/unit/test_skills_index.py tests/unit/test_goal_manager.py tests/unit/core/test_anima_lifecycle.py` — PASS (`81 passed`)

## Notes
- No GitHub Actions rerun/merge/admin bypass performed.