### PR TITLE
docs(spec): プロセスモデル再設計 仕様確定PR + status.json保護 (PR-1a)

### DIFF
--- a/core/execution/_sdk_security.py
+++ b/core/execution/_sdk_security.py
@@ -35,6 +35,7 @@ _PROTECTED_FILES = frozenset(
         "permissions.json",
         "identity.md",
         "bootstrap.md",
+        "status.json",
     }
 )
 

--- a/core/execution/codex_sdk.py
+++ b/core/execution/codex_sdk.py
@@ -1866,9 +1866,7 @@ class CodexSDKExecutor(BaseExecutor):
 
             items = getattr(turn, "items", []) or []
             response_parts = [
-                text
-                for item in items
-                if _item_type(item) == "agent_message" and (text := _extract_item_text(item))
+                text for item in items if _item_type(item) == "agent_message" and (text := _extract_item_text(item))
             ]
             response_parts.append(getattr(turn, "final_response", "") or "")
             response_text = join_answer_parts(response_parts)

--- a/core/tooling/handler_base.py
+++ b/core/tooling/handler_base.py
@@ -85,6 +85,7 @@ _PROTECTED_FILES = frozenset(
         "permissions.json",
         "identity.md",
         "bootstrap.md",
+        "status.json",
         "state/bm25_longterm_index.json",
         "state/bm25_longterm_index.dirty",
     }

