### PR TITLE
fix: format schedule parser for main CI

### DIFF
--- a/core/schedule_parser.py
+++ b/core/schedule_parser.py
@@ -39,9 +39,7 @@ _HEARTBEAT_ACTIVE_HOUR_HEADINGS = {
     "활동시간",
 }
 
-_HEARTBEAT_TIME_RANGE_RE = re.compile(
-    r"(?<![\d#])(\d{1,2}):\d{0,2}\s*-\s*(\d{1,2})(?::\d{0,2})?(?!\d)"
-)
+_HEARTBEAT_TIME_RANGE_RE = re.compile(r"(?<![\d#])(\d{1,2}):\d{0,2}\s*-\s*(\d{1,2})(?::\d{0,2})?(?!\d)")
 _MARKDOWN_HEADING_RE = re.compile(r"^#{1,6}\s+\S")
 
 


### PR DESCRIPTION
## Summary
- Fixes the main CI ruff format failure by applying Ruff's formatting to `core/schedule_parser.py`.
- Scope is limited to formatting-only changes in that file.
- Issue: none (CI repair for push workflow run `27540217757`).

## Impact
- Affected file: `core/schedule_parser.py`
- Runtime behavior change: none expected; formatting only.
- Risk: Low — generated by `ruff format` and limited to a single expression layout change.

## Test plan
- `ruff format --check core/schedule_parser.py` → passed (`1 file already formatted`)
- `ruff check core/schedule_parser.py` → passed (`All checks passed!`)
- `ruff format --check core/ cli/ server/` → passed (`507 files already formatted`)
- `ruff check core/ cli/ server/` → passed (`All checks passed!`)

## Not run
- Unit/e2e/Neo4j tests not run locally; original failure was isolated to Ruff format in the CI lint step.
- GitHub Actions rerun/cancel/dispatch not performed.
