### PR TITLE
fix(rag): コレクション存在判定の三値化 (P0-1)

### DIFF
--- a/cli/commands/index_cmd.py
+++ b/cli/commands/index_cmd.py
@@ -359,7 +359,14 @@ def index_command(args: argparse.Namespace) -> None:
                 "Full rebuild: deleting collections for %s (will recreate with cosine similarity)",
                 anima_name,
             )
-            for collection in vector_store.list_collections():
+            collections = vector_store.list_collections_checked()
+            if collections is None:
+                logger.warning(
+                    "Cannot list collections for %s; skipping full rebuild to avoid partial deletion",
+                    anima_name,
+                )
+                continue
+            for collection in collections:
                 vector_store.delete_collection(collection)
 
         indexer = MemoryIndexer(vector_store, anima_name, anima_dir)

--- a/core/execution/codex_sdk.py
+++ b/core/execution/codex_sdk.py
@@ -1866,9 +1866,7 @@ class CodexSDKExecutor(BaseExecutor):
 
             items = getattr(turn, "items", []) or []
             response_parts = [
-                text
-                for item in items
-                if _item_type(item) == "agent_message" and (text := _extract_item_text(item))
+                text for item in items if _item_type(item) == "agent_message" and (text := _extract_item_text(item))
             ]
             response_parts.append(getattr(turn, "final_response", "") or "")
             response_text = join_answer_parts(response_parts)

--- a/core/memory/rag/http_store.py
+++ b/core/memory/rag/http_store.py
@@ -241,6 +241,16 @@ class HttpVectorStore(VectorStore):
             return list(data["collections"])
         return []
 
+    def list_collections_checked(self) -> list[str] | None:
+        """List collections while preserving transport/service failures."""
+        data = self._post("/list-collections", {"anima_name": self._anima_name})
+        if data is None or "collections" not in data:
+            return None
+        collections = data["collections"]
+        if not isinstance(collections, list) or not all(isinstance(name, str) for name in collections):
+            return None
+        return list(collections)
+
     def upsert(self, collection: str, documents: list[Document]) -> bool:
         """Insert or update documents in a collection."""
         if not documents:

--- a/core/memory/rag/indexer.py
+++ b/core/memory/rag/indexer.py
@@ -29,6 +29,7 @@ from core.memory.rag.contextual_header import apply_contextual_header
 from core.memory.rag.episode_time import apply_episode_heading_event_time
 from core.memory.rag.exclusion import is_archive_path, is_rag_excluded
 from core.memory.rag.facts_chunker import chunk_facts_jsonl
+from core.memory.rag.store import CollectionExistence
 from core.time_utils import ensure_aware, now_iso
 
 if TYPE_CHECKING:
@@ -163,26 +164,24 @@ class MemoryIndexer:
         # short-circuiting (recovery from a wiped/recreated vectordb).
         self._known_collections: set[str] | None = None
 
-    def _collection_exists(self, name: str) -> bool:
-        """Return True if *name* is present in the vector store.
+    def _collection_exists(self, name: str) -> CollectionExistence:
+        """Return the checked existence state for *name*.
 
         Lazily populates ``self._known_collections`` from
-        ``vector_store.list_collections()`` on first access.  Subsequent
+        ``vector_store.list_collections_checked()`` on first access.  Subsequent
         calls reuse the cache; callers add to the cache after successful
         ``create_collection()`` / ``upsert()`` to avoid repeated listing.
 
-        Returns ``True`` on listing failure to preserve legacy behavior
-        (skip when uncertain).
+        An unavailable result is not cached so a later check can recover.
         """
         if self._known_collections is None:
-            try:
-                self._known_collections = set(self.vector_store.list_collections())
-            except Exception as exc:
-                logger.debug("Failed to list collections for cache: %s", exc)
-                # Be conservative: assume it exists rather than triggering
-                # spurious re-indexing of every file on a transient error.
-                return True
-        return name in self._known_collections
+            collections = self.vector_store.list_collections_checked()
+            if collections is None:
+                return CollectionExistence.UNAVAILABLE
+            self._known_collections = set(collections)
+        if name in self._known_collections:
+            return CollectionExistence.EXISTS
+        return CollectionExistence.MISSING
 
     def _mark_collection_known(self, name: str) -> None:
         """Record that *name* is present in the vector store.