--- a/docs/specs/20260807_ipc-v2-task-runner.md
+++ b/docs/specs/20260807_ipc-v2-task-runner.md
@@ -1,0 +1,155 @@
+# IPC v2 root⇔task runner wire仕様
+
+## 1. 適用範囲と互換境界
+
+本仕様は Phase 2/3 の anima root と、1 jobにつき1つ生成される task runner の間だけに適用する。task runner は root が公開する1つの endpoint に接続し、jobの開始から終了まで **1本の永続 duplex connection** を使う。transport は Unix socket 固定ではなく、既存の `core/supervisor/transport.py:44-69,141-197,200-236` を使い、`ANIMAWORKS_IPC_TRANSPORT`、Windows、socket path長超過時のloopback TCP fallbackを維持する（C-07）。
+
+server⇔root は現行の `IPCRequest` / `IPCResponse` / `IPCEvent` JSON Linesと、stream専用connectionの IPC-STREAMを変更しない。現行型は `core/supervisor/ipc.py:37-115`、requestごとのconnectionは `core/supervisor/ipc.py:269-291,286-340,342-398,488-506` にある。特に `IPCResponse.chunk` はJSON objectではなくJSON文字列であり、serverが再度 `json.loads()` する二重JSONを維持する（`core/supervisor/streaming_handler.py:150-160`、`server/routes/chat_producer.py:106-136`）。本仕様の実装でserver API、SSE event名、terminal responseを変更してはならない（A-01/B-01）。
+
+## 2. framingと共通envelope
+
+- UTF-8 JSON Lines。1 message = 1 JSON object + `\n`。embedded改行はJSON escapeする。
+- `v` は整数 `2`、`kind` は `request | response | event`。
+- 全messageに `job_id` と送信側connection内で単調増加する `seq` を持たせる。`seq` は1から始まり、再接続時も同じattemptでは巻き戻さない。
+- job識別は `(job_id, attempt, root_epoch)`。`attempt` は1始まり、`root_epoch` はroot起動ごとに変わるUUID。
+- request/responseには `request_id` を必須とし、responseは同じ値を返す。eventは `event` と `data` を持つ。
+- `lane` はdispatch用の `chat | heartbeat | cron | task | background`。`greet`/`bootstrap`は`chat`、`inbox`は`cron`相当、`consolidation`は`background`へ割り当て、root内でLLMまたは外部CLIを実行する経路を残さない（B-05）。
+- `display_lane` はbusy sidecar互換用の具体名で、rootがspawn時に確定してregistryへ保存する。runnerが変更してはならず、`hello`/`progress`との不一致は`PROTOCOL_ERROR`とする。
+- 未知の必須field、未知の`kind`、型不一致、不正な`v`は `PROTOCOL_ERROR` を返してconnectionを閉じる。未知の任意capabilityは無視できる。
+
+共通fieldは次のとおり。
+
+| field | 型 | 契約 |
+|---|---:|---|
+| `v` | integer | 常に`2` |
+| `kind` | string | `request` / `response` / `event` |
+| `job_id` | string | rootがspawn前に発行した不変ID |
+| `seq` | integer | 方向別・attempt内で単調増加 |
+| `root_epoch` | string | root process generation UUID |
+| `attempt` | integer | 同じ論理taskの実行attempt |
+| `lane` | string | 上記5 laneのいずれか |
+| `display_lane` | string | 既存busy sidecarの`lanes[]`へ出す具体名 |
+
+`display_lane` は `chat/greet/bootstrap`=`conversation:{thread_id|default}`、`inbox`=`inbox`、`heartbeat/cron/consolidation`=`background`、pool型TaskExec=`background-worker:{slot_id}:{task_id}` とする。poolを使わない互換TaskExecだけは現行どおり`background`とする。rootはactive registryの全jobからこの値を集約し、既存payload、root PID、文字列形式を変えずにbusy sidecarへ書く。
+
+## 3. message例
+
+### 3.1 request
+
+rootとtask runnerのどちらからも送信できる。受信側は `(job_id, attempt, request_id)` で重複排除し、同一requestの再送には最初と同じresponseを返す。
+
+```json
+{"v":2,"kind":"request","job_id":"job-7f2","seq":17,"root_epoch":"550e8400-e29b-41d4-a716-446655440000","attempt":1,"lane":"chat","display_lane":"conversation:default","request_id":"req-91","method":"memory.search","params":{"query":"契約更新","limit":5}}
+```
+
+### 3.2 response
+
+成功時だけ`result`、失敗時だけ`error`を持つ。両方または両方なしは禁止する。
+
+```json
+{"v":2,"kind":"response","job_id":"job-7f2","seq":18,"root_epoch":"550e8400-e29b-41d4-a716-446655440000","attempt":1,"lane":"chat","display_lane":"conversation:default","request_id":"req-91","result":{"status":"ok","items":[{"id":"chunk-12","text":"..."}]}}
+```
+
+unavailableの例:
+
+```json
+{"v":2,"kind":"response","job_id":"job-7f2","seq":21,"root_epoch":"550e8400-e29b-41d4-a716-446655440000","attempt":1,"lane":"chat","display_lane":"conversation:default","request_id":"req-92","error":{"code":"UNAVAILABLE","message":"memory queue is full","retryable":true,"retry_after_ms":250}}
+```
+
+### 3.3 eventとACK
+
+SSE chunkの例。`data.chunk`は意図的にJSON文字列のままとし、objectへ正規化しない。
+
+```json
+{"v":2,"kind":"event","job_id":"job-7f2","seq":19,"root_epoch":"550e8400-e29b-41d4-a716-446655440000","attempt":1,"lane":"chat","display_lane":"conversation:default","event":"stream_chunk","data":{"chunk":"{\"type\":\"text_delta\",\"text\":\"更新します\"}"}}
+```
+
+ACKはeventとして表し、`ack_seq`まで同方向に連続して受理済みであることを示す累積ACKとする。ACK event自体にACKを返さない。
+
+```json
+{"v":2,"kind":"event","job_id":"job-7f2","seq":12,"root_epoch":"550e8400-e29b-41d4-a716-446655440000","attempt":1,"lane":"chat","display_lane":"conversation:default","event":"ack","data":{"ack_seq":19}}
+```
+
+## 4. handshake、ACK、再送
+
+1. rootはjob registryへ `job_id`、`attempt`、`root_epoch`、task PID/pgid、`lane`、`display_lane`、run用`request_id`を登録してからspawnする。
+2. task runnerが接続し、最初のmessageとして `hello` eventを送る。`display_lane`は他messageと同じくtop-levelに置き、`data`に`capabilities`、`last_received_seq`、`last_acked_seq`を含める。rootはspawn時のregistryと照合し、`hello_ack`を返す。不一致は`STALE_ROOT`または`UNKNOWN_JOB`で拒否する。
+3. handshake後、rootはregistryに保存した`request_id`で `method="run"` requestを送り、job入力を`params`へ載せる。runnerのterminal `job_result`は必ずこのrun requestへのresponseで、同じ`request_id`を返す。再接続時もrun request IDを変えない。
+4. ACKは「frameを検証し、重複排除/replay stateへ受理した」ことを意味し、request処理の成功を意味しない。処理結果は必ずresponseで返す。
+5. ACK未受信messageは送信側replay bufferに保持する。ただし `event="ack"` frameだけはACK対象でもreplay対象でもなく、送信完了時に破棄する（その`seq`自体は受信側の連続seqを進める）。切断後は同じ `(job_id, attempt, root_epoch)` で再接続し、双方が申告した連続seqの次からACK以外の同じmessageを再送する。
+6. eventはseqで重複排除する。requestは`request_id`でも重複排除し、state mutationを二度適用しない。terminal responseはrootがjob終了までcacheする。
+7. 新しい`root_epoch`へ旧attemptは再接続できない。旧child/pgidを回収し、descriptorをinterrupted/retryableとして処理する。同一attemptを再claimしない。外部副作用のexactly-onceは保証しない。
+
+## 5. payload上限とbackpressure
+
+現行reader上限16 MiB、write chunk 1 MiBは `core/supervisor/ipc.py:29-32,154-176` にある。v2は以下を固定する。
+
+- 1 frameのUTF-8 byte長（末尾`\n`を除く）は最大 **4 MiB**。送信前と受信後の両方で検査する。したがって合法な1 frameは空の未ACK windowへ必ず収容できる。
+- 各方向の未ACK windowは **64 frameか4 MiBの小さい方**。connectionのoutbound queue全体は **256 frameか16 MiBの小さい方**。
+- windowが満杯なら新規requestの受付を止め、既に受けたrequestには `UNAVAILABLE` / `retryable=true` を返す。root memory APIの有界queue超過も同じであり、空配列や空文字を成功として返さない。
+- `writer.drain()`またはACKが5秒進まない場合はslow consumerと判定し、送信可能なら `BACKPRESSURE_TIMEOUT` をterminal errorとして送ってconnectionを閉じる。送信不能ならroot registryへ同errorを記録してjobを失敗扱いにする。無言dropは禁止する。
+- 上限超過requestには `PAYLOAD_TOO_LARGE` responseを返す。上限超過response/eventを生成した側は同codeでjobを失敗させる。暗黙のtruncateは禁止する。
+- `ack`、`grace`、`cancel`、heartbeatに加え、受理済みrequestへ返す `UNAVAILABLE` / `BACKPRESSURE_TIMEOUT` / `PAYLOAD_TOO_LARGE` error responseはcontrol reserve（8 frame・合計512 KiB）を使い、data window飽和中も送れる。reserve用errorはpayload本体やstack traceを含めず64 KiB以下の定型envelopeとし、`request_id`、code、簡潔なmessage、retry情報だけを返す。したがってwindow満杯を理由にerror responseをdata queueへ待たせたりdropしたりしない。reserveも詰まればconnectionを異常終了し、root registryへ同errorと対象request IDを記録する。
+
+## 6. stream中継
+
+task runnerはthinking/tool/text等の既存chunkを `stream_chunk` eventで送る。`data.chunk`に現在の `json.dumps(chunk, ensure_ascii=False)` の結果をそのまま格納する。rootはこれを現行 `IPCResponse(stream=True, chunk=<JSON文字列>)` に戻してserverへ流す。現行event種別のforwardは `core/supervisor/streaming_handler.py:150-229`、terminalは同ファイル `183-195,231-271` に一致させる。
+
+- runner正常完了: §4でrootが送った`run` requestと同じ`request_id`の `job_result` responseを返す。chatではrootが現行 `stream=true, done=true, result={response,replied_to,cycle_result}` へ変換する。
+- runner失敗: `job_result`を空成功にせず、`EXECUTION_ERROR`等のerror responseへ変換する。
+- keepaliveは既存server向けchunk形式を維持するが、v2のhalf-open heartbeatとは別物である。
+- server死は現行同等にSSE再接続時のresponse ID喪失を許容する。root/task死はjournal回復により最大損失1秒または500文字で、表示済みprefixを重複させない（C-05）。根拠となる現行buffer値は `core/memory/streaming_journal.py:38-40`。
+
+## 7. control event、steer、lane規律
+
+- `progress`: runner→root。`data`にtask PID/pgid、lane、job ID、spawn時の`display_lane`、progress時刻を含め、rootのtask registryを更新する。rootは`display_lane`をregistry値と照合してbusy sidecarを再構成し、runnerはsidecarを直接書かない。
+- `inject_message`: root→実行中chat runner。同job/PID/sessionを維持し、対応adapterだけがACK後に注入する。
+- `cancel`: root→runner。cancel受付をACKし、終了結果は別のterminal responseで返す。
+- `grace`: root→runner。§9のflushを要求する。
+- `heartbeat`: idle時のhalf-open検知専用。
+
+steer capabilityはengine別にnegotiationする。Mode SはPR-9b冒頭でadapterが同一clientを公開する改修とSDK並行`query()`の実機検証を行う。Mode C/Xを含め、active turn注入を保証できないengineは `steer=false` とする。fallbackは単純なFIFO待ちへ変えず、現行どおり二件目がinterrupt eventを設定してconversation lockを待つ（現行経路 `core/_anima_messaging.py:882-927,940-955`）（B-09）。
+
+cronは同一task名だけ直列、異なるtask名は並行可能、missed runはskipとする。現行の同名skipと独立spawnは `core/supervisor/scheduler_manager.py:849-876` にある（B-06）。
+
+## 8. 異常検知
+
+- 通常trafficが5秒ない側は`heartbeat`を送る。送信済みheartbeatを含め15秒連続でACK/trafficがなければhalf-openとしてsocketを閉じ、再接続規則へ進む。
+- rootはsocketとは別にtask processの終了とpgidを監視する。runnerは親PID/root epochを監視する。EOF、protocol error、PID終了のいずれも無言成功にしない。
+- rootのtask watchdogはregistry内のtaskごとの最終progressを使い、threshold超過時に当該pgidだけをkillする。server supervisorはroot健全性のみを監視し、task hangを理由にrootをkillしない（A-03/A-04/B-02/C-01）。
+- task runnerはrootが明示注入する `ANIMAWORKS_EMBED_URL` と `ANIMAWORKS_RERANK_URL` の**どちらか一方でも**欠落または空なら、connection確立前に起動エラーとする。親環境の暗黙継承やport既定値推測、local model fallbackは禁止する（C-09）。現行runnerへのURL注入位置は `core/supervisor/process_handle.py:176-185` である。
+
+## 9. SIGTERMとgrace
+
+rootがSIGTERMを受けたら新規job受付を停止し、各runnerへ`grace` eventを送る。runnerは次を順に行う。
+
+1. 新規tool/steer受付を止める。
+2. StreamingJournal bufferをflushしfsyncする。
+3. engine別resume情報をfsyncする。
+4. 未完了のroot state mutation requestのresponse/ACKを待つ。
+5. `grace_ack` event（`data.grace_seq`、flush結果、最後のjournal seqを含む）を返し、自然終了する。
+
+rootは`grace_ack`後に当該jobを回収する。deadline超過時だけTERM→KILLへ進み、失敗をjournal orphan recovery対象として記録する。rootはrunner終了ごとにもorphan recoveryを行う。全runnerのgrace処理後、rootはDB queueをdrainしclientをclean closeしてexitする。root drainの観測区間はSIGTERM受信→DB clean close完了とし、`root_drain_duration = db_closed_at - sigterm_received_at - task_grace_wait_seconds` が5秒以内であることを測る。task runner grace待ちは別metricとして記録し、5秒budgetには含めない（A-07）。
+
+## 10. 三値原則とerror code
+
+検索・取得系responseは次の三値を区別する。
+
+1. 成功: `result.status="ok"`。空集合が正しい場合も`items: []`と根拠を持つ。
+2. 確認済み不在: `result.status="not_found"`。
+3. 判定不能/利用不能: `error.code="UNAVAILABLE"`、`retryable=true`。
+
+主要codeは `PROTOCOL_ERROR`、`UNKNOWN_JOB`、`STALE_ROOT`、`PAYLOAD_TOO_LARGE`、`BACKPRESSURE_TIMEOUT`、`UNAVAILABLE`、`CANCELLED`、`EXECUTION_ERROR`。errorは必ず人間可読`message`、再試行可否`retryable`を持つ。timeout、queue full、切断、DB repair中を `""`、`null`、`[]`、`{"status":"completed"}`へ潰してはならない。
+
+## 11. 決定事項トレーサビリティ
+
+| ID | 本仕様での反映 |
+|---|---|
+| A-01 / B-01 | duplex 1本、envelope、ACK、上限、再接続、互換境界 |
+| A-03 / A-04 / B-02 / C-01 | progress一本化、root task registry、rootのみ監視対象 |
+| A-07 | grace→flush/fsync→`grace_ack`→exit |
+| B-05 / B-06 | 全lane割当とcron規律 |
+| B-09 | capability negotiationと現行interrupt fallback |
+| C-05 | server死/root死/task死ごとのstream回復契約 |
+| C-07 | 既存transport抽象とTCP fallback |
+| C-09 | URL明示注入とfail-closed |

