### PR TITLE
style: apply ruff format for main CI

### DIFF
--- a/core/memory/action_gate.py
+++ b/core/memory/action_gate.py
@@ -16,9 +16,7 @@ from typing import Any
 
 logger = logging.getLogger("animaworks.action_memory_gate")
 
-_REQUIRED_READ_RE = re.compile(
-    r"""read_memory_file\s*\(\s*path\s*=\s*(?P<quote>['"])(?P<path>.+?)(?P=quote)\s*\)"""
-)
+_REQUIRED_READ_RE = re.compile(r"""read_memory_file\s*\(\s*path\s*=\s*(?P<quote>['"])(?P<path>.+?)(?P=quote)\s*\)""")
 _SAFE_SESSION_RE = re.compile(r"[^A-Za-z0-9_.-]+")
 
 _HANDLER_ACTION_TOOLS: frozenset[str] = frozenset(

--- a/core/memory/rag/singleton.py
+++ b/core/memory/rag/singleton.py
@@ -79,9 +79,7 @@ def get_vector_store(anima_name: str | None = None) -> VectorStore | None:
 
     if not direct_chroma_allowed():
         if not _direct_disabled_warned:
-            logger.warning(
-                "Vector store unavailable: direct ChromaDB access is disabled outside the vector worker"
-            )
+            logger.warning("Vector store unavailable: direct ChromaDB access is disabled outside the vector worker")
             _direct_disabled_warned = True
         return None
 

--- a/core/skills/autolearn.py
+++ b/core/skills/autolearn.py
@@ -105,7 +105,9 @@ class AutonomousSkillLearner:
         )
         return [meta for meta in index.search("", include_blocked=True) if not meta.is_procedure]
 
-    def _duplicate_for(self, skill_name: str, metadata: dict[str, Any], existing: list[SkillMetadata]) -> SkillMetadata | None:
+    def _duplicate_for(
+        self, skill_name: str, metadata: dict[str, Any], existing: list[SkillMetadata]
+    ) -> SkillMetadata | None:
         description = str(metadata.get("description") or metadata.get("title") or "").strip()
         for meta in existing:
             if meta.name == skill_name:

--- a/core/skills/curator.py
+++ b/core/skills/curator.py
@@ -247,7 +247,9 @@ class SkillCurator:
             is_probation = str(meta.promotion_status or "").lower() == "probation"
             if is_probation and total >= 3 and failure / total >= 0.7:
                 suggestions.append(
-                    LifecycleSuggestion(meta.name, SkillLifecycleState.review, "probation_failure_rate_high", failure / total)
+                    LifecycleSuggestion(
+                        meta.name, SkillLifecycleState.review, "probation_failure_rate_high", failure / total
+                    )
                 )
                 continue
             if not is_probation and total and failure / total >= 0.7:

