### PR TITLE
fix(rag): embedding前write可否確認 + transient打ち切り (P0-2)

### DIFF
--- a/core/memory/entity_index.py
+++ b/core/memory/entity_index.py
@@ -221,6 +221,9 @@ def sync_entity_collection(
             sorted_items = [(key, entry) for key, entry in sorted_items if normalize_entity_key(key) in wanted]
             if not sorted_items:
                 return True
+        collection = f"{Path(anima_dir).name}_entities"
+        if not vector_store.create_collection(collection):
+            return False
         contents = [_entity_document_content(entry) for _key, entry in sorted_items]
         embeddings = embedding_fn(contents)
         if len(embeddings) != len(contents):
@@ -234,8 +237,6 @@ def sync_entity_collection(
                     metadata=_entity_document_metadata(key, entry),
                 )
             )
-        collection = f"{Path(anima_dir).name}_entities"
-        vector_store.create_collection(collection)
         return bool(vector_store.upsert(collection, docs))
     except Exception:
         logger.warning("Failed to sync entity collection for %s", anima_dir, exc_info=True)

--- a/core/memory/rag/indexer.py
+++ b/core/memory/rag/indexer.py
@@ -75,6 +75,7 @@ class IndexDirectoryResult:
     transient_failures: int = 0
     failed_sources: tuple[str, ...] = ()
     files_reconciled: int = 0
+    files_unprocessed: int = 0
 
     @property
     def transient(self) -> bool:
@@ -492,6 +493,17 @@ class MemoryIndexer:
             self.delete_indexed_file(file_path, memory_type)
             return self._finish_index_file(0, "indexed")
 
+        # Probe write availability before spending GPU time on embeddings.
+        # create_collection() is idempotent and returns False for an open
+        # client circuit, repair fence, or unavailable worker.
+        if not self.vector_store.create_collection(collection_name):
+            logger.warning("Collection unavailable for write, skipping index of %s", file_path)
+            # Collection creation is a service-wide write-availability gate,
+            # never a source-file defect.  Treat every failed probe as
+            # transient so directory indexing stops without quarantining the
+            # source or spending more embedding work.
+            return self._finish_index_file(0, "failed", transient=True)
+
         source_mtime_ns = file_path.stat().st_mtime_ns
         for chunk in chunks:
             chunk.metadata["source_hash"] = file_hash
@@ -568,6 +580,7 @@ class MemoryIndexer:
         files_failed = 0
         files_unchanged = 0
         files_skipped = 0
+        files_unprocessed = 0
         files_reconciled = 0
         transient_failures = 0
         failed_sources: list[str] = []
@@ -624,7 +637,11 @@ class MemoryIndexer:
                         done_count=index + 1,
                         total_count=len(md_files),
                     )
-            files_reconciled = self._reconcile_stale_entries(directory, memory_type)
+                if outcome.status == "failed" and outcome.transient:
+                    files_unprocessed = len(md_files) - index - 1
+                    break
+            if transient_failures == 0:
+                files_reconciled = self._reconcile_stale_entries(directory, memory_type)
         finally:
             self._index_directory_active = previous_active
             self._run_upsert_failures = previous_failures
@@ -634,6 +651,7 @@ class MemoryIndexer:
                 files_failed=files_failed,
                 files_unchanged=files_unchanged,
                 files_skipped=files_skipped,
+                files_unprocessed=files_unprocessed,
                 files_reconciled=files_reconciled,
                 transient_failures=transient_failures,
                 failed_sources=tuple(failed_sources),
@@ -702,7 +720,8 @@ class MemoryIndexer:
         examples = list(result.failed_sources[:3])
         logger.info(
             "Index directory summary: collection=%s successful=%d failed=%d "
-            "failed_sources=%s transient=%s unchanged=%d skipped=%d reconciled=%d chunks=%d",
+            "failed_sources=%s transient=%s unchanged=%d skipped=%d unprocessed=%d "
+            "reconciled=%d chunks=%d",
             collection_name,
             result.files_indexed,
             result.files_failed,
@@ -710,6 +729,7 @@ class MemoryIndexer:
             result.transient,
             result.files_unchanged,
             result.files_skipped,
+            result.files_unprocessed,
             result.files_reconciled,
             result.chunks_indexed,
         )