--- a/docs/specs/20260807_process-model-flag.md
+++ b/docs/specs/20260807_process-model-flag.md
@@ -1,0 +1,139 @@
+# process_model flag・status.json保護仕様
+
+## 1. 正本とschema
+
+animaごとのprocess topologyの正本は `<anima_dir>/status.json` とする（B-07/B-08）。`config.json`、環境変数、DB、in-memory値を正本にしてはならない。
+
+```json
+{
+  "process_model": "phase2",
+  "task_process_isolation": {
+    "cron": true,
+    "heartbeat": false,
+    "task": false,
+    "background": false
+  },
+  "restart_requested": true
+}
+```
+
+### 1.1 `process_model`
+
+| 値 | 意味 |
+|---|---|
+| field欠落 | 後方互換のため`legacy` |
+| `legacy` | 現runner内で全laneを実行し、現global vector workerを使う |
+| `phase2` | DB所有はlegacyのまま。レーン別サブflagでtask runnerへ段階移行 |
+| `phase3` | chatを含む全LLM/CLI laneをtask runnerへ移し、anima rootが自DBを排他所有 |
+
+値はcase-sensitiveなstringに限定する。未知値、空文字、非stringは`legacy`へ黙ってfallbackしてはならない。resolverは `invalid` として理由を返し、稼働中animaは現在topologyを維持、新規start/restartは拒否してoperator-visible errorを出す。誤値をDB owner切替として適用しない。
+
+### 1.2 `task_process_isolation`
+
+Phase 2だけで使用するobjectで、keyは `cron | heartbeat | task | background`、valueはstrict booleanとする。resolverはまず`process_model`を検証し、`phase2`の場合だけsubflag objectを検証する。Phase 2でobject自体が欠落した場合は全keyを`false`、object内の欠落keyは`false`とする。objectが`null`、array、string等の場合、既知keyのvalueがboolean以外の場合、または未知keyがある場合は設定全体を`invalid`とし、`process_model`不正時と同じく現在topologyを維持して新規start/restartを拒否する。型不正をtruthy/falsey変換してはならない。意味は次のとおり。
+
+| key | `true`時にtask runnerへ移す実行 |
+|---|---|
+| `cron` | scheduled cron、およびcron相当laneのinbox |
+| `heartbeat` | scheduled/manual heartbeat |
+| `task` | TaskExec/pending descriptor |
+| `background` | background tool/LLM、およびconsolidation |
+
+`process_model=legacy`ではsubflagの形や値を検証対象にせず、fieldがあれば無視して全てfalseとして解決しwarningを出す。`phase2`では上記strict validation後の各値を使い、chat/greet/bootstrapはlegacy側に残る。`phase3`でもsubflagの形や値を検証対象にせず、fieldがあればwarningを出した上で全laneをisolation済みとして解決する。phase3書込みtransactionでは `task_process_isolation` を削除する。古いwriterが不正なobjectを残してもresolverはphase3を優先し、stale subflagでlaneをlegacyへ戻さない。`process_model`自体が不正ならsubflagに関係なく常にinvalidである。
+
+Phase 3のlane割当はchat/greet/bootstrap→`chat`、inbox→`cron`、consolidation→`background`であり、rootがLLMまたは外部CLIを実行する経路をゼロにする（B-05）。
+
+### 1.3 有効設定の決定表
+
+| `process_model` | subflag | effective topology |
+|---|---|---|
+| 欠落/`legacy` | 任意（malformed含む） | 全legacy。subflagは無視し、fieldがあればwarning |
+| `phase2` | key欠落 | そのlaneはlegacy |
+| `phase2` | key=`true` | そのlaneだけtask runner |
+| `phase2` | subflag object/value/keyが不正 | invalid。現在topologyを変えずstart/restart拒否 |
+| `phase3` | 任意（malformed含む） | 全task runner + root DB owner。subflagは無視 |
+| 不正なprocess値/型 | 任意 | invalid。現在topologyを変えずstart/restart拒否 |
+
+## 2. resolver拡張位置
+
+現行は `core/config/resolver.py:23-75` が `status.json` を読み、field列挙でmodel設定だけを抽出し、`core/config/resolver.py:93-155` がstatusを最優先SSoTとしてmergeする。process fieldは現行schema `core/config/schemas.py:61-107` に存在しない。
+
+後続実装では次を行う。
+
+1. `core/config/schemas.py:61-107` 付近に `ProcessModel = Literal["legacy", "phase2", "phase3"]` とstrictなlane subflag modelを追加する。topology設定をLLM用`AnimaDefaults`へ混ぜない。
+2. `core/config/resolver.py:23-75` と同じstatus loaderを使う `resolve_process_model_config(anima_dir)` を追加し、§1のdefault/validation/統合規則を一箇所で適用する。manager、root、UIがJSONを個別解釈してはならない。
+3. process spawn/reconcile側はresolverのtyped結果だけを参照する。field変更を現runner内のmodel reloadだけで適用しない。
+
+既存 `/api/animas/{name}/reload` は `server/routes/animas.py:633-671` からrunner `core/supervisor/runner.py:953-957`、`core/anima.py:498-507`、`core/memory/config_reader.py:27-80` へ進み、ModelConfigをhot reloadする経路である。このAPIはprocess topologyやDB ownershipを切り替えない。
+
+## 3. 反映とrestart契約
+
+management planeがprocess fieldを変更するときは、同じatomic status updateで `restart_requested=true` を設定する。反映経路は既存reconcile `core/supervisor/_mgr_reconcile.py:101-125` とし、flagをconsumeして自動restartする。単なるreload API呼出し、mtime検知、次回job開始によるlazy切替は禁止する。
+
+reconcileは次の順序を守る。
+
+1. statusをvalidationし、現在値とdesired topologyを比較する。
+2. 新規job受付を停止し、実行中taskへIPC v2 graceを送る。
+3. 対象animaを完全停止し、旧task pgid消滅、旧DB ownerのclose完了を確認する。
+4. `phase3`へ移る場合だけglobal worker側の当該anima DB handleが閉じたことをfenceで確認する。**DB ownership切替はanima停止中だけ適用**する。
+5. desired topologyで起動し、startup ACK後に受付を再開する。
+6. 成功したrestart requestをclearする。失敗を空成功にせず、status/監査ログへerrorを残す。
+
+Phase 2ではDB ownerを変更しない。phase3→phase2/legacy rollbackも同じ停止・close・handoff順序を逆向きに行う。新旧ownerが同時にDBをopenする瞬間を作らない。
+
+現行reconcileはrestart前に `restart_requested` を消す（`core/supervisor/_mgr_reconcile.py:115-125`）。後続実装では失敗時にdesired topologyと失敗理由を保持し、再試行/人手修正を可能にする必要がある。
+
+## 4. rollout、統合、rollback
+
+1. 初期状態はfield欠落=`legacy`。
+2. `process_model=phase2` とし、低リスクanimaで `cron` から1 keyずつtrueにする。カナリア中は `worker_pool_size=1` 固定。
+3. `cron → heartbeat → task → background` を検証後、chat切出しとDB handoffの準備が整った時だけ `process_model=phase3` へ一括統合し、subflag objectを削除する。
+4. 全anima phase3化後もlegacy/phase2実装を **1週間** 保持する。この間のrollbackはflag変更+自動restartで行える。
+5. legacy削除は別PRとし、1週間の観測完了後に **takaの明示承認** をgateとする。削除PR merge後は`legacy` rollback不能になるため、resolver/schemaから値を除く変更も同PRで行う（C-08）。
+
+## 5. status.jsonのmodel-facing file tool保護
+
+### 5.1 本PRで保護する経路
+
+`status.json`はreadableだが、anima自身の汎用file toolからはwrite/edit不可とする。deny rootへ追加するとreadまで壊すため、write-onlyの既存protected listを拡張する。
+
+| 経路 | 保護位置 | 結果 |
+|---|---|---|
+| ToolHandler/MCP/LiteLLMの`write_memory_file`, `write_file`, `edit_file` | protected set `core/tooling/handler_base.py:82-92`; canonical判定 `core/tooling/handler_base.py:344-372`; own anima適用 `core/tooling/handler_perms.py:242-249` | `PermissionDenied`。`Path.resolve()`により自己statusへのsymlinkも拒否 |
+| Mode S native Write/Edit | protected set `core/execution/_sdk_security.py:32-40`; check `core/execution/_sdk_security.py:66-150`; hook `core/execution/_sdk_hooks.py:795-819` | write/edit拒否、read許可 |
+
+read pathはwrite flagを立てないため変更しない。回帰testは `tests/unit/tooling/test_handler.py` でstatus write拒否・内容不変・status read許可・通常knowledge write成功を、`tests/unit/execution/test_agent_sdk_security.py` でMode S status write拒否/read許可・通常knowledge write許可を検証する。
+
+### 5.2 残存経路（本PRでは封鎖しない）
+
+以下は調査記録であり、封鎖はスコープ外である。
+
+| 残存経路 | 現状と理由 |
+|---|---|
+| `execute_command` / Mode S Bash | protected-file predicateを通らず、redirectやscriptでwrite可能（`core/tooling/handler_perms.py:362-474`, `core/execution/_sdk_security.py:153-283`）。command sandboxの仕様変更は別PR |
+| Mode C shell / bwrap相当profile | deny有効時もMCP profileはanima rootを書込み可とし、file-specific read-onlyは`permissions.json`だけ（`core/execution/codex_sdk.py:1266-1315`）。denyなしworkspace-write/danger-full-accessも直接write可能 |
+| Mode X Grok sandbox | anima rootが`read_write`で、条件によりsandbox自体を無効化する（`core/execution/grok_cli.py:317-385`） |
+| superuser/debug mode | ToolHandler/Mode Sの保護を明示的にbypassする（`core/tooling/handler_perms.py:185-186`, `core/execution/_sdk_security.py:82-83`） |
+| supervisorの汎用file toolによる配下anima status | descendant management fileとしてwrite許可が先に評価される（`core/tooling/handler.py:204-215`, `core/tooling/handler_perms.py:281-284`, `core/execution/_sdk_security.py:121-125`）。本PRの「animaが自分で書換える穴」とは別 |
+| 専用subordinate management tool | enable/disable/model等の固定fieldを意図的にwriteする `core/tooling/handler_subordinate_control.py:35-64,104-134,260-286`。汎用file toolではなく管理API |
+| human-origin workspace grant | 明示human origin gate後に`default_workspace`を更新する `core/tooling/handler_workspace.py:47-139,241-255` |
+| trusted host/server/CLI/factory/migration/reconcile | management planeとして正当にwriteする。例: `core/anima_factory.py:468-570`, `server/routes/animas.py:427-470`, `core/config/cli.py:168-193,320-344`, `core/supervisor/_mgr_reconcile.py:101-125` |
+
+残存shell経路があるため、本PRの保護は「全filesystem writeをsecurity boundaryとして防ぐ」ものではない。process flagの実運用writeは認証済みmanagement API/CLIに限定し、shell経路のread-only mount化は別Issueで扱う。
+
+## 6. DB ownership safety
+
+- `legacy`/`phase2`: global vector workerがDB owner。root/task runnerがdirect Chromaをopenしない。
+- `phase3`: anima rootが自anima DBの唯一のowner。task runnerはroot Memory APIだけを使う。
+- handoffは停止中のみ、旧owner close ACK→process/handle消滅確認→新owner openの順。
+- flag parse error、restart失敗、close確認不能では旧ownerを維持し、新ownerをopenしない。errorを`UNAVAILABLE`として表面化する。
+- `ANIMAWORKS_EMBED_URL`/`ANIMAWORKS_RERANK_URL`はrootがtask runnerへ明示注入し、欠落時はfail-closedとする。flagでlocal fallbackを有効化できない。
+
+## 7. 決定事項トレーサビリティ
+
+| ID | 本仕様での反映 |
+|---|---|
+| B-07 | status正本、enum/default/invalid、Phase 2 subflagとPhase 3統合 |
+| B-08 | restart_requested、自動restart、停止中DB handoff、status保護 |
+| C-08 | 1週間rollback猶予、legacy削除別PR、taka承認gate |
+| B-05 | phase3の未列挙lane割当とroot LLMゼロ |

