### PR TITLE
fix(rag): shared metadata分離 shared_index_meta.json (P0-4)

### DIFF
--- a/cli/commands/anima_mgmt.py
+++ b/cli/commands/anima_mgmt.py
@@ -1399,9 +1399,12 @@ def _cleanup_rag_collections(anima_dir: Path, old_name: str, *, vector_url: str 
     """Delete old RAG collections and reset index_meta for re-indexing."""
     import os
 
+    from core.memory.rag.shared_meta import clear_shared_meta
+
     index_meta = anima_dir / "index_meta.json"
     if index_meta.exists():
         index_meta.write_text("{}\n", encoding="utf-8")
+    clear_shared_meta(anima_dir)
 
     vectordb_dir = anima_dir / "vectordb"
     if not vectordb_dir.is_dir():

--- a/cli/commands/index_cmd.py
+++ b/cli/commands/index_cmd.py
@@ -201,8 +201,9 @@ def _index_shared_collections(
     from core.company_resources import get_company_resources
     from core.memory.rag import MemoryIndexer
     from core.memory.rag.repair import is_repair_locked
+    from core.memory.rag.shared_meta import read_shared_hash, write_shared_hash, write_shared_hashes
     from core.memory.rag.singleton import get_vector_store
-    from core.memory.rag_search import _compute_dir_hash, _read_shared_hash, _write_shared_hash
+    from core.memory.rag_search import _compute_dir_hash
 
     ck_dir = base_dir / "common_knowledge"
     cs_dir = base_dir / "common_skills"
@@ -219,7 +220,6 @@ def _index_shared_collections(
         if is_repair_locked(anima_name):
             logger.warning("  %s: skipping shared indexing because RAG repair lock is held", anima_name)
             continue
-        meta_path = anima_dir / "index_meta.json"
         vector_store = get_vector_store(anima_name)
         if vector_store is None:
             logger.warning("Vector store unavailable for %s, skipping shared indexing", anima_name)
@@ -252,25 +252,27 @@ def _index_shared_collections(
             continue
 
         current_company = company_resources.name if company_resources is not None else ""
-        stored_company = _read_shared_hash(meta_path, "shared_company_name")
+        stored_company = read_shared_hash(anima_dir, "shared_company_name")
         if not dry_run and stored_company != current_company and (stored_company is not None or current_company):
             for collection in ("shared_common_knowledge", "shared_common_skills"):
                 try:
                     vector_store.delete_collection(collection)
                 except Exception:
                     logger.warning("  %s: failed to reset %s", anima_name, collection, exc_info=True)
-            _write_shared_hash(meta_path, "shared_company_name", current_company)
-            for key in (
-                "shared_common_knowledge_hash",
-                "shared_common_skills_hash",
-                "shared_company_knowledge_hash",
-                "shared_company_skills_hash",
-            ):
-                _write_shared_hash(meta_path, key, "")
+            write_shared_hashes(
+                anima_dir,
+                {
+                    "shared_company_name": current_company,
+                    "shared_common_knowledge_hash": "",
+                    "shared_common_skills_hash": "",
+                    "shared_company_knowledge_hash": "",
+                    "shared_company_skills_hash": "",
+                },
+            )
 
         for label, src_dir, glob, meta_key in anima_shared_dirs:
             current_hash = _compute_dir_hash(src_dir, glob)
-            stored_hash = _read_shared_hash(meta_path, meta_key)
+            stored_hash = read_shared_hash(anima_dir, meta_key)
 
             if not full and current_hash == stored_hash:
                 logger.info("  %s: %s unchanged, skipping", anima_name, label)
@@ -291,7 +293,7 @@ def _index_shared_collections(
             result = shared_indexer.index_directory(src_dir, label, force=full)
             total += result.chunks_indexed
             if result.files_failed == 0:
-                _write_shared_hash(meta_path, meta_key, current_hash)
+                write_shared_hash(anima_dir, meta_key, current_hash)
             logger.info("    Indexed %d chunks", result.chunks_indexed)
 
     return total

--- a/core/memory/rag/repair_rebuild.py
+++ b/core/memory/rag/repair_rebuild.py
@@ -179,7 +179,7 @@ def _reindex_into_store(
             if not src_dir.is_dir():
                 continue
             total_chunks += shared_indexer.index_directory(src_dir, label, force=True).chunks_indexed
-            write_shared_hash(anima_dir / "index_meta.json", src_dir, glob, meta_key)
+            write_shared_hash(anima_dir, src_dir, glob, meta_key)
     return total_chunks
 
 
@@ -291,10 +291,8 @@ def atomic_rebuild_vectordb(
     return chunks, archive
 
 
-def write_shared_hash(meta_path: Path, src_dir: Path, glob: str, meta_key: str) -> None:
-    try:
-        from core.memory.rag_search import _compute_dir_hash, _write_shared_hash
+def write_shared_hash(anima_dir: Path, src_dir: Path, glob: str, meta_key: str) -> None:
+    from core.memory.rag.shared_meta import write_shared_hash as write_meta_hash
+    from core.memory.rag_search import _compute_dir_hash
 
-        _write_shared_hash(meta_path, meta_key, _compute_dir_hash(src_dir, glob))
-    except Exception:
-        logger.debug("Failed to update shared hash for %s", meta_key, exc_info=True)
+    write_meta_hash(anima_dir, meta_key, _compute_dir_hash(src_dir, glob))

--- a/core/memory/rag/shared_meta.py
+++ b/core/memory/rag/shared_meta.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+# AnimaWorks - Digital Anima Framework
+# Copyright (C) 2026 AnimaWorks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Process-safe storage for per-Anima shared-index metadata."""
+
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+
+from core.platform.locks import file_lock
+
+SHARED_INDEX_META_FILE = "shared_index_meta.json"
+SHARED_INDEX_META_LOCK_FILE = f"{SHARED_INDEX_META_FILE}.lock"
+SHARED_INDEX_META_KEYS = frozenset(
+    {
+        "shared_company_name",
+        "shared_common_knowledge_hash",
+        "shared_common_skills_hash",
+        "shared_company_knowledge_hash",
+        "shared_company_skills_hash",
+    }
+)
+
+
+class SharedIndexMetaError(RuntimeError):
+    """Raised when shared-index metadata exists but cannot be read safely."""
+
+
+def shared_index_meta_path(anima_dir: Path) -> Path:
+    return Path(anima_dir) / SHARED_INDEX_META_FILE
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise SharedIndexMetaError(f"failed to read shared index metadata from {path}") from exc
+    if not isinstance(value, dict):
+        raise SharedIndexMetaError(f"shared index metadata must be a JSON object: {path}")
+    return value
+
+
+def _shared_values(value: dict[str, object], path: Path) -> dict[str, str]:
+    meta: dict[str, str] = {}
+    for key in SHARED_INDEX_META_KEYS:
+        item = value.get(key)
+        if item is None:
+            continue
+        if not isinstance(item, str):
+            raise SharedIndexMetaError(f"shared index metadata value must be a string: {path} ({key})")
+        meta[key] = item
+    return meta
+
+
+def _atomic_write(path: Path, meta: dict[str, str]) -> None:
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            delete=False,
+        ) as temp_file:
+            temp_path = Path(temp_file.name)
+            json.dump(meta, temp_file, indent=2, ensure_ascii=False)
+            temp_file.write("\n")
+            temp_file.flush()
+            os.fsync(temp_file.fileno())
+        os.replace(temp_path, path)
+    finally:
+        if temp_path is not None and temp_path.exists():
+            temp_path.unlink()
+
+
+def _load_or_migrate_locked(anima_dir: Path) -> dict[str, str]:
+    path = shared_index_meta_path(anima_dir)
+    if path.exists():
+        return _shared_values(_load_json(path), path)
+
+    legacy_path = anima_dir / "index_meta.json"
+    if not legacy_path.exists():
+        return {}
+    for attempt in range(3):
+        try:
+            legacy = _shared_values(_load_json(legacy_path), legacy_path)
+            break
+        except SharedIndexMetaError:
+            if attempt == 2:
+                raise
+            time.sleep(0.001)
+    if legacy:
+        _atomic_write(path, legacy)
+    return legacy
+
+
+def read_shared_meta(anima_dir: Path) -> dict[str, str]:
+    """Read shared metadata, migrating legacy keys on first access.
+
+    Reads take the same sidecar flock as writes because a missing new file may
+    require a one-time atomic copy from ``index_meta.json``.
+    """
+    anima_dir = Path(anima_dir)
+    lock_path = anima_dir / SHARED_INDEX_META_LOCK_FILE
+    with lock_path.open("a+", encoding="utf-8") as lock_file, file_lock(lock_file, exclusive=True):
+        return _load_or_migrate_locked(anima_dir)
+
+
+def read_shared_hash(anima_dir: Path, key: str) -> str | None:
+    if key not in SHARED_INDEX_META_KEYS:
+        raise ValueError(f"unsupported shared index metadata key: {key}")
+    return read_shared_meta(anima_dir).get(key)
+
+
+def write_shared_hashes(anima_dir: Path, updates: dict[str, str]) -> None:
+    """Atomically merge shared metadata updates under a process-wide flock."""
+    invalid = updates.keys() - SHARED_INDEX_META_KEYS
+    if invalid:
+        raise ValueError(f"unsupported shared index metadata keys: {sorted(invalid)}")
+    if any(not isinstance(value, str) for value in updates.values()):
+        raise TypeError("shared index metadata values must be strings")
+
+    anima_dir = Path(anima_dir)
+    lock_path = anima_dir / SHARED_INDEX_META_LOCK_FILE
+    with lock_path.open("a+", encoding="utf-8") as lock_file, file_lock(lock_file, exclusive=True):
+        meta = _load_or_migrate_locked(anima_dir)
+        meta.update(updates)
+        _atomic_write(shared_index_meta_path(anima_dir), meta)
+
+
+def write_shared_hash(anima_dir: Path, key: str, value: str) -> None:
+    write_shared_hashes(anima_dir, {key: value})
+
+
+def clear_shared_meta(anima_dir: Path) -> None:
+    """Clear existing shared metadata after an Anima rename."""
+    anima_dir = Path(anima_dir)
+    path = shared_index_meta_path(anima_dir)
+    lock_path = anima_dir / SHARED_INDEX_META_LOCK_FILE
+    with lock_path.open("a+", encoding="utf-8") as lock_file, file_lock(lock_file, exclusive=True):
+        if path.exists():
+            _atomic_write(path, {})

--- a/core/memory/rag_search.py
+++ b/core/memory/rag_search.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from core.company_resources import company_resource_pointer, get_company_resources, infer_data_dir
 from core.memory.fact_observability import warn_rate_limited
+from core.memory.rag.shared_meta import read_shared_hash, write_shared_hash, write_shared_hashes
 from core.memory.rag.store import CollectionExistence
 
 logger = logging.getLogger("animaworks.memory")
@@ -59,32 +60,6 @@ def _compute_dir_hash(dir_path: Path, glob_pattern: str = "*.md") -> str:
     entries.sort()
     h = hashlib.sha256(repr(entries).encode()).hexdigest()
     return h
-
-
-def _read_shared_hash(meta_path: Path, key: str) -> str | None:
-    """Read a stored shared-index hash from *meta_path* (index_meta.json)."""
-    if not meta_path.is_file():
-        return None
-    try:
-        meta = json.loads(meta_path.read_text(encoding="utf-8"))
-        return meta.get(key)
-    except (json.JSONDecodeError, OSError):
-        return None
-
-
-def _write_shared_hash(meta_path: Path, key: str, value: str) -> None:
-    """Write a shared-index hash into *meta_path* (index_meta.json)."""
-    meta: dict = {}
-    if meta_path.is_file():
-        try:
-            meta = json.loads(meta_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            pass
-    meta[key] = value
-    meta_path.write_text(
-        json.dumps(meta, indent=2, ensure_ascii=False) + "\n",
-        encoding="utf-8",
-    )
 
 
 def _shared_collection_exists(vector_store, collection_name: str) -> CollectionExistence:
@@ -202,7 +177,7 @@ class RAGMemorySearch:
         Called on every ``_get_indexer()`` access so that file changes are
         picked up even after the initial ``_init_indexer()`` run.  Uses a
         SHA-256 hash of (relative_path, mtime) tuples stored in the
-        per-anima ``index_meta.json`` to skip re-indexing when unchanged.
+        per-anima ``shared_index_meta.json`` to skip re-indexing when unchanged.
         """
         if self._indexer is None:
             return
@@ -222,8 +197,7 @@ class RAGMemorySearch:
         """Drop stale company content when this Anima's assignment changes."""
         resources = get_company_resources(self._anima_dir)
         current = resources.name if resources is not None else ""
-        meta_path = self._anima_dir / "index_meta.json"
-        stored = _read_shared_hash(meta_path, "shared_company_name")
+        stored = read_shared_hash(self._anima_dir, "shared_company_name")
         if stored == current or (stored is None and not current):
             return
         for collection in ("shared_common_knowledge", "shared_common_skills"):
@@ -231,14 +205,16 @@ class RAGMemorySearch:
                 vector_store.delete_collection(collection)
             except Exception:
                 logger.warning("Failed to reset %s after company assignment change", collection, exc_info=True)
-        _write_shared_hash(meta_path, "shared_company_name", current)
-        for key in (
-            "shared_common_knowledge_hash",
-            "shared_common_skills_hash",
-            "shared_company_knowledge_hash",
-            "shared_company_skills_hash",
-        ):
-            _write_shared_hash(meta_path, key, "")
+        write_shared_hashes(
+            self._anima_dir,
+            {
+                "shared_company_name": current,
+                "shared_common_knowledge_hash": "",
+                "shared_common_skills_hash": "",
+                "shared_company_knowledge_hash": "",
+                "shared_company_skills_hash": "",
+            },
+        )
 
     def _ensure_shared_knowledge_indexed(self, vector_store) -> None:
         """Index common_knowledge/ into ``shared_common_knowledge`` collection.
@@ -253,9 +229,8 @@ class RAGMemorySearch:
             logger.debug("No common_knowledge files found, skipping shared indexing")
             return
 
-        meta_path = self._anima_dir / "index_meta.json"
         current_hash = _compute_dir_hash(ck_dir, "*.md")
-        stored_hash = _read_shared_hash(meta_path, "shared_common_knowledge_hash")
+        stored_hash = read_shared_hash(self._anima_dir, "shared_common_knowledge_hash")
         force = False
         if current_hash == stored_hash:
             # Verify the shared collection still exists in this anima's
@@ -285,7 +260,7 @@ class RAGMemorySearch:
             )
             indexed = shared_indexer.index_directory(ck_dir, "common_knowledge", force=force)
             if indexed.files_failed == 0:
-                _write_shared_hash(meta_path, "shared_common_knowledge_hash", current_hash)
+                write_shared_hash(self._anima_dir, "shared_common_knowledge_hash", current_hash)
             if indexed.chunks_indexed > 0:
                 logger.info(
                     "Indexed %d chunks into shared_common_knowledge",
@@ -307,9 +282,8 @@ class RAGMemorySearch:
             logger.debug("No common_skills files found, skipping shared skills indexing")
             return
 
-        meta_path = self._anima_dir / "index_meta.json"
         current_hash = _compute_dir_hash(cs_dir, "SKILL.md")
-        stored_hash = _read_shared_hash(meta_path, "shared_common_skills_hash")
+        stored_hash = read_shared_hash(self._anima_dir, "shared_common_skills_hash")
         force = False
         if current_hash == stored_hash:
             existence = _shared_collection_exists(vector_store, "shared_common_skills")
@@ -341,7 +315,7 @@ class RAGMemorySearch:
             # Trust/security metadata remains enforced by MemoryIndexer.
             indexed = shared_indexer.index_directory(cs_dir, "common_skills", force=force)
             if indexed.files_failed == 0:
-                _write_shared_hash(meta_path, "shared_common_skills_hash", current_hash)
+                write_shared_hash(self._anima_dir, "shared_common_skills_hash", current_hash)
             if indexed.chunks_indexed > 0:
                 logger.info(
                     "Indexed %d chunks into shared_common_skills",
@@ -382,9 +356,8 @@ class RAGMemorySearch:
         glob: str,
         meta_key: str,
     ) -> None:
-        meta_path = self._anima_dir / "index_meta.json"
         current_hash = _compute_dir_hash(directory, glob)
-        stored_hash = _read_shared_hash(meta_path, meta_key)
+        stored_hash = read_shared_hash(self._anima_dir, meta_key)
         collection = f"shared_{memory_type}"
         force = False
         if current_hash == stored_hash:
@@ -404,7 +377,7 @@ class RAGMemorySearch:
             )
             result = indexer.index_directory(directory, memory_type, force=force)
             if result.files_failed == 0:
-                _write_shared_hash(meta_path, meta_key, current_hash)
+                write_shared_hash(self._anima_dir, meta_key, current_hash)
         except Exception as exc:
             logger.warning("Failed to index company %s: %s", memory_type, exc)
 

--- a/core/org_sync.py
+++ b/core/org_sync.py
@@ -281,6 +281,8 @@ _TRIVIAL_ENTRIES = frozenset(
         "vectordb",
         "status.json",
         "index_meta.json",
+        "shared_index_meta.json",
+        "shared_index_meta.json.lock",
         "identity.md",
     }
 )
@@ -456,7 +458,8 @@ def detect_orphan_animas(
     *age_threshold_s* seconds (possibly still being created) are skipped.
 
     **Trivial orphans** (containing only ``vectordb/``, ``.orphan_notified``,
-    ``status.json``, or ``index_meta.json``) are automatically deleted.
+    ``status.json``, ``index_meta.json``, or ``shared_index_meta.json``) are
+    automatically deleted.
     **Non-trivial orphans** (containing episodes, knowledge, state, etc.)
     are archived to ``archive/orphans/{name}_{timestamp}/`` and then deleted.
 

--- a/core/supervisor/_mgr_scheduler.py
+++ b/core/supervisor/_mgr_scheduler.py
@@ -644,7 +644,8 @@ class SchedulerMixin:
             except (json.JSONDecodeError, OSError):
                 pass
 
-        from core.memory.rag_search import _compute_dir_hash, _read_shared_hash, _write_shared_hash
+        from core.memory.rag.shared_meta import read_shared_hash, write_shared_hash
+        from core.memory.rag_search import _compute_dir_hash
 
         quick_check_timeout = 10.0
         try:
@@ -765,12 +766,11 @@ class SchedulerMixin:
                         exc_info=True,
                     )
 
-                meta_path = anima_dir / "index_meta.json"
                 for label, src_dir, glob, meta_key in shared_sources:
                     if not src_dir.is_dir():
                         continue
                     current_hash = _compute_dir_hash(src_dir, glob)
-                    stored_hash = _read_shared_hash(meta_path, meta_key)
+                    stored_hash = read_shared_hash(anima_dir, meta_key)
                     shared_collection = f"shared_{label}"
                     force = False
                     if current_hash == stored_hash:
@@ -798,7 +798,7 @@ class SchedulerMixin:
                     )
                     total_chunks += result.chunks_indexed
                     if result.files_failed == 0:
-                        _write_shared_hash(meta_path, meta_key, current_hash)
+                        write_shared_hash(anima_dir, meta_key, current_hash)
 
                 logger.info("Daily indexing for %s complete", anima_name)
 

--- a/tests/test_anima_rename.py
+++ b/tests/test_anima_rename.py
@@ -22,7 +22,6 @@ from core.config.models import (
     save_config,
 )
 
-
 # ── Helpers ──────────────────────────────────────────────────
 
 
@@ -449,6 +448,10 @@ class TestCmdAnimaRename:
         (data_dir / "animas" / "sakura" / "index_meta.json").write_text(
             '{"old": "data"}\n', encoding="utf-8",
         )
+        (data_dir / "animas" / "sakura" / "shared_index_meta.json").write_text(
+            '{"shared_company_name": "old-company"}\n',
+            encoding="utf-8",
+        )
 
         mock_data_dir.return_value = data_dir
         mock_animas_dir.return_value = data_dir / "animas"
@@ -457,6 +460,8 @@ class TestCmdAnimaRename:
 
         meta = (data_dir / "animas" / "hinata" / "index_meta.json").read_text(encoding="utf-8")
         assert json.loads(meta) == {}
+        shared_meta = (data_dir / "animas" / "hinata" / "shared_index_meta.json").read_text(encoding="utf-8")
+        assert json.loads(shared_meta) == {}
 
     @patch("core.paths.get_data_dir")
     @patch("core.paths.get_animas_dir")

--- a/tests/unit/cli/test_index_company_shared.py
+++ b/tests/unit/cli/test_index_company_shared.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from cli.commands.index_cmd import _index_shared_collections
 from core.memory.rag.indexer import IndexDirectoryResult
+from core.memory.rag.shared_meta import shared_index_meta_path
 
 
 def _anima(base: Path, name: str, company: str | None) -> Path:
@@ -71,4 +72,4 @@ def test_company_shared_index_dry_run_does_not_mutate(tmp_path: Path) -> None:
     store.delete_collection.assert_not_called()
     indexer.assert_not_called()
     assert not (alice / "index_meta.json").exists()
-
+    assert not shared_index_meta_path(alice).exists()

--- a/tests/unit/cli/test_index_shared.py
+++ b/tests/unit/cli/test_index_shared.py
@@ -21,6 +21,7 @@ from cli.commands.index_cmd import (
     setup_index_command,
 )
 from core.memory.rag.indexer import IndexDirectoryResult
+from core.memory.rag.shared_meta import shared_index_meta_path
 
 # ── _is_anima_enabled ─────────────────────────────────────
 
@@ -135,6 +136,7 @@ class TestIndexSharedCollections:
             )
         for d in anima_dirs:
             assert not (d / "index_meta.json").exists()
+            assert not shared_index_meta_path(d).exists()
 
     def test_indexes_into_each_anima_db(
         self,
@@ -158,10 +160,11 @@ class TestIndexSharedCollections:
 
         assert total == 3 * len(anima_dirs)
         for d in anima_dirs:
-            meta_path = d / "index_meta.json"
+            meta_path = shared_index_meta_path(d)
             assert meta_path.exists()
             data = json.loads(meta_path.read_text(encoding="utf-8"))
             assert "shared_common_knowledge_hash" in data
+            assert not (d / "index_meta.json").exists()
 
     def test_does_not_write_hash_when_indexing_failed(
         self,
@@ -182,7 +185,7 @@ class TestIndexSharedCollections:
             )
 
         assert total == 0
-        assert all(not (directory / "index_meta.json").exists() for directory in anima_dirs)
+        assert all(not shared_index_meta_path(directory).exists() for directory in anima_dirs)
 
     def test_skips_repair_locked_anima(
         self,

--- a/tests/unit/core/memory/test_rag_repair.py
+++ b/tests/unit/core/memory/test_rag_repair.py
@@ -21,6 +21,7 @@ from core.memory.rag.repair import (
     collection_owner,
 )
 from core.memory.rag.repair_utils import SINGLE_SHOT_REASONS
+from core.memory.rag.shared_meta import read_shared_hash, shared_index_meta_path
 from core.memory.rag.sqlite_health import SQLiteHealthResult
 
 
@@ -1124,6 +1125,10 @@ def test_repair_reindexes_shared_collections_when_requested(data_dir: Path, monk
     assert result.ok
     assert ("shared", "common_knowledge") in calls
     assert ("shared", "common_skills") in calls
+    assert read_shared_hash(anima_dir, "shared_common_knowledge_hash") is not None
+    assert read_shared_hash(anima_dir, "shared_common_skills_hash") is not None
+    assert shared_index_meta_path(anima_dir).is_file()
+    assert not (anima_dir / "index_meta.json").exists()
 
 
 def test_repair_failure_preserves_live_db_and_records_state(data_dir: Path, monkeypatch):

--- a/tests/unit/core/memory/test_rag_search_shared_index.py
+++ b/tests/unit/core/memory/test_rag_search_shared_index.py
@@ -7,18 +7,25 @@ from __future__ import annotations
 
 import json
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Barrier
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from core.memory.rag.indexer import IndexDirectoryResult
+from core.memory.rag.indexer import IndexDirectoryResult, MemoryIndexer
+from core.memory.rag.shared_meta import (
+    SharedIndexMetaError,
+    read_shared_hash,
+    shared_index_meta_path,
+    write_shared_hash,
+)
 from core.memory.rag.store import CollectionExistence
 from core.memory.rag_search import (
     RAGMemorySearch,
     _compute_dir_hash,
-    _read_shared_hash,
-    _write_shared_hash,
 )
 
 # ── _compute_dir_hash ─────────────────────────────────────
@@ -84,54 +91,109 @@ class TestComputeDirHash:
         assert h1 != h2
 
 
-# ── _read_shared_hash / _write_shared_hash ────────────────
+# ── shared_index_meta.json helpers ────────────────────────
 
 
 class TestReadWriteSharedHash:
     def test_read_missing_file(self, tmp_path: Path) -> None:
         """Returns None when file doesn't exist."""
-        assert _read_shared_hash(tmp_path / "nope.json", "key") is None
+        assert read_shared_hash(tmp_path, "shared_common_knowledge_hash") is None
 
     def test_read_corrupted_json(self, tmp_path: Path) -> None:
-        """Returns None on malformed JSON."""
-        p = tmp_path / "meta.json"
+        """Malformed metadata is not interpreted as an unset value."""
+        p = shared_index_meta_path(tmp_path)
         p.write_text("{invalid", encoding="utf-8")
-        assert _read_shared_hash(p, "key") is None
+        with pytest.raises(SharedIndexMetaError):
+            read_shared_hash(tmp_path, "shared_common_knowledge_hash")
 
     def test_read_missing_key(self, tmp_path: Path) -> None:
         """Returns None when key is absent."""
-        p = tmp_path / "meta.json"
-        p.write_text('{"other": "val"}', encoding="utf-8")
-        assert _read_shared_hash(p, "key") is None
+        p = shared_index_meta_path(tmp_path)
+        p.write_text('{"shared_company_name": "acme"}', encoding="utf-8")
+        assert read_shared_hash(tmp_path, "shared_common_knowledge_hash") is None
 
     def test_write_creates_file(self, tmp_path: Path) -> None:
-        """Creates index_meta.json when it doesn't exist."""
-        p = tmp_path / "meta.json"
-        _write_shared_hash(p, "my_key", "abc123")
+        """Creates shared_index_meta.json when it doesn't exist."""
+        p = shared_index_meta_path(tmp_path)
+        write_shared_hash(tmp_path, "shared_common_knowledge_hash", "abc123")
         data = json.loads(p.read_text(encoding="utf-8"))
-        assert data["my_key"] == "abc123"
+        assert data["shared_common_knowledge_hash"] == "abc123"
 
     def test_write_preserves_existing_keys(self, tmp_path: Path) -> None:
         """Writing a key preserves other keys."""
-        p = tmp_path / "meta.json"
-        p.write_text('{"existing": "keep"}', encoding="utf-8")
-        _write_shared_hash(p, "new_key", "val")
+        p = shared_index_meta_path(tmp_path)
+        p.write_text('{"shared_company_name": "keep"}', encoding="utf-8")
+        write_shared_hash(tmp_path, "shared_common_knowledge_hash", "val")
         data = json.loads(p.read_text(encoding="utf-8"))
-        assert data["existing"] == "keep"
-        assert data["new_key"] == "val"
+        assert data["shared_company_name"] == "keep"
+        assert data["shared_common_knowledge_hash"] == "val"
 
     def test_write_overwrites_existing_key(self, tmp_path: Path) -> None:
         """Overwriting a key updates its value."""
-        p = tmp_path / "meta.json"
-        _write_shared_hash(p, "k", "old")
-        _write_shared_hash(p, "k", "new")
-        assert _read_shared_hash(p, "k") == "new"
+        write_shared_hash(tmp_path, "shared_company_name", "old")
+        write_shared_hash(tmp_path, "shared_company_name", "new")
+        assert read_shared_hash(tmp_path, "shared_company_name") == "new"
 
     def test_roundtrip(self, tmp_path: Path) -> None:
         """Write then read returns same value."""
-        p = tmp_path / "meta.json"
-        _write_shared_hash(p, "shared_common_knowledge_hash", "deadbeef")
-        assert _read_shared_hash(p, "shared_common_knowledge_hash") == "deadbeef"
+        write_shared_hash(tmp_path, "shared_common_knowledge_hash", "deadbeef")
+        assert read_shared_hash(tmp_path, "shared_common_knowledge_hash") == "deadbeef"
+
+    def test_migrates_all_legacy_shared_keys_once(self, tmp_path: Path) -> None:
+        legacy = {
+            "knowledge/file.md": {"hash": "personal"},
+            "shared_company_name": "acme",
+            "shared_common_knowledge_hash": "common",
+            "shared_common_skills_hash": "skills",
+            "shared_company_knowledge_hash": "company-knowledge",
+            "shared_company_skills_hash": "company-skills",
+        }
+        (tmp_path / "index_meta.json").write_text(json.dumps(legacy), encoding="utf-8")
+
+        assert read_shared_hash(tmp_path, "shared_company_name") == "acme"
+        migrated = json.loads(shared_index_meta_path(tmp_path).read_text(encoding="utf-8"))
+        assert set(migrated) == set(legacy) - {"knowledge/file.md"}
+
+        legacy["shared_company_name"] = "changed-after-migration"
+        (tmp_path / "index_meta.json").write_text(json.dumps(legacy), encoding="utf-8")
+        assert read_shared_hash(tmp_path, "shared_company_name") == "acme"
+
+    def test_personal_and_shared_meta_writes_do_not_overwrite_each_other(self, tmp_path: Path) -> None:
+        indexer = MemoryIndexer.__new__(MemoryIndexer)
+        indexer.meta_path = tmp_path / "index_meta.json"
+        indexer.index_meta = {"knowledge/file.md": {"hash": "personal", "chunks": 1}}
+        barrier = Barrier(2)
+
+        def save_personal() -> None:
+            barrier.wait()
+            indexer._save_index_meta()
+
+        def save_shared() -> None:
+            barrier.wait()
+            write_shared_hash(tmp_path, "shared_common_knowledge_hash", "shared")
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            list(executor.map(lambda function: function(), (save_personal, save_shared)))
+
+        personal = json.loads(indexer.meta_path.read_text(encoding="utf-8"))
+        assert personal["knowledge/file.md"]["hash"] == "personal"
+        assert read_shared_hash(tmp_path, "shared_common_knowledge_hash") == "shared"
+
+    def test_migration_prevents_false_company_reset(self, rag: RAGMemorySearch) -> None:
+        (rag._anima_dir / "index_meta.json").write_text(
+            json.dumps({"shared_company_name": "acme"}),
+            encoding="utf-8",
+        )
+        vector_store = MagicMock()
+
+        with patch(
+            "core.memory.rag_search.get_company_resources",
+            return_value=SimpleNamespace(name="acme"),
+        ):
+            rag._reset_shared_for_company_change(vector_store)
+
+        vector_store.delete_collection.assert_not_called()
+        assert read_shared_hash(rag._anima_dir, "shared_company_name") == "acme"
 
 
 # ── _ensure_shared_knowledge_indexed (change detection) ───
@@ -175,7 +237,7 @@ class TestEnsureSharedKnowledgeChangeDetection:
         mock_vs = MagicMock()
         rag._indexer = MagicMock()
         rag._ensure_shared_knowledge_indexed(mock_vs)
-        meta = rag._anima_dir / "index_meta.json"
+        meta = shared_index_meta_path(rag._anima_dir)
         assert not meta.exists()
 
     def test_indexes_on_first_call(
@@ -195,9 +257,9 @@ class TestEnsureSharedKnowledgeChangeDetection:
 
             rag._ensure_shared_knowledge_indexed(mock_vs)
 
-        meta_path = rag._anima_dir / "index_meta.json"
+        meta_path = shared_index_meta_path(rag._anima_dir)
         assert meta_path.exists()
-        stored = _read_shared_hash(meta_path, "shared_common_knowledge_hash")
+        stored = read_shared_hash(rag._anima_dir, "shared_common_knowledge_hash")
         assert stored is not None
 
     def test_does_not_write_hash_when_any_file_failed(
@@ -216,8 +278,7 @@ class TestEnsureSharedKnowledgeChangeDetection:
             )
             rag._ensure_shared_knowledge_indexed(MagicMock())
 
-        meta_path = rag._anima_dir / "index_meta.json"
-        assert _read_shared_hash(meta_path, "shared_common_knowledge_hash") is None
+        assert read_shared_hash(rag._anima_dir, "shared_common_knowledge_hash") is None
 
     def test_skips_on_second_call_unchanged(
         self,
@@ -278,7 +339,7 @@ class TestEnsureSharedKnowledgeChangeDetection:
         """Hash unchanged but collection missing in vectordb → force re-index.
 
         Recovery scenario: vectordb was wiped/recreated since the last
-        index, leaving the per-anima index_meta.json hash stale.  The
+        index, leaving the per-anima shared_index_meta.json hash stale.  The
         framework must detect the missing collection and force re-index
         with ``force=True`` so it gets recreated.
         """
@@ -296,8 +357,7 @@ class TestEnsureSharedKnowledgeChangeDetection:
             rag._ensure_shared_knowledge_indexed(mock_vs)
             assert MockIdx.call_count == 1
             # Verify hash was stored
-            meta_path = rag._anima_dir / "index_meta.json"
-            stored = _read_shared_hash(meta_path, "shared_common_knowledge_hash")
+            stored = read_shared_hash(rag._anima_dir, "shared_common_knowledge_hash")
             assert stored is not None
 
             MockIdx.reset_mock()
@@ -346,7 +406,7 @@ class TestEnsureSharedSkillsChangeDetection:
         mock_vs = MagicMock()
         rag._indexer = MagicMock()
         rag._ensure_shared_skills_indexed(mock_vs)
-        meta = rag._anima_dir / "index_meta.json"
+        meta = shared_index_meta_path(rag._anima_dir)
         assert not meta.exists()
 
     def test_indexes_on_first_call(
@@ -368,8 +428,7 @@ class TestEnsureSharedSkillsChangeDetection:
 
             rag._ensure_shared_skills_indexed(mock_vs)
 
-        meta_path = rag._anima_dir / "index_meta.json"
-        stored = _read_shared_hash(meta_path, "shared_common_skills_hash")
+        stored = read_shared_hash(rag._anima_dir, "shared_common_skills_hash")
         assert stored is not None
 
     def test_skips_on_second_call_unchanged(

--- a/tests/unit/core/supervisor/test_daily_indexing.py
+++ b/tests/unit/core/supervisor/test_daily_indexing.py
@@ -12,8 +12,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from core.memory.rag.indexer import IndexDirectoryResult
+from core.memory.rag.shared_meta import read_shared_hash, shared_index_meta_path, write_shared_hash
 from core.memory.rag.store import CollectionExistence
-from core.memory.rag_search import _compute_dir_hash, _write_shared_hash
+from core.memory.rag_search import _compute_dir_hash
 from core.supervisor._mgr_scheduler import _marker_dir
 
 
@@ -235,7 +236,7 @@ async def test_daily_indexing_does_not_write_shared_hash_after_failure(tmp_path:
         )
         await sup._run_daily_indexing()
 
-    meta_path = sup.animas_dir / "sakura" / "index_meta.json"
+    meta_path = shared_index_meta_path(sup.animas_dir / "sakura")
     if meta_path.exists():
         assert "shared_common_knowledge_hash" not in json.loads(meta_path.read_text(encoding="utf-8"))
 
@@ -248,9 +249,8 @@ async def test_daily_indexing_skips_shared_reindex_when_collection_unavailable(t
     common_knowledge = tmp_path / "common_knowledge"
     common_knowledge.mkdir()
     (common_knowledge / "guide.md").write_text("# Guide", encoding="utf-8")
-    meta_path = anima_dir / "index_meta.json"
-    _write_shared_hash(
-        meta_path,
+    write_shared_hash(
+        anima_dir,
         "shared_common_knowledge_hash",
         _compute_dir_hash(common_knowledge, "*.md"),
     )
@@ -268,6 +268,7 @@ async def test_daily_indexing_skips_shared_reindex_when_collection_unavailable(t
         await sup._run_daily_indexing()
 
     mock_store.collection_exists.assert_called_once_with("shared_common_knowledge")
+    assert read_shared_hash(anima_dir, "shared_common_knowledge_hash") is not None
     assert mock_indexer_cls.call_count == 1
     mock_indexer_cls.return_value.index_directory.assert_not_called()
 

--- a/tests/unit/core/test_org_sync_orphan.py
+++ b/tests/unit/core/test_org_sync_orphan.py
@@ -10,6 +10,7 @@ Covers:
 - ChromaVectorStore mkdir guard
 - sync_org_structure config pruning
 """
+
 from __future__ import annotations
 
 import json
@@ -89,6 +90,23 @@ class TestDetectOrphanAnimas:
         )
         assert len(orphans) == 1
         assert orphans[0]["action"] == "auto_removed"
+        assert not orphan_dir.exists()
+
+    def test_trivial_orphan_auto_removed_shared_index_meta_only(self, data_dir, make_anima):
+        """Shared metadata and its flock sidecar remain trivial leftovers."""
+        make_anima("sakura")
+
+        orphan_dir = data_dir / "animas" / "rie"
+        orphan_dir.mkdir()
+        (orphan_dir / "shared_index_meta.json").write_text("{}\n", encoding="utf-8")
+        (orphan_dir / "shared_index_meta.json.lock").touch()
+
+        from core.org_sync import detect_orphan_animas
+
+        orphans = detect_orphan_animas(
+            data_dir / "animas", data_dir / "shared", age_threshold_s=0
+        )
+        assert orphans == [{"name": "rie", "action": "auto_removed"}]
         assert not orphan_dir.exists()
 
     def test_trivial_orphan_with_empty_identity(self, data_dir, make_anima):
@@ -253,7 +271,7 @@ class TestAutoCleanupOrphanConfig:
         """Auto-cleanup should unregister the orphan from config.json."""
         make_anima("sakura")
 
-        from core.config.models import load_config, save_config, AnimaModelConfig, invalidate_cache
+        from core.config.models import AnimaModelConfig, invalidate_cache, load_config, save_config
 
         config = load_config(data_dir / "config.json")
         config.animas["rie"] = AnimaModelConfig()
@@ -421,10 +439,9 @@ class TestChromaVectorStoreMkdirGuard:
         assert not persist_dir.parent.exists()
 
         mock_chromadb = MagicMock()
-        with patch.dict(sys.modules, {"chromadb": mock_chromadb}):
-            with caplog.at_level(logging.WARNING):
-                from core.memory.rag.store import ChromaVectorStore
-                ChromaVectorStore(persist_dir=persist_dir)
+        with patch.dict(sys.modules, {"chromadb": mock_chromadb}), caplog.at_level(logging.WARNING):
+            from core.memory.rag.store import ChromaVectorStore
+            ChromaVectorStore(persist_dir=persist_dir)
 
         assert persist_dir.exists()
         assert "Parent directory does not exist" in caplog.text


### PR DESCRIPTION
## 概要
shared_company_name・shared/company hash群をindex_meta.jsonから分離し、個人indexerのfull-file上書きがshared keysを消す競合（stale上書き・別プロセス間）を根絶する。Base: #254（P0-2にstacked）

## 変更
- core/memory/rag/shared_meta.py新設（flock+atomic replace・one-time migration・読取異常は例外で顕在化）
- writer全数移行（runtime/CLI/scheduler/repair）・rename/orphan経路対応

## 検証
- 対象UT 158 passed / ruff clean（PdM再実行済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)