@@ -784,13 +804,17 @@ class MemoryIndexer:
             logger.debug("No chunks extracted from compressed_summary")
             return 0
 
+        # Gate GPU work on write availability.  A failed create is the
+        # fail-soft signal used by HTTP circuit/fence/unavailable paths.
+        if not self.vector_store.create_collection(collection_name):
+            logger.warning("Conversation summary collection unavailable for write, skipping index")
+            return 0
+
         # Generate embeddings
         embeddings = self._generate_embeddings([c.content for c in chunks])
 
         # Build documents and upsert
         from core.memory.rag.store import Document
-
-        self.vector_store.create_collection(collection_name)
 
         documents = [
             Document(

--- a/core/memory/rag/indexer_delete.py
+++ b/core/memory/rag/indexer_delete.py
@@ -62,7 +62,6 @@ def upsert_file_documents(
     documents: list[Any],
 ) -> bool:
     """Upsert current chunks and remove obsolete chunks for the same source file."""
-    indexer.vector_store.create_collection(collection_name)
     existing_ids = get_indexed_file_document_ids(indexer, collection_name, source_file)
     if existing_ids is None:
         logger.warning("Could not inspect existing chunks for %s, skipping index", file_path)

--- a/tests/unit/core/memory/test_entity_index.py
+++ b/tests/unit/core/memory/test_entity_index.py
@@ -5,6 +5,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -186,6 +187,30 @@ def test_sync_entity_collection_is_best_effort_with_injected_store(tmp_path: Pat
     collection, documents = calls["upsert"]
     assert collection == "alice_entities"
     assert documents[0].metadata["canonical"] == "Caroline"
+
+
+@pytest.mark.unit
+def test_sync_entity_collection_create_failure_skips_embedding(tmp_path: Path) -> None:
+    anima_dir = tmp_path / "alice"
+    registry = upsert_entities_from_facts(
+        anima_dir,
+        [_fact("Caroline suggested a book.", fact_id="fact-1", entities=["Caroline"])],
+    )
+    store = MagicMock()
+    store.create_collection.return_value = False
+    embedding_fn = MagicMock(return_value=[[0.1, 0.2]])
+
+    ok = sync_entity_collection(
+        anima_dir,
+        registry=registry,
+        vector_store=store,
+        embedding_fn=embedding_fn,
+    )
+
+    assert ok is False
+    store.create_collection.assert_called_once_with("alice_entities")
+    embedding_fn.assert_not_called()
+    store.upsert.assert_not_called()
 
 
 @pytest.mark.unit

--- a/tests/unit/core/memory/test_index_directory_result.py
+++ b/tests/unit/core/memory/test_index_directory_result.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 from core.memory.rag.indexer import MemoryIndexer, _IndexFileOutcome
 
@@ -13,6 +14,7 @@ def test_index_directory_returns_structured_counts_and_summary(tmp_path: Path, c
 
     indexer = object.__new__(MemoryIndexer)
     indexer.collection_prefix = "sora"
+    indexer._reconcile_stale_entries = MagicMock(return_value=0)
     outcomes = {
         "indexed.md": _IndexFileOutcome("indexed"),
         "failed.md": _IndexFileOutcome("failed", transient=True),
@@ -30,20 +32,57 @@ def test_index_directory_returns_structured_counts_and_summary(tmp_path: Path, c
     with caplog.at_level(logging.INFO, logger="animaworks.rag.indexer"):
         result = indexer.index_directory(tmp_path, "knowledge")
 
+    assert result.chunks_indexed == 0
+    assert result.files_indexed == 0
+    assert result.files_failed == 1
+    assert result.files_unchanged == 0
+    assert result.files_skipped == 0
+    assert result.files_unprocessed == 3
+    assert result.transient_failures == 1
+    assert result.transient is True
+    assert result.failed_sources == ("failed.md",)
+    indexer._reconcile_stale_entries.assert_not_called()
+    assert any(
+        "collection=sora_knowledge" in record.getMessage()
+        and "failed_sources=['failed.md']" in record.getMessage()
+        and "transient=True" in record.getMessage()
+        and "unprocessed=3" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_index_directory_nontransient_failure_continues_and_reconciles(tmp_path: Path) -> None:
+    for name in ("indexed.md", "failed.md", "unchanged.md", "skipped.md"):
+        (tmp_path / name).write_text(f"# {name}", encoding="utf-8")
+
+    indexer = object.__new__(MemoryIndexer)
+    indexer.collection_prefix = "sora"
+    indexer._reconcile_stale_entries = MagicMock(return_value=2)
+    outcomes = {
+        "indexed.md": _IndexFileOutcome("indexed"),
+        "failed.md": _IndexFileOutcome("failed", transient=False),
+        "unchanged.md": _IndexFileOutcome("unchanged"),
+        "skipped.md": _IndexFileOutcome("skipped"),
+    }
+
+    def index_file(file_path: Path, _memory_type: str, force: bool = False) -> int:
+        del force
+        indexer._last_index_file_outcome = outcomes[file_path.name]
+        return 4 if file_path.name == "indexed.md" else 0
+
+    indexer.index_file = index_file  # type: ignore[method-assign]
+
+    result = indexer.index_directory(tmp_path, "knowledge")
+
     assert result.chunks_indexed == 4
     assert result.files_indexed == 1
     assert result.files_failed == 1
     assert result.files_unchanged == 1
     assert result.files_skipped == 1
-    assert result.transient_failures == 1
-    assert result.transient is True
-    assert result.failed_sources == ("failed.md",)
-    assert any(
-        "collection=sora_knowledge" in record.getMessage()
-        and "failed_sources=['failed.md']" in record.getMessage()
-        and "transient=True" in record.getMessage()
-        for record in caplog.records
-    )
+    assert result.files_unprocessed == 0
+    assert result.transient_failures == 0
+    assert result.files_reconciled == 2
+    indexer._reconcile_stale_entries.assert_called_once_with(tmp_path, "knowledge")
 
 
 def test_transient_upsert_failure_is_debug_only(tmp_path: Path, caplog) -> None:

--- a/tests/unit/core/memory/test_indexer_collection_recovery.py
+++ b/tests/unit/core/memory/test_indexer_collection_recovery.py
@@ -41,6 +41,7 @@ def _make_indexer(anima_dir: Path):
         )
     # Patch embedding generation to return deterministic vectors
     idx._generate_embeddings = MagicMock(return_value=[[0.1] * 4])
+    idx.vector_store.create_collection.return_value = True
     idx.vector_store.list_collections_checked.side_effect = lambda: _checked_collections(idx.vector_store)
     return idx
 
@@ -97,6 +98,32 @@ class TestIndexFileCollectionRecovery:
 
     # Markdown content with a ``## `` heading so chunker yields chunks.
     _SAMPLE_MD = "# Title\n\n## Section A\n\n" + ("body sentence with enough length to chunk. " * 5)
+
+    def test_directory_write_gate_stops_before_embedding(self, anima_dir: Path):
+        idx = _make_indexer(anima_dir)
+        files = [anima_dir / "knowledge" / f"{name}.md" for name in ("a", "b", "c")]
+        for file_path in files:
+            file_path.write_text(self._SAMPLE_MD, encoding="utf-8")
+        idx.vector_store.create_collection.return_value = False
+        idx._generate_embeddings.reset_mock()
+        idx._reconcile_stale_entries = MagicMock(return_value=0)
+        idx._save_index_meta = MagicMock()
+
+        result = idx.index_directory(anima_dir / "knowledge", "knowledge")
+
+        assert result.files_failed == 1
+        assert result.transient_failures == 1
+        assert result.files_unprocessed == 2
+        assert result.files_reconciled == 0
+        assert result.transient is True
+        assert result.failed_sources == ("a.md",)
+        idx.vector_store.create_collection.assert_called_once_with("test_anima_knowledge")
+        idx._generate_embeddings.assert_not_called()
+        idx.vector_store.get_by_metadata.assert_not_called()
+        idx.vector_store.upsert.assert_not_called()
+        idx._reconcile_stale_entries.assert_not_called()
+        idx._save_index_meta.assert_not_called()
+        assert all(str(file_path.relative_to(anima_dir)) not in idx.index_meta for file_path in files)
 
     def test_skips_when_hash_matches_and_collection_exists(self, anima_dir: Path):
         idx = _make_indexer(anima_dir)
@@ -192,3 +219,24 @@ class TestIndexConversationSummaryRecovery:
         chunks = idx.index_conversation_summary(state_dir, "test_anima")
         assert chunks > 0
         assert idx.vector_store.upsert.called
+
+    def test_create_failure_skips_embedding_and_metadata_update(self, anima_dir: Path):
+        idx = _make_indexer(anima_dir)
+        state_dir = anima_dir / "state"
+        state_dir.mkdir()
+        (state_dir / "conversation.json").write_text(
+            '{"compressed_summary": "### Section A\\n\\n' + ("hello world " * 10) + '"}',
+            encoding="utf-8",
+        )
+        idx.vector_store.create_collection.return_value = False
+        idx._generate_embeddings.reset_mock()
+        idx._save_index_meta = MagicMock()
+
+        chunks = idx.index_conversation_summary(state_dir, "test_anima")
+
+        assert chunks == 0
+        idx.vector_store.create_collection.assert_called_once_with("test_anima_conversation_summary")
+        idx._generate_embeddings.assert_not_called()
+        idx.vector_store.upsert.assert_not_called()
+        idx._save_index_meta.assert_not_called()
+        assert "conversation_summary" not in idx.index_meta

--- a/tests/unit/core/memory/test_indexer_reconciliation.py
+++ b/tests/unit/core/memory/test_indexer_reconciliation.py
@@ -264,3 +264,29 @@ def test_reconciliation_runs_only_after_successful_directory_scan(tmp_path: Path
 
     assert "knowledge/deleted.md" in indexer.index_meta
     assert store.metadata_calls == []
+
+
+def test_reconciliation_is_skipped_after_transient_directory_failure(tmp_path: Path) -> None:
+    store = ReconciliationVectorStore()
+    indexer, knowledge_dir = _make_indexer(tmp_path, store)
+    for name in ("active.md", "unprocessed.md"):
+        (knowledge_dir / name).write_text("active", encoding="utf-8")
+    stale_source = "knowledge/deleted.md"
+    indexer.index_meta[stale_source] = {"hash": "old"}
+
+    def transient_failure(_path: Path, _memory_type: str, force: bool = False) -> int:
+        del force
+        indexer._last_index_file_outcome = _IndexFileOutcome("failed", transient=True)
+        return 0
+
+    indexer.index_file = MagicMock(side_effect=transient_failure)
+    indexer._save_index_meta = MagicMock()
+
+    result = indexer.index_directory(knowledge_dir, "knowledge")
+
+    assert result.files_failed == 1
+    assert result.files_unprocessed == 1
+    assert result.files_reconciled == 0
+    assert stale_source in indexer.index_meta
+    assert store.metadata_calls == []
+    indexer._save_index_meta.assert_not_called()


### PR DESCRIPTION
## 概要
GPU100%チャーンを直接止める本命修正。「全ファイルembedding→write失敗→hash未更新→次回また全量」ループを、embedding前のwrite可否確認と最初のtransient失敗でのdirectory打ち切りで遮断する。

Base: #252（P0-1三値化に依存するためstacked PR）

## 変更
- create_collection()をembedding前へ移動し戻り値検査（fence/circuit/unavailableは即transient）
- index_directory(): 初回transientで打ち切り、IndexDirectoryResult.files_unprocessedで偽成功読み防止
- 打切り時はreconciliation skip（metadata誤削除封鎖）
- conversation summary経路・entity indexの同型欠陥も修正

## 検証
- 対象UT 778 passed / ruff clean（PdM再実行済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)