--- a/docs/specs/20260807_state-mutation-inventory.md
+++ b/docs/specs/20260807_state-mutation-inventory.md
@@ -1,0 +1,169 @@
+# anima state mutation棚卸し・lease v2仕様
+
+## 1. 所有権の原則
+
+本表は現HEAD `b2586dcc0a87981cb3c3d2eeb57be500a89aea1c` の書込み経路を対象とする。
+
+- Phase 2はstateの直接書込みを維持する。ただしカナリア中は `background_task.worker_pool_size=1` に固定し、`current_state.md` とconversation JSONにはプロセス間advisory lockを追加する（A-06/C-04）。
+- busy sidecarはPhase 2からrootが唯一のwriterとなる。task runnerの既存busy helperはDIで無効化し、IPC progressだけをrootへ送る（A-03/A-04/B-02/C-01）。
+- Phase 3はconversation stateと`index_meta.json`をroot APIへ移す。完成形ではmemory/state mutationをroot APIへ集約する。ただしStreamingJournal、stream checkpoint、engine resume情報はtask runnerの単一writerを維持し、終了前fsyncを必須にする（A-08/C-06）。
+- `status.json`はmanagement planeの正本であり、本PRではmodel-facing file toolによる自己書込みだけを拒否する。詳細は `20260807_process-model-flag.md` に記す。
+
+## 2. 必須stateの棚卸し
+
+| file/resource | 現行writer（process・コード位置） | 現行排他/耐障害性 | Phase 2 | Phase 3 |
+|---|---|---|---|---|
+| `state/current_state.md` | runner/model tool: `core/memory/manager.py:460-461`, `core/tooling/handler_files.py:461-477,538-593`, `core/tooling/handler_memory.py:868-969,1107-1114`; HB: `core/_anima_heartbeat.py:406-425`; conversation finalize: `core/memory/conversation_finalize.py:264-278`; server housekeeping: `core/memory/taskboard_housekeeping.py:228-270,555-575` | atomic replaceまたはplain write。tool経路だけprocess内`threading.Lock`（`core/anima.py:124-135`, `core/tooling/handler.py:461-481`）。プロセス間排他なし | **advisory lock追加対象**。全writerがread-modify-write全体を同じlockで囲む | root state API、root sole-writer |
+| `state/conversation.json`, `state/conversations/{thread}.json` | runner `ConversationMemory`。path/cache/lock: `core/memory/conversation.py:103-131`; save: `178-190`; clear: `293-296` | thread別`asyncio.Lock`はprocess内のみ。cached whole-fileをatomic replaceするため複数processでlost updateし得る | **advisory lock追加対象**。lock取得後にdiskから再loadし、mutationとreplaceまで保持。カナリアpool=1 | 決定済みroot conversation API、root sole-writer |
+| `transcripts/{date}.jsonl` | runner `ConversationMemory.write_transcript`: `core/memory/conversation.py:227-264` | append+flush+fsync、lockなし | conversation lane規律下の直接append。conversation lock範囲に参加 | root conversation API経由append |
+| `index_meta.json` | runner/vector indexer `core/memory/rag/indexer.py:257-263,518-523,684-687`; shared hash RMW `core/memory/rag_search.py:74-86,231-251,266-294,316-346,387-406`; server daily index `core/supervisor/_mgr_scheduler.py:667-803`; repair `core/memory/rag/repair_rebuild.py:179-184,289-293`; skill curator `core/skills/curator.py:491-501` | 一部plain truncate、複数経路の無lock RMW | vector worker所有は現行のまま。直接writeを維持し既存競合を既知リスクとして扱う | 決定済みroot Memory API sole-writer。DB操作成功後だけmetadata commit |
+| `vectordb/**` | global vector worker `core/memory/rag/vector_worker.py:51-54,217-247`; repair staging/swap `core/memory/rag/repair_rebuild.py:218-283` | worker内`ThreadPoolExecutor(max_workers=1)`。repair operationは`state/rag_repair.lock`（`core/memory/rag/repair_utils.py:120-136`） | global worker/proxy維持 | anima rootごとの単一client/単一worker thread/有界queue。staging repair subprocessだけdirect access可 |
+| `run/animas/{name}.busy.json` | 現runner `DigitalAnima`: write `core/anima.py:318-385`; clear `389-408`; server reader/kill `core/supervisor/_mgr_health.py:37-75,180-237,627-639` | PID付きtemp+replace、lockなし。子がhelperを使うと相互上書き可能 | **root sole-writer**。既存payload、root PID、lane名を維持。task healthはroot registryで判定し当該pgidだけkill | 同左。server supervisorはroot healthだけ監視 |
+| `state/task_queue.jsonl`, `task_queue_archive.jsonl` | runner/tool/serverの `TaskQueueManager`: `core/memory/task_queue.py:147-165,208-342,351-457`; pending同期 `core/supervisor/pending_executor.py:429-456`; server API `server/routes/taskboard.py:292-310` | appendはprocess内lock + `.lock` advisory lockを試行してfsyncする（`core/memory/task_queue.py:890-938`）。ただしlock file open/acquire失敗時は現実装が**無lockへfail-open**し、`compact()`のarchive/rewriteもlock外（`845-886`） | 既存方式を基礎にするが、後続lock実装ではfail-closed化。pool=1。`compact()`も同lock対象 | root task/state API sole-writer |
+| `shared/taskboard.sqlite3` | server API、runner queue同期、goal/housekeepingから `TaskBoardStore`; write `core/taskboard/store.py:167-263,265-346,388-432` | SQLite transaction + WAL、短命connection（`core/taskboard/store.py:104-129`）。queueとの跨りtransactionなし | SQLiteのwriter serializationを維持 | fleet/UI DBはserver所有、anima更新はroot API。後続PRでownerを一意にする |
+| `state/pending/**`, `state/background_tasks/pending/**` descriptor | tool/SDK/MCP/server作成: `core/tools/__init__.py:152-231`, `core/tooling/handler_delegation.py:240-263`, `core/execution/_sdk_hooks.py:155-203,358-379`, `core/goals/manager.py:171-220`; runner claim/move/delete `core/supervisor/pending_executor.py:921-1133` | pending→processingのrenameがclaim。process内active setだけでprocess間CASなし | 直接descriptor維持、pool=1。root registryのjob/attemptと対応させる | root task API、root sole-writer |
+| `state/background_tasks/{task_id}.json` | runner `BackgroundTaskManager._save_task`: `core/background.py:187-264,300-380,443-452` | plain overwrite、lock/atomic replaceなし | task IDごとの直接write。pool=1 | root task registry/API sole-writer |
+| `state/task_results/{task_id}.md` | runner pending executor write `core/supervisor/pending_executor.py:402-410`; inboxはread-only `core/_anima_inbox.py:234-260`; server housekeeping delete `core/memory/housekeeping.py:1457-1484` | task IDごとのplain overwrite、retention deleteと共通lockなし | task runner単一writer + server retention cleanup。実行中task IDは削除対象外にfence | root task APIがwrite/deleteを一元化 |
+| processing descriptor隣接 `*.json.lease` | 現runner write/validate `core/platform/processing_lease.py:15-95`; claim `core/supervisor/pending_executor.py:301-315` | plain write。現schemaは`pid/anima/leased_at/task_id`、cmdlineは`core.supervisor.runner`固定 | §4のlease v2。rootがlease writer、task processをfence | root sole-writer、同じv2 schema |
+| `shortterm/{lane}/{thread}/session_state.{json,md}`, archive | runner `ShortTermMemory`: `core/memory/shortterm.py:64-145,186-305` | plain overwrite/rename、lock/fsyncなし | task runner直接、lane規律とpool=1で単一writer | task runner所有の例外。終了前fsync |
+| `shortterm/**/stream_checkpoint.json` | runner `core/memory/shortterm.py:206-245`; stream cleanup `core/supervisor/streaming_handler.py:60-73` | plain overwrite/unlink、lock/fsyncなし | task runner単一writer | 同左、grace/終了前fsync |
+| `shortterm/streaming_journal_*.jsonl`, thread journal | runner `StreamingJournal`: path/open `core/memory/streaming_journal.py:63-130`; buffer/finalize `132-224`; fsync `442-472` | 同一path 1 writerが暗黙前提。eventはflush+fsync、textは最大1秒/500文字buffer | task runner sole-writer。root SIGTERM→grace→child flush+ACK。rootはtask終了時もorphan回収 | 同左（A-07） |
+| Mode S `state/current_session_*.json` | runner `core/execution/_sdk_session.py:125-197` | plain overwrite/unlink、lock/fsyncなし | task runner直接 | 現行配置を維持し終了前fsync |
+| Mode C `shortterm/**/codex_thread_id.txt` | runner `core/execution/codex_sdk.py:381-418` | plain overwrite/unlink | 同上 | 同上 |
+| Mode X `shortterm/**/grok_session_id.txt` | runner `core/execution/grok_cli.py:123-164` | plain overwrite/unlink | 同上 | 同上 |
+| Mode D `shortterm/**/cursor_chat_id.txt` | runner `core/execution/cursor_agent.py:91-139` | plain overwrite/unlink | 同上。A-08のS/C/X列挙外だが実在するため同じ規律 | 同上 |
+| `state/heartbeat_checkpoint.json`, `state/recovery_note.md` | HB runner `core/_anima_heartbeat.py:551-575,669-677,738-742,788-834`; runner orphan recovery `core/supervisor/runner.py:369-462` | plain write/unlink、lockなし | heartbeat task runner単一writer、grace対象 | root trigger + task runner実行。回収/次回注入はroot管理 |
+| `state/cron_logs/*.jsonl` | runner `CronLogger`: `core/memory/cron_logger.py:22-84` | `.lock` + advisory lock + append/fsync。bounded rewriteもlock内 | 維持 | root append APIまたはroot sole-writer |
+| `state/cron_stats.json`, `state/cron_disabled.json` | runner scheduler `core/supervisor/scheduler_manager.py:407-428,460-557` | temp+replace、プロセス間lockなし | scheduling ownerとなるrootへ寄せる | root sole-writer |
+| `state/background_notifications/*.md` | runner completion `core/anima.py:569-586`; scheduler `core/supervisor/scheduler_manager.py:580-590,726-745`; token cap `core/_agent_cycle.py:183-207` | ID/timestamp別file、lockなし | 直接write維持、rootが回収 | root notification API |
+| `state/inbox_read_counts.json`, `overflow_inbox/*.md` | inbox runner `core/_anima_inbox.py:977-1038`; overflow `core/memory/dedup.py:31-93` | countsは無lockRMW、overflowはunique filename | inbox=cron相当laneの直接write | root inbox/state API |
+| `state/goal_state.jsonl` | runner/tool `GoalManager`: `core/goals/manager.py:301-323` | append+fsync、goal lockはthreadingのみ | pool=1で直接append | root task/state API |
+| `state/entity_registry.json` | runner entity index `core/memory/entity_index.py:38-119,333-361` | process lock + advisory lock + atomic replace | 維持 | root Memory API |
+| `state/bm25_longterm_index.*` | runner/server `core/memory/bm25.py:249-278,286-398` | atomic replace、rebuildはO_EXCL singleflight lock | 維持 | root Memory API |
+| `state/rag_upsert_failures.json` | indexer `core/memory/rag/indexer.py:265-301` | temp+replace、無lockRMW | 現indexer owner | root Memory API |
+| `state/rag_repair.json`, `state/rag_repair.lock` | server/repair `core/memory/rag/repair_state.py:27-50`; operation flock `core/memory/rag/repair_utils.py:120-136` | repair operation単位排他、state writeはplain overwrite | server supervisor所有 | root repair owner |
+
+## 3. その他に発見したmutable state
+
+| group | 現行writer・位置 | 現行排他 | Phase 2 → Phase 3 |
+|---|---|---|---|
+| `episodes/*.md`, `knowledge/**`, `procedures/**`, archive | `core/memory/manager.py:440-494`, `core/memory/consolidation.py:116-142`; forgetting merge/archive/delete `core/memory/forgetting.py:1058-1083,1435-1455` | 多くはlockなし。episode appendはfsync、consolidation/forgettingの一部はatomic replace、archive copy/deleteは共通lockなし | 直接write/archive/delete → root Memory API |
+| `facts/*.jsonl` | `core/memory/facts.py:434-487` | process lock + flock + append/fsync/atomic rewrite | 維持 → root Memory API |
+| `activity_log/*.jsonl` | runner/server/MCP `core/memory/activity.py:145-185,291-307` | append+fsync、lockなし | 直接append → root event API |
+| `token_usage/*.jsonl` | runner `core/memory/token_usage.py:134-208` | append、lock/fsyncなし | task runner直接 → root集約 |
+| `token_usage/rollup.json` | token集計時のcache再構築 `core/memory/token_usage.py:317-348,378-402` | JSONLを正本としてatomic write、共通lockなし | cache直接write → root集約。破損時はJSONLから再生成 |
+| `run/action_memory_gate/*.json`, `no_rule_holds.jsonl` | model tool action gate `core/memory/action_gate.py:214-281,286-295,425-497` | session JSONはtemp+replace、notify stateは無lockRMW、hold trailは無lockappend | task runner直接 → root tool-session/state API |
+| `run/replied_to/{session}/{thread}.jsonl` | ToolHandler/engine base `core/tooling/handler.py:548-574`, `core/execution/base.py:661-684` | 無lockappend、engine間で同pathへ書込み得る | task runner直接 → root session API |
+| `state/.consolidation_mode` | consolidation lane `core/_anima_lifecycle.py:401-456`; MCP reader `core/mcp/server.py:623` | plain create/unlink、例外時finally cleanup | background task runner所有 → root registryの明示状態へ移行 |
+| `run/completion_gate_called`, `run/min_trust_seen` | completion gate `core/tooling/handler.py:366-379`, `core/execution/_completion_gate.py:28-68`; trust marker `core/tooling/handler_memory.py:1091-1114,1197-1205`, `core/execution/_sdk_hooks.py:637-645` | session markerのplain write/create、共通lockなし | task runner session artifact。終了時回収 → root session API/registry |
+| `state/pending/.wake`, `state/sdk_stderr.log` | Mode S hook/options `core/execution/_sdk_options.py:247-251,381-390` | wakeはtouch、stderrはSDK subprocess append | task runner artifact。rootはdescriptor wake/diagnosticsとして回収 |
+| `state/skill_usage.jsonl`, curator/promotion/activation state | `core/skills/usage.py:78-123`, `core/skills/curator.py:205-280,410-438`, `core/skills/activation_state.py:30-91`, `core/skills/autolearn.py:51-64,180-191` | append/plain/temp+replace、共通lockなし | 直接write → root skill/state API |
+| `skills/**`, `state/skill_hub_lock.jsonl`, `state/skill_hub_backups/**` | skill hub install/remove/frontmatter/lock `core/skills/hub.py:136-210,247-267,303-323,350-395`; trust/promotion `core/skills/trust.py:95-113`, `core/skills/promotion.py:501-514`; model-facing scan `core/tooling/handler_skills.py:490-510` | directory move/copy、個別atomic writeまたはplain write、hub audit append。全経路共通のprocess間lockなし | approved tool/management経路の直接mutation。task runner間はskill名単位に直列化 → root skill API/sole-writer |
+| `state/skill_curator/report-*.json`, proposals/reference rewrites | server housekeeping report生成・retention delete `core/memory/housekeeping.py:653-683,1419-1454`; runner curator `core/skills/curator.py:131-149,217-218`; reference rewrite `core/skills/reference_rewriter.py:49-147` | report plain write/delete、提案file単位、共通lockなし | server scheduler/curator laneの直接mutation → root skill APIが生成・削除を一元化 |
+| `state/memory_hygiene.json`, consolidation carryover | `core/memory/hygiene.py:35-95`, `core/memory/consolidation.py:146-235` | atomic replace、lockなし | scheduler/lane owner → root |
+| `state/cmd_output/**` | task runner tool `core/tooling/handler_files.py:604-618`; machine toolのwrite本体 `core/tools/machine.py:450-490` とpath/call `682-699` | ID別artifact、lockなし | task runner artifactのまま。root registryは参照だけ保持 |
+| `state/bootstrap_state.json`, archive | management/server `core/bootstrap_state.py:41-82,367-449` | temp+replace | root起動前management plane。task runner書込み禁止 |
+| `state/event_export_spool/*` | activity/token exporter `core/event_export.py:32-109,185-241` | UUID+atomic rename、worker thread lock | runnerごと → root observability worker |
+| `vectordb/knowledge_graph.json` | server/index `core/memory/rag/graph.py:341-366`, `core/supervisor/_mgr_scheduler.py:741-765` | direct overwrite、lockなし | server scheduler → root DB owner |
+| `status.json` | factory `core/anima_factory.py:468-570`; server API `server/routes/animas.py:427-470`; CLI `core/config/cli.py:168-193,320-344`; management tool `core/tooling/handler_subordinate_control.py:35-64,104-134,260-286`; reconcile `core/supervisor/_mgr_reconcile.py:101-125` | 複数の無lock RMW | management-plane正本。model-facing自己file tool書込み拒否。flag変更はrestart経路、DB handoffは停止中だけ |
+
+server housekeepingは上記の個別行に加えてepisode/hygiene archive、DM/cron log削除、shortterm episode化・削除、facts lock削除、`archive/superseded`・failed descriptor・runtime artifact削除を行う（`core/memory/housekeeping.py:383-650,988-1514,1524-1935`）。Phase 2ではserver maintenance writerと各runnerが競合しないよう対象path/実行中jobをfenceし、Phase 3では各resourceのroot APIへdelete/archive操作も含める。mutation棚卸しの「writer」にはcreate/updateだけでなくrename/archive/deleteも含む。
+
+停止中のanimaを対象にするmerge/migration/factoryも、memory tree、conversation/task queue、status、旧stateのrename/copy/deleteを行うmanagement-plane writerである（`core/lifecycle/anima_merge/service.py:720-770,772-775,1578-1599,1665-1687`, `core/lifecycle/anima_merge/task_refs.py:60-94,202-227`, `core/migrations/steps.py:745-820`, `core/anima_factory.py:468-570,698-704`）。これらはPhase 2/3のruntime writerではなく、対象root/task runner/DB ownerが全停止したことを確認してからだけ実行するoffline mutationと分類する。実行中なら変更せず拒否し、完了後の起動時にresolver/rootが再読込する。
+
+## 4. Phase 2 advisory lock契約
+
+流用元は `TaskQueueManager._locked_queue()` の `threading.RLock + <resource>.lock + acquire_file_lock(exclusive=True)`（`core/memory/task_queue.py:890-920`）、OS抽象は `core/platform/locks.py:32-58` とする。ただし現行task queueはlock file open/acquire失敗時に無lockで処理を続ける。新規2 lockでは構造だけを流用し、失敗時は例外/`UNAVAILABLE`へ**fail-closed**に直す。新しい独自lock方式を作らない。
+
+### 4.1 `current_state.md`
+
+- lock pathは `state/current_state.md.lock`。
+- tool、MemoryManager、HB、conversation finalize、server housekeepingを含む**全writer**が参加する。
+- lock範囲はread/mtime確認から内容merge、temp write、`os.replace()`まで。最終writeだけをlockしてはならない。
+- acquisition失敗時は無lockへfallbackせず、明示error/unavailableとする。state updateを空成功にしない。
+
+### 4.2 conversation JSON
+
+- defaultは `state/conversation.json.lock`、threadは `state/conversations/{thread}.json.lock`。
+- lock取得後にin-memory cacheを捨ててdiskを再読込し、append/compress/finalize/clearとatomic replaceを同じcritical sectionで行う。
+- transcript appendも同threadのconversation mutationに付随する場合は同じlock内で行う。
+
+これらのlock追加実装は後続Phase 2 PRの範囲であり、本PRでは仕様だけを確定する。task queue appendは同patternを試行済みだがfail-openであり、`compact()`もlock外であるため、後続PRで取得失敗をfail-closedにして両方を同lockへ含める。
+
+## 5. processing lease schema v2
+
+### 5.1 JSON schema
+
+v2は既存fieldを残し、次を必須にする（A-05/C-02/B-03）。`pid`はroot PID、`task_pid`は実行child PIDであり、同一値にしてはならない。
+
+```json
+{
+  "schema_version": 2,
+  "pid": 4100,
+  "anima": "sakura",
+  "leased_at": 1786070400.125,
+  "task_id": "task-abc",
+  "job_id": "job-7f2",
+  "task_pid": 4123,
+  "pgid": 4123,
+  "root_epoch": "550e8400-e29b-41d4-a716-446655440000",
+  "attempt": 1,
+  "process_start_time": 1786070400.02
+}
+```
+
+| field | 型/制約 | 意味 |
+|---|---|---|
+| `schema_version` | integer=`2` | version discriminator |
+| `pid` | positive integer | leaseを発行・所有するroot PID（旧fieldを維持） |
+| `anima` | non-empty string | anima名 |
+| `leased_at` | finite number | lease作成Unix time |
+| `task_id` | non-empty string | taskboard/descriptor ID |
+| `job_id` | non-empty string | IPC v2 job ID |
+| `task_pid` | positive integer | task runner PID |
+| `pgid` | positive integer | task runnerと子CLIを含むkill単位 |
+| `root_epoch` | UUID string | root起動generation |
+| `attempt` | integer >= 1 | 論理taskの実行attempt。同一attemptは再claim不可 |
+| `process_start_time` | finite number | `psutil.Process(task_pid).create_time()` のUnix time |
+
+writeは同directoryの一時fileへJSONを書いてflush+fsyncし、`os.replace()`した後directory fsyncを行う。rootだけが作成・更新・削除する。
+
+### 5.2 validatorとPID reuse fence
+
+validatorは内部的に `live | dead | unknown` を返し、既存bool APIは`unknown`を保守的にliveとして扱う。rootはunknown processをkillまたはdescriptor回収してはならず、診断を記録して次周期で再検査する。
+
+1. schema/type/anima/task/job/attemptを検証する。
+2. `root_epoch`を現在のroot registryと照合する。同一なら継続、異なればstale child回収候補とする。
+3. `os.kill(task_pid, 0)`またはpsutilで存在確認する。
+4. 現在の `psutil.Process(task_pid).create_time()` を保存値と比較する。platform精度に合わせて両方をcentisecondへ丸め、一致しなければPID再利用として`dead`とする。
+5. cmdlineに `core.supervisor.task_runner`、対象anima、`job_id`がすべて存在することを確認する。旧rootを確認する場合は `core.supervisor.runner` も許容する。新validatorは `core.supervisor.task_runner` を必ずlive対象に加える。
+6. stale `root_epoch`でもprocess identityが一致するchildだけをpgid単位で回収し、消滅確認後にdescriptorをinterrupted/failedへ移す。PID/開始時刻不一致のprocessへsignalを送らない。
+
+root restart時は「旧child/pgid回収→消滅確認→descriptor recovery」の順とする。同じ`attempt`を再claimしない。明示的な再委譲/再試行は`attempt+1`を新規発行する。外部commitやmessageのexactly-onceは保証せず、現行のVerify要求文言（`core/supervisor/pending_executor.py:821-836,859-875`）を維持する（C-03）。idempotency key導入はスコープ外である。
+
+### 5.3 旧schema互換
+
+`schema_version`がなく、既存4 field `pid/anima/leased_at/task_id`が妥当なfileはv1として読む。v1は現行どおりPID存在とcmdlineの `core.supervisor.runner` + animaで判定する（現行実装 `core/platform/processing_lease.py:45-95`）。
+
+- live v1 leaseは実行中とみなし、その場で書換えない。
+- dead v1 leaseは現行orphan recoveryへ渡す。
+- malformed fileはdead扱いにするが、descriptorを失わずfailed側へ移して監査可能にする。
+- 新規claimと再試行は必ずv2を書く。v1 readerはrollback猶予中および旧fileが残る限り維持する。
+
+## 6. state競合・回復の受入条件
+
+- chat、heartbeat、複数TaskExecを同時実行し、conversation turn、`current_state.md` update、task queue eventが欠落しない。
+- busy hang試験はtask PID/pgidを明示し、threshold + poll周期2回以内に当該pgidだけが消え、root PIDが変わらない。
+- root restart後に同一attemptが再claimされず、旧pgid消滅、descriptor移動、Layer 2 status、notification回数を確認する。
+- task/root死のjournal回復は最大損失1秒または500文字、表示済みprefix重複なしをassertする。
+
+## 7. 決定事項トレーサビリティ
+
+| ID | 本仕様での反映 |
+|---|---|
+| A-03 / A-04 / B-02 / C-01 | busy root sole-writer、task registry、監視分離 |
+| A-05 / C-02 / B-03 | lease v2、task runner cmdline、PID reuse fence、旧schema |
+| C-03 | 同一attempt再claim禁止、exactly-once非保証 |
+| A-06 / C-04 / B-04 | 全mutation棚卸し、Phase 2 lock、Phase 3 root API |
+| A-07 | journal grace/ACKとtask終了時orphan recovery |
+| A-08 / C-06 | engine別resume配置維持とfsync |

