### PR TITLE
feat(rerank): 中央rerank API新設 + CrossEncoderローカルロード全廃 (PR-0)

### DIFF
--- a/cli/commands/index_cmd.py
+++ b/cli/commands/index_cmd.py
@@ -21,10 +21,11 @@ logger = logging.getLogger("animaworks.cli.index")
 def _setup_server_delegation() -> bool:
     """Detect running server and configure HTTP delegation.
 
-    When the server is running, sets ``ANIMAWORKS_VECTOR_URL`` and
-    ``ANIMAWORKS_EMBED_URL`` so that ``get_vector_store()`` returns
-    ``HttpVectorStore`` and embeddings are generated server-side.
-    This prevents unsafe concurrent ChromaDB access.
+    When the server is running, sets ``ANIMAWORKS_VECTOR_URL``,
+    ``ANIMAWORKS_EMBED_URL``, and ``ANIMAWORKS_RERANK_URL`` so that
+    ``get_vector_store()`` returns ``HttpVectorStore`` and embeddings /
+    rerank are generated server-side.  This prevents unsafe concurrent
+    ChromaDB access and per-process model loads.
 
     Returns:
         True if delegation was activated (server is running).
@@ -45,6 +46,7 @@ def _setup_server_delegation() -> bool:
     base = f"http://127.0.0.1:{port}/api"
     os.environ["ANIMAWORKS_VECTOR_URL"] = f"{base}/internal/vector"
     os.environ["ANIMAWORKS_EMBED_URL"] = f"{base}/internal/embed"
+    os.environ["ANIMAWORKS_RERANK_URL"] = f"{base}/internal/rerank"
     logger.info(
         "Server detected (pid=%d). Using HTTP delegation for safe ChromaDB access.",
         pid,

--- a/core/execution/_sdk_options.py
+++ b/core/execution/_sdk_options.py
@@ -225,10 +225,15 @@ class SDKOptionsMixin:
             "PYTHONPATH": str(PROJECT_DIR),
             "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
         }
-        # Without the embed/vector URLs the MCP server cannot delegate to the
-        # animaworks server and silently loads SentenceTransformer models
-        # in-process (2026-07-17 OOM incident).
-        for key in ("ANIMAWORKS_EMBED_URL", "ANIMAWORKS_VECTOR_URL"):
+        # Without the embed/vector/rerank URLs the MCP server cannot delegate
+        # to the animaworks server and silently loads SentenceTransformer /
+        # CrossEncoder models in-process (2026-07-17 OOM / 2026-08-07 rerank
+        # load storms).
+        for key in (
+            "ANIMAWORKS_EMBED_URL",
+            "ANIMAWORKS_VECTOR_URL",
+            "ANIMAWORKS_RERANK_URL",
+        ):
             value = os.environ.get(key)
             if value:
                 env[key] = value

--- a/core/execution/codex_sdk.py
+++ b/core/execution/codex_sdk.py
@@ -1866,9 +1866,7 @@ class CodexSDKExecutor(BaseExecutor):
 
             items = getattr(turn, "items", []) or []
             response_parts = [
-                text
-                for item in items
-                if _item_type(item) == "agent_message" and (text := _extract_item_text(item))
+                text for item in items if _item_type(item) == "agent_message" and (text := _extract_item_text(item))
             ]
             response_parts.append(getattr(turn, "final_response", "") or "")
             response_text = join_answer_parts(response_parts)

--- a/core/execution/grok_cli.py
+++ b/core/execution/grok_cli.py
@@ -443,9 +443,9 @@ class GrokCLIExecutor(BaseExecutor):
                 # (a dict fails schema validation: "did not match any variant
                 # of untagged enum McpServer").
                 # The MCP server runs with ONLY these variables — without the
-                # embed/vector URLs it silently falls back to loading
-                # SentenceTransformer models in-process (2026-07-17 OOM:
-                # a 61.8GB python3 killed the whole fleet).
+                # embed/vector/rerank URLs it silently falls back to loading
+                # SentenceTransformer / CrossEncoder models in-process
+                # (2026-07-17 OOM; 2026-08-07 CrossEncoder load storm).
                 "env": [
                     {"name": "ANIMAWORKS_ANIMA_DIR", "value": str(self._anima_dir)},
                     {"name": "ANIMAWORKS_PROJECT_DIR", "value": str(PROJECT_DIR)},
@@ -453,7 +453,11 @@ class GrokCLIExecutor(BaseExecutor):
                     {"name": "PATH", "value": os.environ.get("PATH", "/usr/bin:/bin")},
                     *(
                         {"name": key, "value": os.environ[key]}
-                        for key in ("ANIMAWORKS_EMBED_URL", "ANIMAWORKS_VECTOR_URL")
+                        for key in (
+                            "ANIMAWORKS_EMBED_URL",
+                            "ANIMAWORKS_VECTOR_URL",
+                            "ANIMAWORKS_RERANK_URL",
+                        )
                         if os.environ.get(key)
                     ),
                 ],

--- a/core/memory/retrieval/reranker.py
+++ b/core/memory/retrieval/reranker.py
@@ -1,16 +1,25 @@
 from __future__ import annotations
 
 # AnimaWorks - Digital Anima Framework
-"""Cross-encoder reranker for hybrid search results."""
+"""Cross-encoder reranker for hybrid search results.
+
+When ``ANIMAWORKS_RERANK_URL`` is set (child processes), scoring delegates
+to the server's ``/api/internal/rerank`` endpoint instead of loading the
+CrossEncoder model locally.  HTTP failures skip rerank (original order is
+kept) rather than falling back to a local model load.
+"""
 
 import asyncio
 import logging
+import os
 import threading
 from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_MODEL = "cross-encoder/ms-marco-MiniLM-L-12-v2"
+_BATCH_LIMIT = 1000
+_HTTP_TIMEOUT = 180.0
 
 
 class CrossEncoderReranker:
@@ -70,7 +79,7 @@ class CrossEncoderReranker:
             self._available = False
             return False
 
-    def _score_sync(self, query: str, texts: list[str]) -> list[float] | None:
+    def _score_local(self, query: str, texts: list[str]) -> list[float] | None:
         if not self._ensure_model():
             return None
         try:
@@ -98,6 +107,57 @@ class CrossEncoderReranker:
                     logger.warning("Cross-encoder CPU fallback scoring failed", exc_info=True)
             logger.warning("Cross-encoder scoring failed", exc_info=True)
             return None
+
+    def _score_http(self, query: str, texts: list[str], rerank_url: str) -> list[float] | None:
+        """Score via server's /api/internal/rerank. On failure return None (skip)."""
+        import httpx
+
+        all_scores: list[float] = []
+        try:
+            for i in range(0, len(texts), _BATCH_LIMIT):
+                batch = texts[i : i + _BATCH_LIMIT]
+                resp = httpx.post(
+                    rerank_url,
+                    json={"query": query, "documents": batch},
+                    timeout=_HTTP_TIMEOUT,
+                )
+                resp.raise_for_status()
+                scores = resp.json()["scores"]
+                if len(scores) != len(batch):
+                    logger.warning(
+                        "HTTP rerank returned %d scores for %d documents; skipping",
+                        len(scores),
+                        len(batch),
+                    )
+                    return None
+                all_scores.extend(float(s) for s in scores)
+        except Exception:
+            logger.warning(
+                "HTTP rerank failed (url=%s); skipping rerank, keeping original order",
+                rerank_url,
+                exc_info=True,
+            )
+            return None
+        return all_scores
+
+    def _score_sync(self, query: str, texts: list[str]) -> list[float] | None:
+        """Score documents; HTTP-delegate when ANIMAWORKS_RERANK_URL is set."""
+        if not texts:
+            return []
+        rerank_url = os.environ.get("ANIMAWORKS_RERANK_URL")
+        if rerank_url:
+            return self._score_http(query, texts, rerank_url)
+        return self._score_local(query, texts)
+
+    def score_sync(self, query: str, texts: list[str]) -> list[float] | None:
+        """Public scoring entry used by the central /api/internal/rerank endpoint.
+
+        Always uses the local model (server process). Child processes should
+        call the HTTP endpoint rather than this method.
+        """
+        if not texts:
+            return []
+        return self._score_local(query, texts)
 
     def rerank_sync(
         self,
@@ -180,3 +240,10 @@ def get_reranker(model_name: str = _DEFAULT_MODEL) -> CrossEncoderReranker:
         if _reranker is None or _reranker._model_name != model_name:
             _reranker = CrossEncoderReranker(model_name)
         return _reranker
+
+
+def _reset_for_testing() -> None:
+    """Reset singleton for test isolation."""
+    global _reranker  # noqa: PLW0603
+    with _reranker_lock:
+        _reranker = None

--- a/server/app.py
+++ b/server/app.py
@@ -674,6 +674,7 @@ async def _prepare_startup_vector_worker(app: FastAPI) -> None:
     app.state.child_env_urls = {
         "ANIMAWORKS_EMBED_URL": f"http://127.0.0.1:{_server_port}/api/internal/embed",
         "ANIMAWORKS_VECTOR_URL": f"http://127.0.0.1:{_server_port}/api/internal/vector",
+        "ANIMAWORKS_RERANK_URL": f"http://127.0.0.1:{_server_port}/api/internal/rerank",
     }
     app.state.supervisor.child_env_urls = app.state.child_env_urls
 

--- a/server/github_gateway.py
+++ b/server/github_gateway.py
@@ -445,9 +445,7 @@ class GitHubWebhookManager:
         author_cf = author.casefold()
         bot = self._config.bot_login
         reviewer = self._config.reviewer_login
-        return (bool(bot) and author_cf == bot.casefold()) or (
-            bool(reviewer) and author_cf == reviewer.casefold()
-        )
+        return (bool(bot) and author_cf == bot.casefold()) or (bool(reviewer) and author_cf == reviewer.casefold())
 
     def _send(self, to: str, content: str, kind: str, key: str) -> None:
         Messenger(self._require_shared_dir(), "pr-review-dispatch").send(

--- a/server/routes/internal.py
+++ b/server/routes/internal.py
@@ -37,6 +37,12 @@ class EmbedRequest(BaseModel):
     priority: Literal["interactive", "bulk"] = "interactive"
 
 
+class RerankRequest(BaseModel):
+    query: str
+    documents: list[str]
+    top_k: int | None = None
+
+
 class VectorQueryRequest(BaseModel):
     anima_name: str | None = None
     collection: str
@@ -275,6 +281,55 @@ def create_internal_router() -> APIRouter:
             partial(thread_safe_encode, body.texts, purpose=body.purpose, priority=body.priority),
         )
         return {"embeddings": embeddings}
+
+    # ── Cross-encoder rerank endpoint ─────────────────────────────
+
+    @router.post("/internal/rerank")
+    async def internal_rerank(body: RerankRequest):
+        """Centralized cross-encoder reranking for child processes.
+
+        Child processes call this endpoint via HTTP instead of loading
+        the CrossEncoder model on their own, eliminating per-MCP-subprocess
+        model loads (~130 MB each).
+        """
+        if len(body.documents) > 1000:
+            return JSONResponse(
+                status_code=400,
+                content={"detail": "Max 1000 documents per request"},
+            )
+        if not body.documents:
+            return {"scores": []}
+
+        from functools import partial
+
+        from core.memory.retrieval.reranker import get_reranker
+
+        reranker = get_reranker()
+        loop = asyncio.get_running_loop()
+        scores = await loop.run_in_executor(
+            _native_executor,
+            partial(reranker.score_sync, body.query, body.documents),
+        )
+        if scores is None:
+            # Explicit failure — never collapse to empty success (caller must
+            # treat as unavailable and keep original order).
+            return JSONResponse(
+                status_code=503,
+                content={"detail": "Reranker unavailable"},
+            )
+
+        if body.top_k is not None and body.top_k >= 0:
+            # Optional ranked view; primary contract remains full scores array.
+            indexed = sorted(
+                enumerate(scores),
+                key=lambda pair: pair[1],
+                reverse=True,
+            )[: body.top_k]
+            return {
+                "scores": scores,
+                "results": [{"index": i, "score": s} for i, s in indexed],
+            }
+        return {"scores": scores}
 
     # ── Vector store endpoints (ChromaDB process separation) ───────
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,6 +219,7 @@ def data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     # Clear HTTP delegation env vars so tests use local ChromaDB / models
     monkeypatch.delenv("ANIMAWORKS_VECTOR_URL", raising=False)
     monkeypatch.delenv("ANIMAWORKS_EMBED_URL", raising=False)
+    monkeypatch.delenv("ANIMAWORKS_RERANK_URL", raising=False)
 
     # Invalidate caches to pick up the new data dir
     invalidate_cache()

--- a/tests/unit/core/memory/test_reranker_http.py
+++ b/tests/unit/core/memory/test_reranker_http.py
@@ -1,0 +1,242 @@
+"""Unit tests for CrossEncoderReranker HTTP/local routing."""
+# AnimaWorks - Digital Anima Framework
+# Copyright (C) 2026 AnimaWorks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_reranker():
+    from core.memory.retrieval.reranker import _reset_for_testing
+
+    _reset_for_testing()
+    yield
+    _reset_for_testing()
+
+
+@pytest.fixture
+def mock_cross_encoder(monkeypatch):
+    """Inject a mock sentence_transformers.CrossEncoder."""
+    import types
+
+    mock_cls = MagicMock()
+    mock_module = types.ModuleType("sentence_transformers")
+    mock_module.CrossEncoder = mock_cls  # type: ignore[attr-defined]
+
+    already_present = "sentence_transformers" in sys.modules
+    original = sys.modules.get("sentence_transformers")
+    sys.modules["sentence_transformers"] = mock_module
+    yield mock_cls
+    if already_present:
+        sys.modules["sentence_transformers"] = original  # type: ignore[assignment]
+    else:
+        sys.modules.pop("sentence_transformers", None)
+
+
+class TestRerankerLocal:
+    def test_local_mode_scores_and_reranks(self, monkeypatch, mock_cross_encoder):
+        """Without ANIMAWORKS_RERANK_URL, local CrossEncoder is used."""
+        monkeypatch.delenv("ANIMAWORKS_RERANK_URL", raising=False)
+
+        mock_model = MagicMock()
+        mock_model.predict.return_value = [0.1, 0.9, 0.5]
+        mock_cross_encoder.return_value = mock_model
+
+        from core.memory.retrieval.reranker import CrossEncoderReranker
+
+        reranker = CrossEncoderReranker()
+        result = reranker.rerank_sync(
+            "query",
+            [{"content": "a"}, {"content": "b"}, {"content": "c"}],
+            top_k=3,
+        )
+
+        assert [r["content"] for r in result] == ["b", "c", "a"]
+        assert result[0]["ce_score"] == pytest.approx(0.9)
+        mock_cross_encoder.assert_called_once()
+        mock_model.predict.assert_called_once()
+
+
+class TestRerankerHTTP:
+    def test_http_mode_calls_endpoint(self, monkeypatch):
+        """When ANIMAWORKS_RERANK_URL is set, scoring uses HTTP."""
+        monkeypatch.setenv(
+            "ANIMAWORKS_RERANK_URL",
+            "http://127.0.0.1:18500/api/internal/rerank",
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"scores": [0.2, 0.8]}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.post", return_value=mock_response) as mock_post:
+            from core.memory.retrieval.reranker import CrossEncoderReranker
+
+            reranker = CrossEncoderReranker()
+            result = reranker.rerank_sync(
+                "query",
+                [{"content": "low"}, {"content": "high"}],
+                top_k=2,
+            )
+
+        assert [r["content"] for r in result] == ["high", "low"]
+        mock_post.assert_called_once_with(
+            "http://127.0.0.1:18500/api/internal/rerank",
+            json={"query": "query", "documents": ["low", "high"]},
+            timeout=180.0,
+        )
+
+    def test_http_mode_does_not_import_sentence_transformers(self, monkeypatch):
+        """With RERANK_URL set, sentence_transformers must not enter sys.modules."""
+        monkeypatch.setenv(
+            "ANIMAWORKS_RERANK_URL",
+            "http://127.0.0.1:18500/api/internal/rerank",
+        )
+
+        # Ensure a clean slate: remove any prior import from other tests.
+        st_was_present = "sentence_transformers" in sys.modules
+        st_original = sys.modules.pop("sentence_transformers", None)
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"scores": [0.5, 0.6, 0.7]}
+        mock_response.raise_for_status = MagicMock()
+
+        try:
+            with patch("httpx.post", return_value=mock_response):
+                from core.memory.retrieval.reranker import CrossEncoderReranker
+
+                reranker = CrossEncoderReranker()
+                result = reranker.rerank_sync(
+                    "q",
+                    [{"content": "a"}, {"content": "b"}, {"content": "c"}],
+                    top_k=3,
+                )
+
+            assert len(result) == 3
+            assert "sentence_transformers" not in sys.modules
+        finally:
+            if st_was_present and st_original is not None:
+                sys.modules["sentence_transformers"] = st_original
+
+    def test_http_failure_skips_rerank_keeps_order(self, monkeypatch):
+        """HTTP failure skips rerank (original order) — no local model fallback."""
+        import httpx
+
+        monkeypatch.setenv("ANIMAWORKS_RERANK_URL", "http://localhost/rerank")
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "503",
+            request=MagicMock(),
+            response=MagicMock(),
+        )
+
+        items = [
+            {"content": "first", "id": 1},
+            {"content": "second", "id": 2},
+            {"content": "third", "id": 3},
+        ]
+
+        st_was_present = "sentence_transformers" in sys.modules
+        st_original = sys.modules.pop("sentence_transformers", None)
+
+        try:
+            with patch("httpx.post", return_value=mock_response):
+                from core.memory.retrieval.reranker import CrossEncoderReranker
+
+                reranker = CrossEncoderReranker()
+                result = reranker.rerank_sync("q", items, top_k=3)
+
+            # Original order preserved; no ce_score (skip path)
+            assert [r["content"] for r in result] == ["first", "second", "third"]
+            assert all("ce_score" not in r for r in result)
+            assert "sentence_transformers" not in sys.modules
+        finally:
+            if st_was_present and st_original is not None:
+                sys.modules["sentence_transformers"] = st_original
+
+    def test_http_connection_error_skips(self, monkeypatch):
+        """Network errors also skip without local fallback."""
+        import httpx
+
+        monkeypatch.setenv("ANIMAWORKS_RERANK_URL", "http://localhost/rerank")
+
+        with patch(
+            "httpx.post",
+            side_effect=httpx.ConnectError("refused"),
+        ):
+            from core.memory.retrieval.reranker import CrossEncoderReranker
+
+            reranker = CrossEncoderReranker()
+            result = reranker.rerank_sync(
+                "q",
+                [{"content": "a"}, {"content": "b"}],
+                top_k=2,
+            )
+
+        assert [r["content"] for r in result] == ["a", "b"]
+
+    def test_http_batches_large_requests(self, monkeypatch):
+        """Requests over batch limit should be split."""
+        monkeypatch.setenv("ANIMAWORKS_RERANK_URL", "http://localhost/rerank")
+
+        batch1 = MagicMock()
+        batch1.json.return_value = {"scores": [float(i) for i in range(1000)]}
+        batch1.raise_for_status = MagicMock()
+
+        batch2 = MagicMock()
+        batch2.json.return_value = {"scores": [1000.0, 1001.0]}
+        batch2.raise_for_status = MagicMock()
+
+        items = [{"content": f"d{i}"} for i in range(1002)]
+
+        with patch("httpx.post", side_effect=[batch1, batch2]) as mock_post:
+            from core.memory.retrieval.reranker import CrossEncoderReranker
+
+            reranker = CrossEncoderReranker()
+            result = reranker.rerank_sync("q", items, top_k=3, min_candidates=2)
+
+        assert mock_post.call_count == 2
+        # Highest scores are 1001 and 1000 (from batch2)
+        assert result[0]["content"] == "d1001"
+        assert result[1]["content"] == "d1000"
+
+    def test_empty_items_skip_http(self, monkeypatch):
+        """Empty items return immediately without HTTP call."""
+        monkeypatch.setenv("ANIMAWORKS_RERANK_URL", "http://localhost/rerank")
+
+        with patch("httpx.post") as mock_post:
+            from core.memory.retrieval.reranker import CrossEncoderReranker
+
+            reranker = CrossEncoderReranker()
+            result = reranker.rerank_sync("q", [], top_k=5)
+
+        assert result == []
+        mock_post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_rerank_uses_http(self, monkeypatch):
+        """Async path also respects ANIMAWORKS_RERANK_URL."""
+        monkeypatch.setenv("ANIMAWORKS_RERANK_URL", "http://localhost/rerank")
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"scores": [0.3, 0.7]}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("httpx.post", return_value=mock_response):
+            from core.memory.retrieval.reranker import CrossEncoderReranker
+
+            reranker = CrossEncoderReranker()
+            result = await reranker.rerank(
+                "q",
+                [{"fact": "a"}, {"fact": "b"}],
+                top_k=2,
+            )
+
+        assert [r["fact"] for r in result] == ["b", "a"]

