### PR TITLE
test: stub optional openai_codex in codex sdk tests

### DIFF
--- a/tests/e2e/test_codex_mode_e2e.py
+++ b/tests/e2e/test_codex_mode_e2e.py
@@ -9,9 +9,51 @@ Verifies the full AgentCore integration with CodexSDKExecutor using
 mocked Codex SDK.  No real Codex CLI or API key required.
 """
 
+import sys
+import types
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+
+def _install_fake_openai_codex() -> None:
+    """Provide the optional Codex SDK surface used by these E2E tests.
+
+    CI intentionally does not install the ``openai-codex`` extra.  These
+    tests patch CodexSDKExecutor._create_codex_client, but executor selection
+    still checks import availability before that patch is reached.
+    """
+    if sys.modules.get("openai_codex") is not None:
+        return
+
+    fake_openai_codex = types.ModuleType("openai_codex")
+    fake_openai_codex.AsyncCodex = MagicMock(name="AsyncCodex")
+    fake_openai_codex.CodexConfig = MagicMock(name="CodexConfig")
+    fake_openai_codex.ApprovalMode = SimpleNamespace(deny_all="deny_all")
+    fake_openai_codex.Sandbox = SimpleNamespace(full_access="full_access", workspace_write="workspace_write")
+
+    fake_generated = types.ModuleType("openai_codex.generated")
+    fake_v2_all = types.ModuleType("openai_codex.generated.v2_all")
+
+    class ReasoningSummary:
+        def __init__(self, root):
+            self.root = root
+
+    fake_v2_all.ReasoningSummary = ReasoningSummary
+    fake_v2_all.ReasoningSummaryValue = SimpleNamespace(
+        auto=SimpleNamespace(value="auto"),
+        concise=SimpleNamespace(value="concise"),
+        detailed=SimpleNamespace(value="detailed"),
+        none=SimpleNamespace(value="none"),
+    )
+
+    sys.modules["openai_codex"] = fake_openai_codex
+    sys.modules["openai_codex.generated"] = fake_generated
+    sys.modules["openai_codex.generated.v2_all"] = fake_v2_all
+
+
+_install_fake_openai_codex()
 
 
 def _mock_codex(start_thread):

--- a/tests/unit/test_codex_sdk_executor.py
+++ b/tests/unit/test_codex_sdk_executor.py
@@ -11,7 +11,9 @@ All tests use mocks — no Codex CLI binary or API key required.
 import asyncio
 import logging
 import os
+import sys
 import tomllib
+import types
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -43,6 +45,40 @@ from core.execution.codex_sdk import (
     clear_codex_thread_ids,
 )
 from core.prompt.context import ContextTracker
+
+
+def _install_fake_openai_codex() -> None:
+    """Provide the optional Codex SDK surface used by these unit tests."""
+    if sys.modules.get("openai_codex") is not None:
+        return
+
+    fake_openai_codex = types.ModuleType("openai_codex")
+    fake_openai_codex.AsyncCodex = MagicMock(name="AsyncCodex")
+    fake_openai_codex.CodexConfig = MagicMock(name="CodexConfig")
+    fake_openai_codex.ApprovalMode = SimpleNamespace(deny_all="deny_all")
+    fake_openai_codex.Sandbox = SimpleNamespace(full_access="full_access", workspace_write="workspace_write")
+
+    fake_generated = types.ModuleType("openai_codex.generated")
+    fake_v2_all = types.ModuleType("openai_codex.generated.v2_all")
+
+    class ReasoningSummary:
+        def __init__(self, root):
+            self.root = root
+
+    fake_v2_all.ReasoningSummary = ReasoningSummary
+    fake_v2_all.ReasoningSummaryValue = SimpleNamespace(
+        auto=SimpleNamespace(value="auto"),
+        concise=SimpleNamespace(value="concise"),
+        detailed=SimpleNamespace(value="detailed"),
+        none=SimpleNamespace(value="none"),
+    )
+
+    sys.modules["openai_codex"] = fake_openai_codex
+    sys.modules["openai_codex.generated"] = fake_generated
+    sys.modules["openai_codex.generated.v2_all"] = fake_v2_all
+
+
+_install_fake_openai_codex()
 
 # ── Fixtures ─────────────────────────────────────────────────
 
@@ -480,9 +516,7 @@ class TestExecutorInit:
         assert "summary" not in kwargs
         assert "sandbox" not in kwargs
 
-    def test_codex_turn_kwargs_invalid_reasoning_summary_falls_back_to_concise(
-        self, model_config, anima_dir, caplog
-    ):
+    def test_codex_turn_kwargs_invalid_reasoning_summary_falls_back_to_concise(self, model_config, anima_dir, caplog):
         caplog.set_level(logging.WARNING, logger="animaworks.execution.codex_sdk")
         model_config.extra_keys = {"codex_reasoning_summary": "verbose"}
         exc = CodexSDKExecutor(model_config=model_config, anima_dir=anima_dir)


### PR DESCRIPTION
## Summary
- keep `openai-codex` optional after the v0.9.1 dependency split
- add a lightweight fake `openai_codex` module surface for `test_codex_sdk_executor.py`
- preserve the runtime behavior: real Mode C still raises `ImportError` when the optional SDK is not installed

## Root cause
`release: v0.9.1` moved `openai-codex` out of default dependencies and removed the `codex` extra from `all-tools`. CI installs `.[test,all-tools]`, so `openai_codex` is no longer present in unit tests. `test_create_codex_client_passes_executable_override` patched `openai_codex.CodexConfig` directly, which requires importing the optional package and caused main CI to fail.

## Tests
- `UV_CACHE_DIR=/tmp/uv-cache-14d11180 uv run --extra test --extra all-tools pytest tests/unit/test_codex_sdk_executor.py::TestExecutorInit::test_create_codex_client_passes_executable_override tests/unit/test_codex_sdk_executor.py::TestExecutorInit::test_codex_turn_kwargs_requests_concise_reasoning_summary_by_default tests/unit/test_codex_sdk_executor.py::TestExecutorInit::test_codex_turn_kwargs_can_disable_reasoning_summary -q --tb=short`
- `UV_CACHE_DIR=/tmp/uv-cache-14d11180 uv run --extra test --extra all-tools ruff check tests/unit/test_codex_sdk_executor.py`
- `UV_CACHE_DIR=/tmp/uv-cache-14d11180 uv run --extra test --extra all-tools ruff format --check tests/unit/test_codex_sdk_executor.py`
- `UV_CACHE_DIR=/tmp/uv-cache-14d11180 uv run --extra test --extra all-tools pytest tests/unit/test_codex_sdk_executor.py -q --tb=short --timeout=30`

## Safety
No merge, approval, deployment, Actions rerun/cancel/dispatch, release operation, PyPI setting change, secret change, or force push performed.