--- a/server/github_gateway.py
+++ b/server/github_gateway.py
@@ -445,9 +445,7 @@ class GitHubWebhookManager:
         author_cf = author.casefold()
         bot = self._config.bot_login
         reviewer = self._config.reviewer_login
-        return (bool(bot) and author_cf == bot.casefold()) or (
-            bool(reviewer) and author_cf == reviewer.casefold()
-        )
+        return (bool(bot) and author_cf == bot.casefold()) or (bool(reviewer) and author_cf == reviewer.casefold())
 
     def _send(self, to: str, content: str, kind: str, key: str) -> None:
         Messenger(self._require_shared_dir(), "pr-review-dispatch").send(

--- a/tests/unit/execution/test_agent_sdk_security.py
+++ b/tests/unit/execution/test_agent_sdk_security.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import pytest
 
 from core.config.global_permissions import GlobalPermissionsCache
-from core.paths import PROJECT_DIR
+from core.execution._sdk_hooks import _collect_all_subordinates
 from core.execution.agent_sdk import (
     _PROTECTED_FILES,
     _WRITE_COMMANDS,
@@ -22,7 +22,7 @@ from core.execution.agent_sdk import (
     _sanitise_tool_args,
     _summarise_tool_input,
 )
-from core.execution._sdk_hooks import _collect_all_subordinates
+from core.paths import PROJECT_DIR
 
 
 @pytest.fixture(autouse=True)
@@ -74,6 +74,7 @@ class TestConstants:
         assert "permissions.md" in _PROTECTED_FILES
         assert "identity.md" in _PROTECTED_FILES
         assert "bootstrap.md" in _PROTECTED_FILES
+        assert "status.json" in _PROTECTED_FILES
 
     def test_protected_files_is_frozenset(self):
         assert isinstance(_PROTECTED_FILES, frozenset)
@@ -109,6 +110,11 @@ class TestCheckA1FileAccess:
         result = _check_a1_file_access(path, anima_dir, write=True)
         assert result is not None
         assert "protected file" in result
+
+    def test_write_to_own_status_blocked_but_read_allowed(self, anima_dir: Path):
+        path = str(anima_dir / "status.json")
+        assert _check_a1_file_access(path, anima_dir, write=True) is not None
+        assert _check_a1_file_access(path, anima_dir, write=False) is None
 
     def test_read_own_permissions_allowed(self, anima_dir: Path):
         """Reading protected files should be allowed."""

--- a/tests/unit/tooling/test_handler.py
+++ b/tests/unit/tooling/test_handler.py
@@ -1532,6 +1532,7 @@ class TestMemoryWriteSecurity:
             "permissions.md",
             "identity.md",
             "bootstrap.md",
+            "status.json",
         ],
     )
     def test_write_memory_file_blocked_for_protected(
@@ -1560,6 +1561,13 @@ class TestMemoryWriteSecurity:
         written = (anima_dir / "knowledge" / "safe.md").read_text(encoding="utf-8")
         assert "safe content" in written
         assert written.startswith("---")  # auto-frontmatter
+
+    def test_read_memory_file_status_json_still_allowed(
+        self,
+        handler: ToolHandler,
+    ):
+        result = handler.handle("read_memory_file", {"path": "status.json"})
+        assert json.loads(result) == {}
 
     def test_read_memory_file_cannot_bypass_explicit_deny(self, handler: ToolHandler, anima_dir: Path):
         from core.config.models import PermissionsConfig
@@ -1737,6 +1745,21 @@ class TestFilePermissionWriteProtection:
         )
         parsed = json.loads(result)
         assert parsed["error_type"] == "PermissionDenied"