--- a/tests/unit/core/test_agent_sdk_mcp.py
+++ b/tests/unit/core/test_agent_sdk_mcp.py
@@ -75,18 +75,20 @@ class TestBuildMcpEnv:
         assert env["PATH"] == "/usr/bin:/bin"
 
     def test_passes_embed_and_vector_urls(self, tmp_path: Path) -> None:
-        """Embed/vector URLs propagate so the MCP server delegates over HTTP."""
+        """Embed/vector/rerank URLs propagate so the MCP server delegates over HTTP."""
         executor = _make_executor(tmp_path / "animas" / "test-anima")
         with patch.dict(
             os.environ,
             {
                 "ANIMAWORKS_EMBED_URL": "http://127.0.0.1:18500/api/internal/embed",
                 "ANIMAWORKS_VECTOR_URL": "http://127.0.0.1:18500/api/internal/vector",
+                "ANIMAWORKS_RERANK_URL": "http://127.0.0.1:18500/api/internal/rerank",
             },
         ):
             env = executor._build_mcp_env()
         assert env["ANIMAWORKS_EMBED_URL"] == "http://127.0.0.1:18500/api/internal/embed"
         assert env["ANIMAWORKS_VECTOR_URL"] == "http://127.0.0.1:18500/api/internal/vector"
