### PR TITLE
ci: PRの整形漏れをCI側で自動修正するautofixジョブ (#232)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,8 @@ jobs:
             echo "No fixes needed."
             exit 0
           fi
-          git config user.name "xuiltul"
-          git config user.email "xuiltul@users.noreply.github.com"
+          git config user.name "animaworks-dev-team"
+          git config user.email "animaworks-dev-team@users.noreply.github.com"
           git commit -am "style: ruff auto-fix by CI"
           git push
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # 同一リポジトリからのPRは、整形漏れをfailさせずCI側で自動修正してpushする (#232)。
+  # 修正コミットはPATでpushされるため新しいCI runがトリガーされ、必須チェックも新SHAで再評価される。
+  # 差分ゼロなら何もしない（＝自動修正コミットのrunで再修正は起きず、ループしない）。
+  autofix:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.AUTOFIX_TOKEN }}
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: pip install "ruff>=0.9"
+
+      - name: Auto-fix lint & format
+        run: |
+          ruff check --fix core/ cli/ server/ || true
+          ruff format core/ cli/ server/
+
+      - name: Push fixes if needed
+        run: |
+          if git diff --quiet; then
+            echo "No fixes needed."
+            exit 0
+          fi
+          git config user.name "xuiltul"
+          git config user.email "xuiltul@users.noreply.github.com"
+          git commit -am "style: ruff auto-fix by CI"
+          git push
+
   unit-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## 背景

ruff format漏れで毎回CIが落ち、気楽にPRできない問題（#232 のv0スコープ相当）。

## 変更内容

`ci.yml` に `autofix` ジョブを追加:

- 同一リポジトリからのPRのみ対象（フォークPRは従来通り `--check` でfail）
- headブランチをcheckoutし `ruff check --fix` + `ruff format` を実行
- 差分があれば `AUTOFIX_TOKEN`（PAT・登録済み）でコミット＆push
  - PATによるpushなので新コミットでCIが再トリガーされ、必須チェック `unit-tests` も新SHAで評価される
  - concurrencyグループにより旧runは自動キャンセル
- 差分ゼロなら何もしない → 自動修正コミットのrunでは再修正が発生せず、**ループしない**（actor判定不要なので animaworks-dev-team 名義のfleet PRでもそのまま動く）

## Issue #232 との関係

「修正PRを別途作る」案の代わりに、PRブランチへ直接整形コミットを積む最小構成。lint自動修正（safe fixのみ）も含む。mypy/pytestの自動修正は対象外（従来通りfail）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)