@@ -192,10 +191,10 @@ class MemoryIndexer:
         re-list collections.
         """
         if self._known_collections is None:
-            try:
-                self._known_collections = set(self.vector_store.list_collections())
-            except Exception:
-                self._known_collections = set()
+            collections = self.vector_store.list_collections_checked()
+            if collections is None:
+                return
+            self._known_collections = set(collections)
         self._known_collections.add(name)
 
     def _init_embedding_model(self) -> None:
@@ -463,8 +462,12 @@ class MemoryIndexer:
                 # recreated since the last index, the meta hash would
                 # otherwise cause us to silently skip and the collection
                 # would never be re-created.
-                if self._collection_exists(collection_name):
+                existence = self._collection_exists(collection_name)
+                if existence is CollectionExistence.EXISTS:
                     logger.debug("File unchanged, skipping: %s", file_path)
+                    return self._finish_index_file(0, "unchanged")
+                if existence is CollectionExistence.UNAVAILABLE:
+                    logger.debug("Collection availability unknown, skipping re-index of %s", file_path)
                     return self._finish_index_file(0, "unchanged")
                 logger.info(
                     "Collection '%s' missing despite tracked hash, forcing re-index of %s",
@@ -759,8 +762,12 @@ class MemoryIndexer:
             if self.index_meta[meta_key].get("hash") == content_hash:
                 # Verify the collection still exists; force re-index if
                 # the vectordb was wiped/recreated.
-                if self._collection_exists(collection_name):
+                existence = self._collection_exists(collection_name)
+                if existence is CollectionExistence.EXISTS:
                     logger.debug("compressed_summary unchanged, skipping")
+                    return 0
+                if existence is CollectionExistence.UNAVAILABLE:
+                    logger.debug("Conversation collection availability unknown, skipping re-index")
                     return 0
                 logger.info(
                     "Collection '%s' missing despite tracked hash, forcing re-index of conversation_summary",

--- a/core/memory/rag/repair_rebuild.py
+++ b/core/memory/rag/repair_rebuild.py
@@ -105,12 +105,11 @@ def verify_rebuilt_vectordb(anima_name: str, *, expected_chunks: int) -> None:
         raise RebuildVerificationError(
             f"vector store unavailable for {anima_name} after rebuild (indexed {expected_chunks} chunks)"
         )
-    try:
-        collections = store.list_collections()
-    except Exception as exc:  # noqa: BLE001 — any failure here means the DB is unusable
+    collections = store.list_collections_checked()
+    if collections is None:
         raise RebuildVerificationError(
-            f"rebuilt vector DB for {anima_name} is unreadable (indexed {expected_chunks} chunks): {exc}"
-        ) from exc
+            f"rebuilt vector DB for {anima_name} is unreadable (indexed {expected_chunks} chunks)"
+        )
     if not collections:
         raise RebuildVerificationError(
             f"rebuilt vector DB for {anima_name} has no collections despite indexing {expected_chunks} chunks "
@@ -243,10 +242,16 @@ def atomic_rebuild_vectordb(
                 include_shared=include_shared,
                 anima_dir=resolved_anima_dir,
             )
-            if chunks > 0 and not store.list_collections():
-                raise RebuildVerificationError(
-                    f"staged vector DB for {anima_name} has no collections despite indexing {chunks} chunks"
-                )
+            if chunks > 0:
+                collections = store.list_collections_checked()
+                if collections is None:
+                    raise RebuildVerificationError(
+                        f"staged vector DB for {anima_name} is unreadable despite indexing {chunks} chunks"
+                    )
+                if not collections:
+                    raise RebuildVerificationError(
+                        f"staged vector DB for {anima_name} has no collections despite indexing {chunks} chunks"
+                    )
         finally:
             store.close()
             gc.collect()

--- a/core/memory/rag/store.py
+++ b/core/memory/rag/store.py
@@ -17,6 +17,7 @@ import threading
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from enum import StrEnum
 from pathlib import Path
 from typing import Any, TypeVar, cast
 
@@ -48,6 +49,14 @@ class SearchResult:
     score: float
 
 
+class CollectionExistence(StrEnum):
+    """Three-state result for a collection existence check."""
+
+    EXISTS = "exists"
+    MISSING = "missing"
+    UNAVAILABLE = "unavailable"
+
+
 # ── VectorStore abstract base class ────────────────────────────────
 
 
@@ -76,6 +85,26 @@ class VectorStore(ABC):
     @abstractmethod
     def list_collections(self) -> list[str]:
         """List all collection names."""
+
+    def list_collections_checked(self) -> list[str] | None:
+        """List collections without conflating failures with an empty store.
+
+        Returns ``None`` when the backend cannot determine the collection
+        list.  ``[]`` is reserved for a successful read of an empty store.
+        """
+        try:
+            return self.list_collections()
+        except Exception:
+            return None
+
+    def collection_exists(self, name: str) -> CollectionExistence:
+        """Return whether a collection exists, is missing, or is unavailable."""
+        collections = self.list_collections_checked()
+        if collections is None:
+            return CollectionExistence.UNAVAILABLE
+        if name in collections:
+            return CollectionExistence.EXISTS
+        return CollectionExistence.MISSING
 
     @abstractmethod
     def upsert(self, collection: str, documents: list[Document]) -> bool:

--- a/core/memory/rag/vector_worker.py
+++ b/core/memory/rag/vector_worker.py
@@ -878,9 +878,9 @@ def create_app() -> FastAPI:
             lambda store: store.list_collections(),
         )
         if collections is None:
-            return {"collections": []}
+            return JSONResponse(status_code=503, content={"detail": "Vector store unavailable"})
         if _is_vector_action_error(collections):
-            return {"collections": []}
+            return JSONResponse(status_code=503, content={"detail": "Vector store unavailable"})
         return {"collections": collections}
 
     @app.post("/quick-check")

--- a/core/memory/rag_search.py
+++ b/core/memory/rag_search.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from core.company_resources import company_resource_pointer, get_company_resources, infer_data_dir
 from core.memory.fact_observability import warn_rate_limited
+from core.memory.rag.store import CollectionExistence
 
 logger = logging.getLogger("animaworks.memory")
 
@@ -86,20 +87,9 @@ def _write_shared_hash(meta_path: Path, key: str, value: str) -> None:
     )
 
 
-def _shared_collection_exists(vector_store, collection_name: str) -> bool:
-    """Return True if *collection_name* exists in *vector_store*.
-
-    Used to verify shared collections (``shared_common_knowledge`` /
-    ``shared_common_skills``) before short-circuiting on hash match.
-    Returns ``True`` on listing failure (be conservative — preserve
-    legacy behavior on transient errors rather than triggering full
-    re-indexing across all animas).
-    """
-    try:
-        return collection_name in vector_store.list_collections()
-    except Exception as exc:
-        logger.debug("Failed to list collections for existence check: %s", exc)
-        return True
+def _shared_collection_exists(vector_store, collection_name: str) -> CollectionExistence:
+    """Return the checked existence state for a shared collection."""
+    return vector_store.collection_exists(collection_name)
 
 
 # ── RAGMemorySearch ───────────────────────────────────────
@@ -271,8 +261,12 @@ class RAGMemorySearch:
             # Verify the shared collection still exists in this anima's
             # vector store; if missing, fall through with force=True so
             # the collection gets recreated.
-            if _shared_collection_exists(vector_store, "shared_common_knowledge"):
+            existence = _shared_collection_exists(vector_store, "shared_common_knowledge")
+            if existence is CollectionExistence.EXISTS:
                 logger.debug("common_knowledge unchanged (hash match), skipping")
+                return
+            if existence is CollectionExistence.UNAVAILABLE:
+                logger.debug("common_knowledge collection availability unknown; skipping re-index")
                 return
             logger.info("shared_common_knowledge collection missing despite tracked hash, forcing re-index")
             force = True
@@ -318,8 +312,12 @@ class RAGMemorySearch:
         stored_hash = _read_shared_hash(meta_path, "shared_common_skills_hash")
         force = False
         if current_hash == stored_hash:
-            if _shared_collection_exists(vector_store, "shared_common_skills"):
+            existence = _shared_collection_exists(vector_store, "shared_common_skills")
+            if existence is CollectionExistence.EXISTS:
                 logger.debug("common_skills unchanged (hash match), skipping")
+                return
+            if existence is CollectionExistence.UNAVAILABLE:
+                logger.debug("common_skills collection availability unknown; skipping re-index")
                 return
             logger.info("shared_common_skills collection missing despite tracked hash, forcing re-index")
             force = True
@@ -388,9 +386,12 @@ class RAGMemorySearch:
         current_hash = _compute_dir_hash(directory, glob)
         stored_hash = _read_shared_hash(meta_path, meta_key)
         collection = f"shared_{memory_type}"
-        force = current_hash == stored_hash and not _shared_collection_exists(vector_store, collection)
-        if current_hash == stored_hash and not force:
-            return
+        force = False
+        if current_hash == stored_hash:
+            existence = _shared_collection_exists(vector_store, collection)
+            if existence is not CollectionExistence.MISSING:
+                return
+            force = True
         try:
             from core.memory.rag import MemoryIndexer
 

--- a/core/supervisor/_mgr_scheduler.py
+++ b/core/supervisor/_mgr_scheduler.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
+from core.memory.rag.store import CollectionExistence
 from core.supervisor.process_handle import ProcessState
 from core.time_utils import get_app_timezone, now_local
 
@@ -773,11 +774,8 @@ class SchedulerMixin:
                     shared_collection = f"shared_{label}"
                     force = False
                     if current_hash == stored_hash:
-                        try:
-                            existing = vector_store.list_collections()
-                        except Exception:
-                            existing = None
-                        if existing is None or shared_collection in existing:
+                        existence = vector_store.collection_exists(shared_collection)
+                        if existence is not CollectionExistence.MISSING:
                             continue
                         logger.info(
                             "%s: collection '%s' missing despite tracked hash, forcing re-index",

--- a/server/github_gateway.py
+++ b/server/github_gateway.py
@@ -445,9 +445,7 @@ class GitHubWebhookManager:
         author_cf = author.casefold()
         bot = self._config.bot_login
         reviewer = self._config.reviewer_login
-        return (bool(bot) and author_cf == bot.casefold()) or (
-            bool(reviewer) and author_cf == reviewer.casefold()
-        )
+        return (bool(bot) and author_cf == bot.casefold()) or (bool(reviewer) and author_cf == reviewer.casefold())
 
     def _send(self, to: str, content: str, kind: str, key: str) -> None:
         Messenger(self._require_shared_dir(), "pr-review-dispatch").send(

--- a/tests/unit/cli/test_index_shared.py
+++ b/tests/unit/cli/test_index_shared.py
@@ -336,7 +336,7 @@ def test_index_command_full_reindexes_facts(tmp_path: Path) -> None:
     (anima_dir / "facts" / "2026-07-15.jsonl").write_text('{"text":"fact"}\n', encoding="utf-8")
     args = argparse.Namespace(anima="alice", full=True, shared=False, dry_run=False)
     mock_store = MagicMock()
-    mock_store.list_collections.return_value = []
+    mock_store.list_collections_checked.return_value = []
 
     with (
         patch("cli.commands.index_cmd.get_data_dir", return_value=tmp_path),
@@ -359,3 +359,26 @@ def test_index_command_full_reindexes_facts(tmp_path: Path) -> None:
         "facts",
         force=True,
     )
+
+
+def test_index_command_full_skips_when_collection_list_unavailable(tmp_path: Path) -> None:
+    anima_dir = tmp_path / "animas" / "alice"
+    (anima_dir / "knowledge").mkdir(parents=True)
+    (anima_dir / "knowledge" / "note.md").write_text("# Note", encoding="utf-8")
+    args = argparse.Namespace(anima="alice", full=True, shared=False, dry_run=False)
+    mock_store = MagicMock()
+    mock_store.list_collections_checked.return_value = None
+
+    with (
+        patch("cli.commands.index_cmd.get_data_dir", return_value=tmp_path),
+        patch("cli.commands.index_cmd._setup_server_delegation", return_value=False),
+        patch("cli.commands.index_cmd._setup_offline_vector_worker_if_needed", return_value=None),
+        patch("cli.commands.index_cmd._check_model_change", return_value="test-model"),
+        patch("core.memory.rag.repair.is_repair_locked", return_value=False),
+        patch("core.memory.rag.singleton.get_vector_store", return_value=mock_store),
+        patch("core.memory.rag.MemoryIndexer") as mock_indexer_cls,
+    ):
+        index_command(args)
+
+    mock_store.delete_collection.assert_not_called()
+    mock_indexer_cls.assert_not_called()

--- a/tests/unit/core/memory/test_http_vector_store.py
+++ b/tests/unit/core/memory/test_http_vector_store.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 
 from core.memory.rag.http_store import HttpVectorStore
-from core.memory.rag.store import Document, SearchResult
+from core.memory.rag.store import CollectionExistence, Document, SearchResult
 
 
 def _make_store(
@@ -86,6 +86,8 @@ def test_http_vector_store_read_503_from_vector_worker_fails_soft():
     assert store.get_by_metadata("rin_knowledge", {"type": "knowledge"}) == []
     assert store.get_by_ids("rin_knowledge", ["doc1"]) == []
     assert store.list_collections() == []
+    assert store.list_collections_checked() is None
+    assert store.collection_exists("rin_knowledge") is CollectionExistence.UNAVAILABLE
 
 
 # ── test_upsert_sends_documents ───────────────────────────────────
@@ -258,6 +260,33 @@ def test_list_collections():
         colls = store.list_collections()
 
     assert colls == ["col1", "col2"]
+
+
+def test_list_collections_checked_distinguishes_empty_and_existence():
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"collections": []}
+    mock_response.raise_for_status = MagicMock()
+    mock_client.post.return_value = mock_response
+
+    with patch("httpx.Client", return_value=mock_client):
+        store = _make_store()
+        assert store.list_collections_checked() == []
+        assert store.collection_exists("missing") is CollectionExistence.MISSING
+
+    mock_response.json.return_value = {"collections": ["present"]}
+    assert store.collection_exists("present") is CollectionExistence.EXISTS
+
+
+def test_list_collections_checked_transport_error_is_unavailable():
+    mock_client = MagicMock()
+    mock_client.post.side_effect = httpx.TransportError("connection refused")
+    store = _make_store()
+    store._client = mock_client
+
+    assert store.list_collections_checked() is None
+    assert store.collection_exists("missing") is CollectionExistence.UNAVAILABLE
+    assert store.list_collections() == []
 
 
 # ── test_create_collection_and_delete_collection ──────────────────

--- a/tests/unit/core/memory/test_indexer_collection_recovery.py
+++ b/tests/unit/core/memory/test_indexer_collection_recovery.py
@@ -18,6 +18,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from core.memory.rag.store import CollectionExistence
+
 
 @pytest.fixture
 def anima_dir(tmp_path: Path) -> Path:
@@ -39,7 +41,15 @@ def _make_indexer(anima_dir: Path):
         )
     # Patch embedding generation to return deterministic vectors
     idx._generate_embeddings = MagicMock(return_value=[[0.1] * 4])
+    idx.vector_store.list_collections_checked.side_effect = lambda: _checked_collections(idx.vector_store)
     return idx
+
+
+def _checked_collections(vector_store):
+    try:
+        return vector_store.list_collections()
+    except Exception:
+        return None
 
 
 class TestCollectionExistenceCache:
@@ -48,16 +58,16 @@ class TestCollectionExistenceCache:
     def test_first_call_populates_cache(self, anima_dir: Path):
         idx = _make_indexer(anima_dir)
         idx.vector_store.list_collections.return_value = ["foo", "bar"]
-        assert idx._collection_exists("foo") is True
+        assert idx._collection_exists("foo") is CollectionExistence.EXISTS
         assert idx.vector_store.list_collections.call_count == 1
         # Second call uses cache
-        assert idx._collection_exists("bar") is True
+        assert idx._collection_exists("bar") is CollectionExistence.EXISTS
         assert idx.vector_store.list_collections.call_count == 1
 
     def test_missing_returns_false(self, anima_dir: Path):
         idx = _make_indexer(anima_dir)
         idx.vector_store.list_collections.return_value = ["foo"]
-        assert idx._collection_exists("missing") is False
+        assert idx._collection_exists("missing") is CollectionExistence.MISSING
 
     def test_listing_failure_is_conservative(self, anima_dir: Path):
         """When list_collections raises, we should NOT trigger spurious re-index."""
@@ -65,16 +75,16 @@ class TestCollectionExistenceCache:
         idx.vector_store.list_collections.side_effect = RuntimeError("transient")
         # Be conservative: assume the collection exists rather than
         # forcing a full re-index of everything on a transient error.
-        assert idx._collection_exists("any") is True
+        assert idx._collection_exists("any") is CollectionExistence.UNAVAILABLE
 
     def test_mark_known_adds_to_cache(self, anima_dir: Path):
         idx = _make_indexer(anima_dir)
         idx.vector_store.list_collections.return_value = []
         # Initially not present
-        assert idx._collection_exists("new") is False
+        assert idx._collection_exists("new") is CollectionExistence.MISSING
         # After marking known, present without re-listing
         idx._mark_collection_known("new")
-        assert idx._collection_exists("new") is True
+        assert idx._collection_exists("new") is CollectionExistence.EXISTS
 
 
 class TestIndexFileCollectionRecovery:
@@ -135,6 +145,23 @@ class TestIndexFileCollectionRecovery:
         chunks = idx.index_file(f, "knowledge")
         assert chunks > 0, "should have re-indexed despite hash match"
         assert idx.vector_store.upsert.called, "must recreate collection via upsert"
+
+    def test_unavailable_collection_check_does_not_reindex_or_embed(self, anima_dir: Path):
+        idx = _make_indexer(anima_dir)
+        idx.vector_store.upsert.return_value = True
+        f = anima_dir / "knowledge" / "topic.md"
+        f.write_text(self._SAMPLE_MD, encoding="utf-8")
+
+        assert idx.index_file(f, "knowledge") > 0
+        idx._known_collections = None
+        idx.vector_store.list_collections_checked.side_effect = None
+        idx.vector_store.list_collections_checked.return_value = None
+        idx.vector_store.upsert.reset_mock()
+        idx._generate_embeddings.reset_mock()
+
+        assert idx.index_file(f, "knowledge") == 0
+        idx._generate_embeddings.assert_not_called()
+        idx.vector_store.upsert.assert_not_called()
 
 
 class TestIndexConversationSummaryRecovery:

--- a/tests/unit/core/memory/test_rag_repair.py
+++ b/tests/unit/core/memory/test_rag_repair.py
@@ -37,6 +37,9 @@ class _RebuiltStore:
     def list_collections(self) -> list[str]:
         return list(self._collections)
 
+    def list_collections_checked(self) -> list[str] | None:
+        return self.list_collections()
+
 
 def test_classifies_today_error_finding_id():
     err = "Error executing plan: Internal error: Error finding id"
@@ -89,6 +92,17 @@ def test_chroma_transient_is_not_single_shot_and_does_not_start_repair(data_dir:
 def test_collection_owner_uses_default_anima_for_shared_collection():
     assert collection_owner("shared_common_knowledge", default_anima="sora") == ("sora", True)
     assert collection_owner("mikoto_knowledge") == ("mikoto", False)
+
+
+def test_rebuild_verification_rejects_unavailable_collection_list(monkeypatch):
+    from core.memory.rag.repair_rebuild import RebuildVerificationError, verify_rebuilt_vectordb
+
+    store = MagicMock()
+    store.list_collections_checked.return_value = None
+    monkeypatch.setattr("core.memory.rag.singleton.get_vector_store", lambda anima_name=None: store)
+
+    with pytest.raises(RebuildVerificationError, match="unreadable"):
+        verify_rebuilt_vectordb("sora", expected_chunks=1)
 
 
 def test_record_chroma_error_triggers_after_threshold(data_dir: Path):
@@ -824,6 +838,9 @@ class _FakeBuildStore:
 
     def list_collections(self) -> list[str]:
         return list(self._collections)
+
+    def list_collections_checked(self) -> list[str] | None:
+        return self.list_collections()
 
     def close(self) -> None:
         self.closed = True

--- a/tests/unit/core/memory/test_rag_search_index_gaps.py
+++ b/tests/unit/core/memory/test_rag_search_index_gaps.py
@@ -156,6 +156,7 @@ class TestColdCatchupIndexing:
             return True
 
         mock_store.list_collections.side_effect = _list_collections
+        mock_store.list_collections_checked.side_effect = _list_collections
         mock_store.upsert.side_effect = _upsert
 
         def _make_real_indexer(vector_store, anima_name, anima_dir_arg, **kwargs):
@@ -313,5 +314,5 @@ class TestSkillsKeywordFallback:
             )
 
         sources = [r["source_file"] for r in results]
-        assert any("common_skills/shared-deploy/SKILL.md" == s or "shared-deploy" in s for s in sources)
+        assert any(s == "common_skills/shared-deploy/SKILL.md" or "shared-deploy" in s for s in sources)
         assert any(r["memory_type"] == "common_skills" for r in results)

--- a/tests/unit/core/memory/test_rag_search_shared_index.py
+++ b/tests/unit/core/memory/test_rag_search_shared_index.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from core.memory.rag.indexer import IndexDirectoryResult
+from core.memory.rag.store import CollectionExistence
 from core.memory.rag_search import (
     RAGMemorySearch,
     _compute_dir_hash,
@@ -228,7 +229,7 @@ class TestEnsureSharedKnowledgeChangeDetection:
         mock_vs = MagicMock()
         # Simulate the shared collection existing in the vector store
         # so the existence check after hash match also passes.
-        mock_vs.list_collections.return_value = ["shared_common_knowledge"]
+        mock_vs.collection_exists.return_value = CollectionExistence.EXISTS
         rag._indexer = MagicMock()
 
         with patch("core.memory.rag.MemoryIndexer") as MockIdx:
@@ -284,7 +285,7 @@ class TestEnsureSharedKnowledgeChangeDetection:
         (common_knowledge_dir / "guide.md").write_text("# Guide")
         mock_vs = MagicMock()
         # First call: no collection yet, should index normally
-        mock_vs.list_collections.return_value = []
+        mock_vs.collection_exists.return_value = CollectionExistence.MISSING
         rag._indexer = MagicMock()
 
         with patch("core.memory.rag.MemoryIndexer") as MockIdx:
@@ -312,6 +313,29 @@ class TestEnsureSharedKnowledgeChangeDetection:
                 "common_knowledge",
                 force=True,
             )
+
+    def test_unavailable_collection_does_not_force_reindex(
+        self,
+        rag: RAGMemorySearch,
+        common_knowledge_dir: Path,
+    ) -> None:
+        (common_knowledge_dir / "guide.md").write_text("# Guide")
+        mock_vs = MagicMock()
+        rag._indexer = MagicMock()
+
+        with patch("core.memory.rag.MemoryIndexer") as MockIdx:
+            mock_shared = MagicMock()
+            mock_shared.index_directory.return_value = IndexDirectoryResult(chunks_indexed=5, files_indexed=1)
+            MockIdx.return_value = mock_shared
+            rag._ensure_shared_knowledge_indexed(mock_vs)
+
+            MockIdx.reset_mock()
+            mock_shared.reset_mock()
+            mock_vs.collection_exists.return_value = CollectionExistence.UNAVAILABLE
+            rag._ensure_shared_knowledge_indexed(mock_vs)
+
+            MockIdx.assert_not_called()
+            mock_shared.index_directory.assert_not_called()
 
 
 class TestEnsureSharedSkillsChangeDetection:
@@ -358,7 +382,7 @@ class TestEnsureSharedSkillsChangeDetection:
         skill_dir.mkdir()
         (skill_dir / "SKILL.md").write_text("# Deploy")
         mock_vs = MagicMock()
-        mock_vs.list_collections.return_value = ["shared_common_skills"]
+        mock_vs.collection_exists.return_value = CollectionExistence.EXISTS
         rag._indexer = MagicMock()
 
         with patch("core.memory.rag.MemoryIndexer") as MockIdx:
@@ -385,7 +409,7 @@ class TestEnsureSharedSkillsChangeDetection:
         skill_dir.mkdir()
         (skill_dir / "SKILL.md").write_text("# Deploy")
         mock_vs = MagicMock()
-        mock_vs.list_collections.return_value = []
+        mock_vs.collection_exists.return_value = CollectionExistence.MISSING
         rag._indexer = MagicMock()
 
         with patch("core.memory.rag.MemoryIndexer") as MockIdx:

--- a/tests/unit/core/memory/test_vector_worker_app.py
+++ b/tests/unit/core/memory/test_vector_worker_app.py
@@ -657,9 +657,24 @@ def test_vector_worker_native_exception_does_not_escape_asgi(monkeypatch) -> Non
     ):
         resp = client.post("/list-collections", json={"anima_name": "natsume"})
 
-    assert resp.status_code == 200
-    assert resp.json() == {"collections": []}
+    assert resp.status_code == 503
+    assert resp.json() == {"detail": "Vector store unavailable"}
     reset.assert_called_once_with("natsume")
+
+
+def test_vector_worker_list_store_unavailable_returns_503(monkeypatch) -> None:
+    monkeypatch.delenv("ANIMAWORKS_VECTOR_URL", raising=False)
+
+    from core.memory.rag.vector_worker import create_app
+
+    with (
+        patch("core.memory.rag.singleton.get_vector_store", return_value=None),
+        TestClient(create_app()) as client,
+    ):
+        resp = client.post("/list-collections", json={"anima_name": "sora"})
+
+    assert resp.status_code == 503
+    assert resp.json() == {"detail": "Vector store unavailable"}
 
 
 def test_vector_worker_write_endpoints_success(monkeypatch) -> None:

--- a/tests/unit/core/supervisor/test_daily_indexing.py
+++ b/tests/unit/core/supervisor/test_daily_indexing.py
@@ -12,6 +12,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from core.memory.rag.indexer import IndexDirectoryResult
+from core.memory.rag.store import CollectionExistence
+from core.memory.rag_search import _compute_dir_hash, _write_shared_hash
 from core.supervisor._mgr_scheduler import _marker_dir
 
 
@@ -236,6 +238,38 @@ async def test_daily_indexing_does_not_write_shared_hash_after_failure(tmp_path:
     meta_path = sup.animas_dir / "sakura" / "index_meta.json"
     if meta_path.exists():
         assert "shared_common_knowledge_hash" not in json.loads(meta_path.read_text(encoding="utf-8"))
+
+
+@pytest.mark.asyncio
+async def test_daily_indexing_skips_shared_reindex_when_collection_unavailable(tmp_path: Path) -> None:
+    sup = _make_supervisor(tmp_path)
+    anima_dir = sup.animas_dir / "sakura"
+    _create_anima_dir(sup.animas_dir, "sakura")
+    common_knowledge = tmp_path / "common_knowledge"
+    common_knowledge.mkdir()
+    (common_knowledge / "guide.md").write_text("# Guide", encoding="utf-8")
+    meta_path = anima_dir / "index_meta.json"
+    _write_shared_hash(
+        meta_path,
+        "shared_common_knowledge_hash",
+        _compute_dir_hash(common_knowledge, "*.md"),
+    )
+
+    mock_store = MagicMock()
+    mock_store.collection_exists.return_value = CollectionExistence.UNAVAILABLE
+    with (
+        patch("core.paths.get_data_dir", return_value=tmp_path),
+        patch("core.memory.rag.singleton.get_vector_store", return_value=mock_store),
+        patch("core.memory.rag.MemoryIndexer") as mock_indexer_cls,
+        patch("core.paths.get_common_knowledge_dir", return_value=common_knowledge),
+        patch("core.paths.get_common_skills_dir", return_value=tmp_path / "common_skills"),
+    ):
+        mock_indexer_cls.return_value.index_directory.return_value = IndexDirectoryResult()
+        await sup._run_daily_indexing()
+
+    mock_store.collection_exists.assert_called_once_with("shared_common_knowledge")
+    assert mock_indexer_cls.call_count == 1
+    mock_indexer_cls.return_value.index_directory.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 概要
RAG再indexチャーン止血の第1弾。worker障害/503/repair fenceを`list_collections()`が`[]`に潰す偽陽性が「collection missing despite tracked hash」（日266〜601件）→force再index→GPU100%の起点。存在判定を三値化し「不明なら再indexしない」を実効化する。

## 変更
- `CollectionExistence`（exists/missing/unavailable）をVectorStore interfaceに正式定義（hasattr feature detection禁止方針準拠）
- worker `/list-collections`: unavailable/native errorを503へ（200空list廃止）
- checked API移行: shared判定・MemoryIndexer・daily scheduler・repair verification・CLI full-delete
- 正常な空DBの自己回復は従来維持。既存fail-soft APIは無変更

## 検証
- `pytest tests/unit -k 'vector or index or collection or shared'` → 666 passed（PdM再実行済み）
- ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)