+
+    def test_write_file_handler_blocks_status_json_without_modifying_it(
+        self,
+        handler: ToolHandler,
+        anima_dir: Path,
+    ):
+        status_path = anima_dir / "status.json"
+        original = status_path.read_text(encoding="utf-8")
+        result = handler.handle(
+            "write_file",
+            {"path": str(status_path), "content": '{"process_model":"phase3"}'},
+        )
+        parsed = json.loads(result)
+        assert parsed["error_type"] == "PermissionDenied"
+        assert status_path.read_text(encoding="utf-8") == original
 
     def test_edit_file_handler_blocks_protected(
         self,


### PR DESCRIPTION
## 概要
Phase 2/3プロセスモデル再設計（root常駐+使い捨てtask runner+DB排他所有）の実装に先立つ仕様確定PR。レビューBlocker（IPC未定義・state競合・lease PID再利用・flag正本）を仕様書として確定する。

## 成果物
- IPC v2 wire仕様書（root⇔task runner永続duplex 1本・kind/job_id/seq/ACK・backpressure契約・server⇔root既存プロトコル無変更）
- state mutation棚卸し表 + lease schema v2仕様
- process_model flag仕様（正本=status.json・reconcile restart_requested反映）
- コード変更はstatus.jsonのprotected list追加のみ（+ Mode S側保護、回帰テスト付き）

## 検証
- 対象UT 338 passed / ruff clean（PdM再実行済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)