### PR TITLE
fix: guard the STOPPING-stuck health check against a live shutdown

### DIFF
--- a/core/supervisor/_mgr_health.py
+++ b/core/supervisor/_mgr_health.py
@@ -306,7 +306,7 @@ class HealthMixin:
 
         # Detect handles stuck in STOPPING state (e.g. after failed shutdown)
         if handle.state == ProcessState.STOPPING:
-            if not handle.stopping_since:
+            if self._shutdown or not handle.stopping_since:
                 return
             stopping_duration = (now_local() - ensure_aware(handle.stopping_since)).total_seconds()
             if stopping_duration > 30:

--- a/tests/unit/test_process_handle_stop.py
+++ b/tests/unit/test_process_handle_stop.py
@@ -472,3 +472,33 @@ class TestHealthCheckStoppingDetection:
 
         # State should remain STOPPING
         assert handle.state == ProcessState.STOPPING
+
+    @pytest.mark.asyncio
+    async def test_health_check_stuck_stopping_during_shutdown_leaves_state_alone(
+        self, supervisor: ProcessSupervisor, tmp_path: Path,
+    ):
+        """A STOPPING handle stuck >30s must not be marked FAILED once the
+        supervisor has started shutting down: every other writer of
+        handle.state for a failure already checks _shutdown first, and this
+        branch did not.
+        """
+        handle = ProcessHandle(
+            anima_name="stuck-anima",
+            socket_path=tmp_path / "stuck.sock",
+            animas_dir=tmp_path / "animas",
+            shared_dir=tmp_path / "shared",
+        )
+        handle.state = ProcessState.STOPPING
+        handle.stopping_since = now_jst() - timedelta(seconds=60)
+
+        supervisor.processes["stuck-anima"] = handle
+        supervisor._shutdown = True
+
+        with patch.object(
+            supervisor, "_handle_process_failure", new_callable=AsyncMock,
+        ) as mock_failure:
+            await supervisor._check_process_health("stuck-anima", handle)
+            await asyncio.sleep(0)
+
+        assert handle.state == ProcessState.STOPPING
+        mock_failure.assert_not_called()


### PR DESCRIPTION
`_check_process_health`'s STOPPING-stuck branch (`_mgr_health.py`) sets `handle.state = ProcessState.FAILED` and schedules a restart whenever a handle has sat in `STOPPING` for more than 30 seconds, with no check for `self._shutdown`. Every other writer of `handle.state` for a failure already guards on it: `_handle_process_failure`'s entrance guard and `_mark_process_error`'s early return (both added in #244) skip entirely once shutdown has started. This branch was the one left over, so a health check landing during the tail end of `shutdown_all()` can stamp `FAILED` on an anima that is simply still stopping.

Fix: fold `self._shutdown` into the same early-return check as `stopping_since`, matching the guard style already used by the other two writers.

Verified with a new regression test (`test_health_check_stuck_stopping_during_shutdown_leaves_state_alone`, `tests/unit/test_process_handle_stop.py`), run in a clean Docker container against unmodified `main`:
- Fails on `main` (`handle.state` becomes `FAILED`), passes on this branch (`handle.state` stays `STOPPING`).
- Full `tests/unit/test_process_handle_stop.py` (10/10) and the health/streaming e2e suites (`test_process_handle_sse_bugs_e2e.py`, `test_streaming_crash_recovery_e2e.py`, `test_ipc_health_recovery.py`, 9/9) pass.
- `ruff check` / `ruff format --check` on `core/ cli/ server/` clean.
- Not run: the `neo4j-integration-tests` CI job (needs a live Neo4j service, unrelated to this path) and `tests/unit/tools/test_aws_collector.py` (needs the optional `all-tools` extra, not installed). The rest of `tests/unit/` (14481 passed) has 25 pre-existing failures unrelated to this change: they need a `git` binary or a non-root user the verification container doesn't have, none touch `core/supervisor/`.

Fixes #246
