### PR TITLE
fix: fall back to CPU when CUDA probing fails

### DIFF
--- a/core/memory/rag/singleton.py
+++ b/core/memory/rag/singleton.py
@@ -38,6 +38,7 @@ _embedding_model: SentenceTransformer | None = None
 _embedding_model_name: str | None = None
 _init_failed: bool = False
 _direct_disabled_warned: bool = False
+_cuda_unavailable_warned: bool = False
 
 
 def _get_http_store(base_url: str, anima_name: str | None) -> HttpVectorStore:
@@ -137,6 +138,28 @@ def _get_configured_model_name() -> str:
         return "intfloat/multilingual-e5-small"
 
 
+def _cuda_available_safely() -> bool:
+    """Return whether CUDA can be initialized without raising.
+
+    Some hosts expose CUDA libraries while the installed driver/GPU pair is
+    incompatible.  In that state PyTorch can raise ``cudaGetDeviceCount``
+    during lazy CUDA initialization.  Treat that as "CUDA unavailable" so RAG
+    embeddings continue on CPU instead of surfacing a 500 from the internal
+    embedding endpoint.
+    """
+    global _cuda_unavailable_warned
+
+    try:
+        import torch
+
+        return bool(torch.cuda.is_available() and torch.cuda.device_count() > 0)
+    except Exception as exc:
+        if not _cuda_unavailable_warned:
+            logger.warning("CUDA unavailable for embedding model; using CPU: %s", exc)
+            _cuda_unavailable_warned = True
+        return False
+
+
 def get_embedding_model(model_name: str | None = None) -> SentenceTransformer:
     """Return process-level singleton SentenceTransformer model.
 
@@ -181,7 +204,7 @@ def get_embedding_model(model_name: str | None = None) -> SentenceTransformer:
             _use_gpu = load_config().rag.use_gpu
         except Exception:
             _use_gpu = False
-        device = "cuda" if _use_gpu else "cpu"
+        device = "cuda" if _use_gpu and _cuda_available_safely() else "cpu"
         logger.info("Loading embedding model (singleton): %s on %s", resolved_name, device)
         try:
             _embedding_model = SentenceTransformer(resolved_name, cache_folder=str(cache_dir), device=device)
@@ -323,7 +346,7 @@ def get_embedding_model_name() -> str:
 
 def _reset_for_testing():
     """Reset singletons for test isolation."""
-    global _direct_disabled_warned, _embedding_model, _embedding_model_name, _init_failed
+    global _cuda_unavailable_warned, _direct_disabled_warned, _embedding_model, _embedding_model_name, _init_failed
     with _lock:
         _vector_stores.clear()
         _http_stores.clear()
@@ -331,3 +354,4 @@ def _reset_for_testing():
         _embedding_model_name = None
         _init_failed = False
         _direct_disabled_warned = False
+        _cuda_unavailable_warned = False

--- a/tests/unit/test_rag_singleton_cuda_fallback.py
+++ b/tests/unit/test_rag_singleton_cuda_fallback.py
@@ -1,0 +1,91 @@
+"""CUDA fallback tests for core/memory/rag/singleton.py."""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons(monkeypatch):
+    monkeypatch.delenv("ANIMAWORKS_VECTOR_URL", raising=False)
+    monkeypatch.delenv("ANIMAWORKS_EMBED_URL", raising=False)
+
+    from core.memory.rag.singleton import _reset_for_testing
+
+    _reset_for_testing()
+    yield
+    _reset_for_testing()
+
+
+@pytest.fixture
+def mock_sentence_transformers():
+    mock_module = types.ModuleType("sentence_transformers")
+    mock_class = MagicMock()
+    mock_module.SentenceTransformer = mock_class
+    sys.modules["sentence_transformers"] = mock_module
+    yield mock_class
+    sys.modules.pop("sentence_transformers", None)
+
+
+def _install_mock_torch(monkeypatch, *, available: bool = True, device_count=1) -> None:
+    """Install a minimal torch mock for CUDA availability checks."""
+    mock_torch = types.ModuleType("torch")
+    mock_torch.cuda = MagicMock()
+    mock_torch.cuda.is_available.return_value = available
+    if isinstance(device_count, Exception):
+        mock_torch.cuda.device_count.side_effect = device_count
+    else:
+        mock_torch.cuda.device_count.return_value = device_count
+    monkeypatch.setitem(sys.modules, "torch", mock_torch)
+
+
+def test_cuda_initialization_failure_falls_back_to_cpu(tmp_path, monkeypatch, mock_sentence_transformers):
+    """CUDA availability errors should not prevent local embedding use."""
+    monkeypatch.setenv("ANIMAWORKS_DATA_DIR", str(tmp_path))
+    _install_mock_torch(monkeypatch)
+
+    config = MagicMock()
+    config.rag.use_gpu = True
+    mock_model = MagicMock()
+    mock_sentence_transformers.side_effect = [
+        RuntimeError("cudaGetDeviceCount Error 804"),
+        mock_model,
+    ]
+
+    with patch("core.config.load_config", return_value=config):
+        from core.memory.rag.singleton import get_embedding_model
+
+        result = get_embedding_model("model-x")
+
+    assert result is mock_model
+    assert mock_sentence_transformers.call_args_list == [
+        call("model-x", cache_folder=str(tmp_path / "models"), device="cuda"),
+        call("model-x", cache_folder=str(tmp_path / "models"), device="cpu"),
+    ]
+
+
+def test_cuda_device_count_failure_uses_cpu_without_cuda_constructor(tmp_path, monkeypatch, mock_sentence_transformers):
+    """Broken CUDA probing should route embeddings to CPU before model load."""
+    monkeypatch.setenv("ANIMAWORKS_DATA_DIR", str(tmp_path))
+    _install_mock_torch(monkeypatch, device_count=RuntimeError("cudaGetDeviceCount Error 804"))
+
+    config = MagicMock()
+    config.rag.use_gpu = True
+    mock_model = MagicMock()
+    mock_sentence_transformers.return_value = mock_model
+
+    with patch("core.config.load_config", return_value=config):
+        from core.memory.rag.singleton import get_embedding_model
+
+        result = get_embedding_model("model-x")
+
+    assert result is mock_model
+    mock_sentence_transformers.assert_called_once_with(
+        "model-x",
+        cache_folder=str(tmp_path / "models"),
+        device="cpu",
+    )


### PR DESCRIPTION
## Summary
- guard embedding model CUDA selection with a safe torch CUDA availability probe
- fall back to CPU when `cudaGetDeviceCount`/device probing raises before model construction
- add unit coverage for broken CUDA probing and existing GPU-constructor fallback

## Verification
- `pytest -q tests/unit/test_rag_singleton_cuda_fallback.py`
- `ruff check core/memory/rag/singleton.py tests/unit/test_rag_singleton_cuda_fallback.py`
- `ruff format --check core/memory/rag/singleton.py tests/unit/test_rag_singleton_cuda_fallback.py`