### PR TITLE
fix: register flaky pytest marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ markers = [
     "ollama: tests requiring Ollama server access",
     "locomo: LoCoMo benchmark smoke (requires OPENAI_API_BASE; run with -m locomo)",
     "timeout: set per-test timeout in seconds (requires pytest-timeout)",
+    "flaky: marks tests that may be retried by pytest-rerunfailures",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary
- Register the `flaky` pytest marker used by `tests/e2e/test_mode_a2.py`.
- Fixes strict-marker collection failure in the main CI e2e job.

## Impact
- Scope: pytest configuration only (`pyproject.toml`).
- Behavior change: no runtime code changes; tests using `@pytest.mark.flaky` can now be collected under `--strict-markers`.
- Risk: Low, marker registration is additive and matches existing pytest marker configuration style.

## Test plan
- PASS: `pytest tests/e2e/test_mode_a2.py -q -m "not live and not azure and not ollama"` — 8 passed, 8 deselected.
- PASS (collection marker check): the targeted command above collected `tests/e2e/test_mode_a2.py` without the previous `'flaky' not found in markers configuration option` error.
- LOCAL ENV LIMITATION: `pytest tests/e2e/test_mode_a2.py -q --timeout=60 -m "not live and not azure and not ollama"` could not run locally because this checkout environment does not have the `pytest-timeout` plugin available (`unrecognized arguments: --timeout=60`). CI includes that plugin per project dependencies.
- PARTIAL/UNRELATED FAIL: `pytest tests/e2e/ -x -q -m "not live and not azure and not ollama"` progressed past collection and ran 397 tests before stopping at existing `tests/e2e/test_codex_mode_e2e.py::TestRunCycle::test_run_cycle_mode_c_chat` (`StopAsyncIteration` mock exhaustion). This is unrelated to the flaky marker registration.

Issue: none — direct CI failure fix for main run 27518148577.