--- a/core/skills/probation_promotion.py
+++ b/core/skills/probation_promotion.py
@@ -75,7 +75,11 @@ def create_probation_skill_for_converter(
     meta["risk"]["requires_human_approval"] = runtime_approval_required(meta["risk"], scan_result)
     converter._write_skill_file(skill_md, meta, body)
 
-    if scan_result.verdict != SkillScanVerdict.safe or scan_result.size_violations or meta["risk"]["requires_human_approval"]:
+    if (
+        scan_result.verdict != SkillScanVerdict.safe
+        or scan_result.size_violations
+        or meta["risk"]["requires_human_approval"]
+    ):
         shutil.rmtree(active_skill_dir, ignore_errors=True)
         converter._append_audit(
             {

--- a/core/skills/promotion.py
+++ b/core/skills/promotion.py
@@ -440,7 +440,9 @@ class ProcedureToSkillConverter:
         tags = as_list(overrides.get("tags") or procedure_metadata.get("tags"))
         routing = procedure_metadata.get("routing") if isinstance(procedure_metadata.get("routing"), dict) else {}
         routing_risk = routing.get("risk") if isinstance(routing.get("risk"), dict) else {}
-        risk = normalise_risk({**routing_risk, **(procedure_metadata.get("risk") or {}), **(overrides.get("risk") or {})})
+        risk = normalise_risk(
+            {**routing_risk, **(procedure_metadata.get("risk") or {}), **(overrides.get("risk") or {})}
+        )
 
         return {
             "name": skill_name,

--- a/core/skills/router.py
+++ b/core/skills/router.py
@@ -490,4 +490,3 @@ def _pointer_path(meta: SkillMetadata) -> str:
     if path.name == "SKILL.md":
         return f"skills/{path.parent.name}/SKILL.md"
     return str(path)
-

--- a/core/skills/trust.py
+++ b/core/skills/trust.py
@@ -76,8 +76,13 @@ def promote_skill_to_trusted(
     skill_path = meta.path
     text = skill_path.read_text(encoding="utf-8")
     frontmatter, body = parse_frontmatter(text)
-    scan = (scanner or SkillScanner()).scan_skill(skill_path.parent if skill_path.name == "SKILL.md" else skill_path, source="anima")
-    if scan.verdict in {SkillScanVerdict.dangerous, SkillScanVerdict.warn, SkillScanVerdict.caution} or scan.size_violations:
+    scan = (scanner or SkillScanner()).scan_skill(
+        skill_path.parent if skill_path.name == "SKILL.md" else skill_path, source="anima"
+    )
+    if (
+        scan.verdict in {SkillScanVerdict.dangerous, SkillScanVerdict.warn, SkillScanVerdict.caution}
+        or scan.size_violations
+    ):
         raise ValueError(f"Cannot promote unsafe skill: {scan.verdict.value}")
 
     trusted_at = now_iso()
@@ -103,7 +108,9 @@ def promote_skill_to_trusted(
     )
     rendered = yaml.dump(frontmatter, allow_unicode=True, default_flow_style=False, sort_keys=False).strip()
     atomic_write_text(skill_path, f"---\n{rendered}\n---\n\n{body.rstrip()}\n")
-    SkillUsageTracker(anima_dir).record(meta.name, SkillUsageEventType.patch, is_common=meta.is_common, notes="trusted_promotion")
+    SkillUsageTracker(anima_dir).record(
+        meta.name, SkillUsageEventType.patch, is_common=meta.is_common, notes="trusted_promotion"
+    )
     return TrustedPromotionResult(
         skill_name=meta.name,
         path=_pointer_for_path(anima_dir, skill_path),

--- a/core/tooling/schemas/builder.py
+++ b/core/tooling/schemas/builder.py
@@ -245,9 +245,7 @@ def build_unified_tool_list(
 
     if include_create_skill:
         tools.extend(
-            t
-            for t in _skill_authoring_schemas_for_trigger(trigger)
-            if t["name"] in {"create_skill", "trust_skill"}
+            t for t in _skill_authoring_schemas_for_trigger(trigger) if t["name"] in {"create_skill", "trust_skill"}
         )
         tools.extend(_curator_skill_schemas())
 


### PR DESCRIPTION
## Summary
- Apply `ruff format` to fix the current `main` CI lint failure.
- Base: `34d18dafc2de244958e1aeb13fa9e8ec7f191285`
- Failing CI run: `26202279682` (`unit-tests` job, `Lint` step)

## Cause
`ruff check core/ cli/ server/` passed, but `ruff format --check core/ cli/ server/` failed on `main` because 9 files required formatting.

## Changed files
- `core/memory/action_gate.py`
- `core/memory/rag/singleton.py`
- `core/skills/autolearn.py`
- `core/skills/curator.py`
- `core/skills/probation_promotion.py`
- `core/skills/promotion.py`
- `core/skills/router.py`
- `core/skills/trust.py`
- `core/tooling/schemas/builder.py`

## Verification
- `ruff format core/ cli/ server/` → `9 files reformatted, 461 files left unchanged`
- `git diff --check` → exit 0
- `ruff format --check core/ cli/ server/` → `470 files already formatted`
- `ruff check core/ cli/ server/` → `All checks passed!`

## Safety
- No direct push to `main`.
- No force push.
- No merge.
- No GitHub Actions rerun/cancel/dispatch.
- No logic change; formatting-only diff.
