### PR TITLE
Widen cron health no-execution window to 24h

### DIFF
--- a/core/i18n/strings/config.py
+++ b/core/i18n/strings/config.py
@@ -117,12 +117,14 @@ STRINGS: dict[str, dict[str, str]] = {
     "scheduler.cron_health_no_execution": {
         "ja": (
             "{job_count}件のcronジョブが登録されていますが、"
-            "直近{hours}時間でcron実行が0件です。"
-            "cron.mdとスケジュール設定を確認してください。"
+            "直近{hours}時間にcron実行ログがありません。"
+            "低頻度（例: 日次/週次）のcronであれば正常な場合があります。"
+            "想定より頻度が高いはずの場合は、cron.mdとスケジュール設定を確認してください。"
         ),
         "en": (
-            "{job_count} cron job(s) registered but 0 executions in the last "
-            "{hours} hours. Please check cron.md and schedule settings."
+            "{job_count} cron job(s) registered but no execution logs in the last "
+            "{hours} hours. This can be normal for low-frequency crons (e.g., daily/weekly). "
+            "If the expected frequency is higher, please check cron.md and schedule settings."
         ),
     },
     "anima.greeting_error": {

--- a/core/supervisor/scheduler_manager.py
+++ b/core/supervisor/scheduler_manager.py
@@ -31,7 +31,8 @@ from core.time_utils import get_app_timezone, now_local
 _INDENTED_SCHEDULE_RE = re.compile(r"^\s+schedule:", re.MULTILINE)
 # Cron health check:
 # - interval: how often the health job runs (kept short for timely detection)
-# - window: lookback window for "no executions" detection (widened to avoid false positives for low-frequency crons)
+# - window: lookback window for "no executions" detection
+#   (widened to avoid false positives for low-frequency crons)
 _HEALTH_CHECK_INTERVAL_HOURS = 3
 _HEALTH_CHECK_WINDOW_HOURS = 24
 
@@ -462,9 +463,9 @@ class SchedulerManager:
                 return
 
             # Only treat a missing execution as unhealthy when at least one
-            # cron was actually expected to fire inside the health window.
+            # cron was actually expected to fire inside the no-execution window.
             now = now_local()
-            window_start = now - timedelta(hours=_HEALTH_CHECK_HOURS)
+            window_start = now - timedelta(hours=_HEALTH_CHECK_WINDOW_HOURS)
             if not self._any_cron_expected_in_window(cron_jobs, window_start, now):
                 return
 

--- a/core/supervisor/scheduler_manager.py
+++ b/core/supervisor/scheduler_manager.py
@@ -29,7 +29,11 @@ from core.schemas import CronTask
 from core.time_utils import get_app_timezone, now_local
 
 _INDENTED_SCHEDULE_RE = re.compile(r"^\s+schedule:", re.MULTILINE)
-_HEALTH_CHECK_HOURS = 3
+# Cron health check:
+# - interval: how often the health job runs (kept short for timely detection)
+# - window: lookback window for "no executions" detection (widened to avoid false positives for low-frequency crons)
+_HEALTH_CHECK_INTERVAL_HOURS = 3
+_HEALTH_CHECK_WINDOW_HOURS = 24
 
 if TYPE_CHECKING:
     from core.anima import DigitalAnima
@@ -403,7 +407,7 @@ class SchedulerManager:
 
         self.scheduler.add_job(
             self._cron_health_tick,
-            CronTrigger(minute=0, hour=f"*/{_HEALTH_CHECK_HOURS}"),
+            CronTrigger(minute=0, hour=f"*/{_HEALTH_CHECK_INTERVAL_HOURS}"),
             id=f"{self._anima_name}_cron_health",
             name=f"{self._anima_name} cron health check",
             replace_existing=True,
@@ -465,7 +469,7 @@ class SchedulerManager:
                 return
 
             entries = self._anima._activity._load_entries(
-                hours=_HEALTH_CHECK_HOURS,
+                hours=_HEALTH_CHECK_WINDOW_HOURS,
                 types=["cron_executed"],
             )
 
@@ -474,7 +478,7 @@ class SchedulerManager:
                     t(
                         "scheduler.cron_health_no_execution",
                         job_count=len(cron_jobs),
-                        hours=_HEALTH_CHECK_HOURS,
+                        hours=_HEALTH_CHECK_WINDOW_HOURS,
                     )
                 )
         except Exception:

--- a/tests/unit/core/supervisor/test_cron_health.py
+++ b/tests/unit/core/supervisor/test_cron_health.py
@@ -171,6 +171,35 @@ class TestCronHealthTick:
         assert len(files) == 1
         content = files[0].read_text(encoding="utf-8")
         assert "1" in content  # 1 cron job (health job excluded)
+        scheduler_mgr._anima._activity._load_entries.assert_called_once_with(
+            hours=24,
+            types=["cron_executed"],
+        )
+
+    @pytest.mark.asyncio
+    async def test_expected_fire_in_24h_window_triggers_notification(
+        self, scheduler_mgr: SchedulerManager, tmp_path: Path
+    ) -> None:
+        # The health job still runs every 3h, but missing-execution detection
+        # now looks back across 24h to avoid false positives for daily crons.
+        in_widened_window = now_local() - timedelta(hours=23)
+        mock_scheduler = MagicMock()
+        job_cron = _job_with_next_fire("test_anima_cron_0", in_widened_window)
+        mock_scheduler.get_jobs.return_value = [job_cron]
+        scheduler_mgr.scheduler = mock_scheduler
+
+        scheduler_mgr._anima._activity._load_entries = MagicMock(return_value=[])
+
+        await scheduler_mgr._cron_health_tick()
+
+        files = _notif_files(tmp_path)
+        assert len(files) == 1
+        content = files[0].read_text(encoding="utf-8")
+        assert "直近24時間" in content
+        scheduler_mgr._anima._activity._load_entries.assert_called_once_with(
+            hours=24,
+            types=["cron_executed"],
+        )
 
     @pytest.mark.asyncio
     async def test_long_period_cron_outside_window_no_notification(
@@ -252,26 +281,32 @@ class TestAnyCronExpectedInWindow:
 
     def test_fire_inside_window(self) -> None:
         now = now_local()
-        ws = now - timedelta(hours=3)
+        ws = now - timedelta(hours=24)
         job = _job_with_next_fire("c0", now - timedelta(hours=1))
+        assert SchedulerManager._any_cron_expected_in_window([job], ws, now) is True
+
+    def test_fire_inside_widened_window(self) -> None:
+        now = now_local()
+        ws = now - timedelta(hours=24)
+        job = _job_with_next_fire("c0", now - timedelta(hours=23))
         assert SchedulerManager._any_cron_expected_in_window([job], ws, now) is True
 
     def test_fire_outside_window(self) -> None:
         now = now_local()
-        ws = now - timedelta(hours=3)
+        ws = now - timedelta(hours=24)
         job = _job_with_next_fire("c0", now + timedelta(days=2))
         assert SchedulerManager._any_cron_expected_in_window([job], ws, now) is False
 
     def test_mixed_jobs_any_match(self) -> None:
         now = now_local()
-        ws = now - timedelta(hours=3)
+        ws = now - timedelta(hours=24)
         far = _job_with_next_fire("c0", now + timedelta(days=2))
         near = _job_with_next_fire("c1", now - timedelta(minutes=30))
         assert SchedulerManager._any_cron_expected_in_window([far, near], ws, now) is True
 
     def test_trigger_error_is_conservative(self) -> None:
         now = now_local()
-        ws = now - timedelta(hours=3)
+        ws = now - timedelta(hours=24)
         job = MagicMock()
         job.id = "c0"
         job.trigger.get_next_fire_time.side_effect = RuntimeError("boom")


### PR DESCRIPTION
## Summary
- split cron health check interval and no-execution window
- keep the health tick interval at 3h while widening the no-execution log window to 24h
- soften the warning wording for low-frequency daily/weekly cron jobs

## Scope
- Short-term B+C only
- Does not add next_run_time-based detection

## Verification
- python -m py_compile core/supervisor/scheduler_manager.py core/i18n/strings/config.py