+        assert env["ANIMAWORKS_RERANK_URL"] == "http://127.0.0.1:18500/api/internal/rerank"
 
     def test_omits_embed_and_vector_urls_when_unset(self, tmp_path: Path) -> None:
         """No stale/empty URL keys when the parent process has none."""
@@ -94,10 +96,12 @@ class TestBuildMcpEnv:
         env_copy = os.environ.copy()
         env_copy.pop("ANIMAWORKS_EMBED_URL", None)
         env_copy.pop("ANIMAWORKS_VECTOR_URL", None)
+        env_copy.pop("ANIMAWORKS_RERANK_URL", None)
         with patch.dict(os.environ, env_copy, clear=True):
             env = executor._build_mcp_env()
         assert "ANIMAWORKS_EMBED_URL" not in env
         assert "ANIMAWORKS_VECTOR_URL" not in env
+        assert "ANIMAWORKS_RERANK_URL" not in env
 
 
 class TestBuildSdkEnv:

--- a/tests/unit/server/routes/test_internal_rerank.py
+++ b/tests/unit/server/routes/test_internal_rerank.py
@@ -1,0 +1,171 @@
+"""Unit tests for POST /api/internal/rerank endpoint."""
+# AnimaWorks - Digital Anima Framework
+# Copyright (C) 2026 AnimaWorks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+def _make_test_app():
+    """Create a minimal FastAPI app with internal routes."""
+    from fastapi import FastAPI
+
+    from server.routes.internal import create_internal_router
+
+    app = FastAPI()
+    app.state.shared_dir = Path("/tmp/test-shared")
+    app.include_router(create_internal_router(), prefix="/api")
+    return app
+
+
+@pytest.fixture
+def app():
+    return _make_test_app()
+
+
+class TestInternalRerank:
+    @pytest.mark.anyio
+    async def test_returns_scores(self, app):
+        """Valid request returns scores for each document."""
+        mock_reranker = MagicMock()
+        mock_reranker.score_sync.return_value = [0.1, 0.9, 0.5]
+
+        with patch(
+            "core.memory.retrieval.reranker.get_reranker",
+            return_value=mock_reranker,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                resp = await client.post(
+                    "/api/internal/rerank",
+                    json={
+                        "query": "hello",
+                        "documents": ["a", "b", "c"],
+                    },
+                )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["scores"] == pytest.approx([0.1, 0.9, 0.5])
+        mock_reranker.score_sync.assert_called_once_with("hello", ["a", "b", "c"])
+
+    @pytest.mark.anyio
+    async def test_empty_documents_returns_empty(self, app):
+        """Empty documents list returns empty scores without loading model."""
+        with patch("core.memory.retrieval.reranker.get_reranker") as mock_get:
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                resp = await client.post(
+                    "/api/internal/rerank",
+                    json={"query": "q", "documents": []},
+                )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"scores": []}
+        mock_get.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_rejects_over_1000_documents(self, app):
+        """Requests with >1000 documents should be rejected."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+        ) as client:
+            resp = await client.post(
+                "/api/internal/rerank",
+                json={
+                    "query": "q",
+                    "documents": [f"doc_{i}" for i in range(1001)],
+                },
+            )
+
+        assert resp.status_code == 400
+        assert "Max 1000" in resp.json()["detail"]
+
+    @pytest.mark.anyio
+    async def test_exactly_1000_documents_accepted(self, app):
+        """Exactly 1000 documents should be accepted."""
+        mock_reranker = MagicMock()
+        mock_reranker.score_sync.return_value = [0.1] * 1000
+
+        with patch(
+            "core.memory.retrieval.reranker.get_reranker",
+            return_value=mock_reranker,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                resp = await client.post(
+                    "/api/internal/rerank",
+                    json={
+                        "query": "q",
+                        "documents": [f"d{i}" for i in range(1000)],
+                    },
+                )
+
+        assert resp.status_code == 200
+        assert len(resp.json()["scores"]) == 1000
+
+    @pytest.mark.anyio
+    async def test_unavailable_returns_503(self, app):
+        """Model failure must be an explicit error, not empty success."""
+        mock_reranker = MagicMock()
+        mock_reranker.score_sync.return_value = None
+
+        with patch(
+            "core.memory.retrieval.reranker.get_reranker",
+            return_value=mock_reranker,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                resp = await client.post(
+                    "/api/internal/rerank",
+                    json={"query": "q", "documents": ["a"]},
+                )
+
+        assert resp.status_code == 503
+        assert "unavailable" in resp.json()["detail"].lower()
+
+    @pytest.mark.anyio
+    async def test_top_k_adds_results(self, app):
+        """Optional top_k returns ranked index+score alongside full scores."""
+        mock_reranker = MagicMock()
+        mock_reranker.score_sync.return_value = [0.1, 0.9, 0.5]
+
+        with patch(
+            "core.memory.retrieval.reranker.get_reranker",
+            return_value=mock_reranker,
+        ):
+            async with AsyncClient(
+                transport=ASGITransport(app=app),
+                base_url="http://test",
+            ) as client:
+                resp = await client.post(
+                    "/api/internal/rerank",
+                    json={
+                        "query": "q",
+                        "documents": ["a", "b", "c"],
+                        "top_k": 2,
+                    },
+                )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["scores"] == pytest.approx([0.1, 0.9, 0.5])
+        assert data["results"] == [
+            {"index": 1, "score": pytest.approx(0.9)},
+            {"index": 2, "score": pytest.approx(0.5)},
+        ]

--- a/tests/unit/test_grok_cli_executor.py
+++ b/tests/unit/test_grok_cli_executor.py
@@ -322,30 +322,34 @@ class TestGrokFailureMetadata:
 
 class TestDiscoveryAndHelperEnvironment:
     def test_mcp_env_passes_embed_and_vector_urls(self, executor: GrokCLIExecutor):
-        """MCP server env must include embed/vector URLs so it delegates over
-        HTTP instead of loading SentenceTransformer models in-process
-        (2026-07-17 OOM incident)."""
+        """MCP server env must include embed/vector/rerank URLs so it delegates
+        over HTTP instead of loading models in-process
+        (2026-07-17 OOM / 2026-08-07 CrossEncoder load storm)."""
         with patch.dict(
             os.environ,
             {
                 "ANIMAWORKS_EMBED_URL": "http://127.0.0.1:18500/api/internal/embed",
                 "ANIMAWORKS_VECTOR_URL": "http://127.0.0.1:18500/api/internal/vector",
+                "ANIMAWORKS_RERANK_URL": "http://127.0.0.1:18500/api/internal/rerank",
             },
         ):
             servers = executor._mcp_servers()
         env_map = {item["name"]: item["value"] for item in servers[0]["env"]}
         assert env_map["ANIMAWORKS_EMBED_URL"] == "http://127.0.0.1:18500/api/internal/embed"
         assert env_map["ANIMAWORKS_VECTOR_URL"] == "http://127.0.0.1:18500/api/internal/vector"
+        assert env_map["ANIMAWORKS_RERANK_URL"] == "http://127.0.0.1:18500/api/internal/rerank"
 
     def test_mcp_env_omits_urls_when_unset(self, executor: GrokCLIExecutor):
         env_copy = os.environ.copy()
         env_copy.pop("ANIMAWORKS_EMBED_URL", None)
         env_copy.pop("ANIMAWORKS_VECTOR_URL", None)
+        env_copy.pop("ANIMAWORKS_RERANK_URL", None)
         with patch.dict(os.environ, env_copy, clear=True):
             servers = executor._mcp_servers()
         env_names = {item["name"] for item in servers[0]["env"]}
         assert "ANIMAWORKS_EMBED_URL" not in env_names
         assert "ANIMAWORKS_VECTOR_URL" not in env_names
+        assert "ANIMAWORKS_RERANK_URL" not in env_names
 
     def test_session_paths_and_trigger_normalization(self, anima_dir: Path):
         assert _resolve_session_type("message:user") == "chat"


### PR DESCRIPTION
## 概要
Phase 2/3プロセスモデル再設計の前提PR-0。CrossEncoderReranker（ms-marco-MiniLM-L-12-v2）にembedding同様の中央API委譲を導入し、runner/MCPサブプロセス毎のモデルロード（実測1体105回・~130MB/回）を消滅させる。

## 変更
- `POST /api/internal/rerank` 新設（max 1000 docs・空→`[]`・失敗503、embedの慣行準拠）
- `ANIMAWORKS_RERANK_URL` 設定時はHTTP委譲。HTTP失敗時はrerankスキップ（元順位維持・ローカルfallbackなし＝fail-closed）
- server/app.py・_sdk_options.py・grok_cli.py・index_cmd.py にURL注入配線
- URL設定時に sentence_transformers が sys.modules に現れないことの回帰テスト

## 検証
- 対象UT 87 passed / ruff clean（PdM再実行済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)