### PR TITLE
fix(rag): 会社所属判定の読取失敗ガード (P0-3)

### DIFF
--- a/cli/commands/index_cmd.py
+++ b/cli/commands/index_cmd.py
@@ -198,10 +198,11 @@ def _index_shared_collections(
 
     Returns total chunks indexed across all animas.
     """
-    from core.company_resources import get_company_resources
+    from core.company_resources import get_company_resources_for_company
+    from core.config.models import read_anima_company_checked
     from core.memory.rag import MemoryIndexer
     from core.memory.rag.repair import is_repair_locked
-    from core.memory.rag.shared_meta import read_shared_hash, write_shared_hash, write_shared_hashes
+    from core.memory.rag.shared_meta import read_shared_hash, reset_shared_for_company_change, write_shared_hash
     from core.memory.rag.singleton import get_vector_store
     from core.memory.rag_search import _compute_dir_hash
 
@@ -220,13 +221,18 @@ def _index_shared_collections(
         if is_repair_locked(anima_name):
             logger.warning("  %s: skipping shared indexing because RAG repair lock is held", anima_name)
             continue
+        company_valid, company = read_anima_company_checked(anima_dir)
+        if not company_valid:
+            logger.warning("  %s: company membership unavailable, skipping shared indexing", anima_name)
+            continue
+        current_company = company or ""
+        company_resources = get_company_resources_for_company(company, data_dir=base_dir)
         vector_store = get_vector_store(anima_name)
         if vector_store is None:
             logger.warning("Vector store unavailable for %s, skipping shared indexing", anima_name)
             continue
 
         anima_shared_dirs = list(shared_dirs)
-        company_resources = get_company_resources(anima_dir, data_dir=base_dir)
         if company_resources is not None:
             if company_resources.knowledge_dir.is_dir() and any(company_resources.knowledge_dir.rglob("*.md")):
                 anima_shared_dirs.append(
@@ -247,28 +253,13 @@ def _index_shared_collections(
                     )
                 )
 
+        if not dry_run and not reset_shared_for_company_change(anima_dir, vector_store, current_company):
+            logger.warning("  %s: shared reset incomplete, skipping indexing", anima_name)
+            continue
+
         if not anima_shared_dirs:
             logger.info("  %s: no shared knowledge/skills files found, skipping", anima_name)
             continue
-
-        current_company = company_resources.name if company_resources is not None else ""
-        stored_company = read_shared_hash(anima_dir, "shared_company_name")
-        if not dry_run and stored_company != current_company and (stored_company is not None or current_company):
-            for collection in ("shared_common_knowledge", "shared_common_skills"):
-                try:
-                    vector_store.delete_collection(collection)
-                except Exception:
-                    logger.warning("  %s: failed to reset %s", anima_name, collection, exc_info=True)
-            write_shared_hashes(
-                anima_dir,
-                {
-                    "shared_company_name": current_company,
-                    "shared_common_knowledge_hash": "",
-                    "shared_common_skills_hash": "",
-                    "shared_company_knowledge_hash": "",
-                    "shared_company_skills_hash": "",
-                },
-            )
 
         for label, src_dir, glob, meta_key in anima_shared_dirs:
             current_hash = _compute_dir_hash(src_dir, glob)

--- a/core/company_resources.py
+++ b/core/company_resources.py
@@ -45,10 +45,20 @@ def get_company_resources(
     from core.config.models import read_anima_company
 
     company = read_anima_company(Path(anima_dir))
+    base = Path(data_dir) if data_dir is not None else infer_data_dir(Path(anima_dir))
+    return get_company_resources_for_company(company, data_dir=base)
+
+
+def get_company_resources_for_company(
+    company: str | None,
+    *,
+    data_dir: Path,
+) -> CompanyResources | None:
+    """Resolve resources from an already-read company value."""
     if not company or company in {".", ".."} or Path(company).name != company or "\\" in company:
         return None
 
-    base = Path(data_dir) if data_dir is not None else infer_data_dir(Path(anima_dir))
+    base = Path(data_dir)
     companies_dir = (base / "companies").resolve()
     root = (companies_dir / company).resolve()
     try:

--- a/core/memory/rag/shared_meta.py
+++ b/core/memory/rag/shared_meta.py
@@ -7,12 +7,15 @@ from __future__ import annotations
 """Process-safe storage for per-Anima shared-index metadata."""
 
 import json
+import logging
 import os
 import tempfile
 import time
 from pathlib import Path
 
 from core.platform.locks import file_lock
+
+logger = logging.getLogger("animaworks.memory")
 
 SHARED_INDEX_META_FILE = "shared_index_meta.json"
 SHARED_INDEX_META_LOCK_FILE = f"{SHARED_INDEX_META_FILE}.lock"
@@ -135,6 +138,37 @@ def write_shared_hashes(anima_dir: Path, updates: dict[str, str]) -> None:
 
 def write_shared_hash(anima_dir: Path, key: str, value: str) -> None:
     write_shared_hashes(anima_dir, {key: value})
+
+
+def reset_shared_for_company_change(anima_dir: Path, vector_store, current_company: str) -> bool:
+    """Reset shared collections and metadata as one successful-delete commit."""
+    stored_company = read_shared_hash(anima_dir, "shared_company_name")
+    if stored_company == current_company or (stored_company is None and not current_company):
+        return True
+
+    deleted = True
+    for collection in ("shared_common_knowledge", "shared_common_skills"):
+        try:
+            if vector_store.delete_collection(collection) is not True:
+                deleted = False
+                logger.warning("Failed to reset %s after company assignment change", collection)
+        except Exception:
+            deleted = False
+            logger.warning("Failed to reset %s after company assignment change", collection, exc_info=True)
+    if not deleted:
+        return False
+
+    write_shared_hashes(
+        anima_dir,
+        {
+            "shared_company_name": current_company,
+            "shared_common_knowledge_hash": "",
+            "shared_common_skills_hash": "",
+            "shared_company_knowledge_hash": "",
+            "shared_company_skills_hash": "",
+        },
+    )
+    return True
 
 
 def clear_shared_meta(anima_dir: Path) -> None:

--- a/core/memory/rag_search.py
+++ b/core/memory/rag_search.py
@@ -10,9 +10,16 @@ import re
 from datetime import UTC, datetime
 from pathlib import Path
 
-from core.company_resources import company_resource_pointer, get_company_resources, infer_data_dir
+from core.company_resources import (
+    CompanyResources,
+    company_resource_pointer,
+    get_company_resources,
+    get_company_resources_for_company,
+    infer_data_dir,
+)
+from core.config.models import read_anima_company_checked
 from core.memory.fact_observability import warn_rate_limited
-from core.memory.rag.shared_meta import read_shared_hash, write_shared_hash, write_shared_hashes
+from core.memory.rag.shared_meta import read_shared_hash, reset_shared_for_company_change, write_shared_hash
 from core.memory.rag.store import CollectionExistence
 
 logger = logging.getLogger("animaworks.memory")
@@ -183,38 +190,31 @@ class RAGMemorySearch:
             return
         try:
             vector_store = self._indexer.vector_store
-            self._reset_shared_for_company_change(vector_store)
+            company_valid, company = self._reset_shared_for_company_change(vector_store)
+            if not company_valid:
+                return
+            company_resources = get_company_resources_for_company(
+                company,
+                data_dir=infer_data_dir(self._anima_dir),
+            )
             self._ensure_shared_knowledge_indexed(vector_store)
             self._ensure_shared_skills_indexed(vector_store)
-            self._ensure_company_knowledge_indexed(vector_store)
-            self._ensure_company_skills_indexed(vector_store)
+            self._ensure_company_knowledge_indexed(vector_store, company_resources)
+            self._ensure_company_skills_indexed(vector_store, company_resources)
         except ImportError:
             pass
         except Exception as e:
             logger.debug("Shared collection check failed: %s", e)
 
-    def _reset_shared_for_company_change(self, vector_store) -> None:
-        """Drop stale company content when this Anima's assignment changes."""
-        resources = get_company_resources(self._anima_dir)
-        current = resources.name if resources is not None else ""
-        stored = read_shared_hash(self._anima_dir, "shared_company_name")
-        if stored == current or (stored is None and not current):
-            return
-        for collection in ("shared_common_knowledge", "shared_common_skills"):
-            try:
-                vector_store.delete_collection(collection)
-            except Exception:
-                logger.warning("Failed to reset %s after company assignment change", collection, exc_info=True)
-        write_shared_hashes(
-            self._anima_dir,
-            {
-                "shared_company_name": current,
-                "shared_common_knowledge_hash": "",
-                "shared_common_skills_hash": "",
-                "shared_company_knowledge_hash": "",
-                "shared_company_skills_hash": "",
-            },
-        )
+    def _reset_shared_for_company_change(self, vector_store) -> tuple[bool, str | None]:
+        """Drop stale company content only after a checked membership read."""
+        valid, company = read_anima_company_checked(self._anima_dir)
+        if not valid:
+            logger.warning("Company membership unavailable for %s; skipping shared indexing", self._anima_dir.name)
+            return False, None
+        if not reset_shared_for_company_change(self._anima_dir, vector_store, company or ""):
+            return False, company
+        return True, company
 
     def _ensure_shared_knowledge_indexed(self, vector_store) -> None:
         """Index common_knowledge/ into ``shared_common_knowledge`` collection.
@@ -324,8 +324,11 @@ class RAGMemorySearch:
         except Exception as e:
             logger.warning("Failed to index shared common_skills: %s", e)
 
-    def _ensure_company_knowledge_indexed(self, vector_store) -> None:
-        resources = get_company_resources(self._anima_dir)
+    def _ensure_company_knowledge_indexed(
+        self,
+        vector_store,
+        resources: CompanyResources | None,
+    ) -> None:
         if resources is None or not resources.knowledge_dir.is_dir() or not any(resources.knowledge_dir.rglob("*.md")):
             return
         self._index_company_directory(
@@ -336,8 +339,11 @@ class RAGMemorySearch:
             "shared_company_knowledge_hash",
         )
 
-    def _ensure_company_skills_indexed(self, vector_store) -> None:
-        resources = get_company_resources(self._anima_dir)
+    def _ensure_company_skills_indexed(
+        self,
+        vector_store,
+        resources: CompanyResources | None,
+    ) -> None:
         if resources is None or not resources.skills_dir.is_dir() or not any(resources.skills_dir.rglob("SKILL.md")):
             return
         self._index_company_directory(

--- a/tests/unit/cli/test_index_company_shared.py
+++ b/tests/unit/cli/test_index_company_shared.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from cli.commands.index_cmd import _index_shared_collections
 from core.memory.rag.indexer import IndexDirectoryResult
-from core.memory.rag.shared_meta import shared_index_meta_path
+from core.memory.rag.shared_meta import read_shared_hash, shared_index_meta_path, write_shared_hashes
 
 
 def _anima(base: Path, name: str, company: str | None) -> Path:
@@ -33,6 +33,8 @@ def test_shared_index_targets_each_animas_own_company_only(tmp_path: Path) -> No
     _knowledge(tmp_path, "other")
 
     stores = {name: MagicMock(name=f"store-{name}") for name in ("alice", "bob", "legacy")}
+    for store in stores.values():
+        store.delete_collection.return_value = True
     indexed: list[tuple[MagicMock, Path, str]] = []
 
     def make_indexer(store, **_kwargs):
@@ -73,3 +75,62 @@ def test_company_shared_index_dry_run_does_not_mutate(tmp_path: Path) -> None:
     indexer.assert_not_called()
     assert not (alice / "index_meta.json").exists()
     assert not shared_index_meta_path(alice).exists()
+
+
+def test_company_change_delete_failure_preserves_marker_and_hashes(tmp_path: Path) -> None:
+    alice = _anima(tmp_path, "alice", "alpha")
+    _knowledge(tmp_path, "alpha")
+    write_shared_hashes(
+        alice,
+        {
+            "shared_company_name": "old",
+            "shared_company_knowledge_hash": "old-hash",
+        },
+    )
+    meta_path = shared_index_meta_path(alice)
+    before = meta_path.read_text(encoding="utf-8")
+    store = MagicMock()
+    store.delete_collection.side_effect = [True, False]
+
+    with (
+        patch("core.memory.rag.repair.is_repair_locked", return_value=False),
+        patch("core.memory.rag.singleton.get_vector_store", return_value=store),
+        patch("core.memory.rag.MemoryIndexer") as indexer,
+    ):
+        assert _index_shared_collections([alice], tmp_path, full=False, dry_run=False) == 0
+
+    indexer.assert_not_called()
+    assert meta_path.read_text(encoding="utf-8") == before
+
+
+def test_company_checked_value_is_reused_for_cli_marker_and_resources(tmp_path: Path) -> None:
+    alice = _anima(tmp_path, "alice", "alpha")
+    alpha = _knowledge(tmp_path, "alpha")
+    _knowledge(tmp_path, "beta")
+    write_shared_hashes(alice, {"shared_company_name": "old"})
+    status_path = alice / "status.json"
+    store = MagicMock()
+
+    def delete_and_change_status(_collection: str) -> bool:
+        status_path.write_text(json.dumps({"company": "beta"}), encoding="utf-8")
+        return True
+
+    store.delete_collection.side_effect = delete_and_change_status
+    indexed: list[Path] = []
+
+    def make_indexer(*_args, **_kwargs):
+        indexer = MagicMock()
+        indexer.index_directory.side_effect = lambda directory, *_args, **_kwargs: (
+            indexed.append(directory) or IndexDirectoryResult(chunks_indexed=1, files_indexed=1)
+        )
+        return indexer
+
+    with (
+        patch("core.memory.rag.repair.is_repair_locked", return_value=False),
+        patch("core.memory.rag.singleton.get_vector_store", return_value=store),
+        patch("core.memory.rag.MemoryIndexer", side_effect=make_indexer),
+    ):
+        assert _index_shared_collections([alice], tmp_path, full=False, dry_run=False) == 1
+
+    assert indexed == [alpha]
+    assert read_shared_hash(alice, "shared_company_name") == "alpha"

--- a/tests/unit/cli/test_index_shared.py
+++ b/tests/unit/cli/test_index_shared.py
@@ -21,7 +21,7 @@ from cli.commands.index_cmd import (
     setup_index_command,
 )
 from core.memory.rag.indexer import IndexDirectoryResult
-from core.memory.rag.shared_meta import shared_index_meta_path
+from core.memory.rag.shared_meta import shared_index_meta_path, write_shared_hash
 
 # ── _is_anima_enabled ─────────────────────────────────────
 
@@ -119,6 +119,8 @@ class TestIndexSharedCollections:
         alice.mkdir(parents=True, exist_ok=True)
         bob = animas / "bob"
         bob.mkdir(parents=True, exist_ok=True)
+        for directory in (alice, bob):
+            (directory / "status.json").write_text("{}", encoding="utf-8")
         return [alice, bob]
 
     def test_dry_run_does_not_write_meta(
@@ -186,6 +188,57 @@ class TestIndexSharedCollections:
 
         assert total == 0
         assert all(not shared_index_meta_path(directory).exists() for directory in anima_dirs)
+
+    @pytest.mark.parametrize("status", [None, "{invalid", "[]"])
+    def test_unreadable_company_skips_delete_and_hash_updates(
+        self,
+        anima_dirs: list[Path],
+        base_dir: Path,
+        status: str | None,
+    ) -> None:
+        anima_dir = anima_dirs[0]
+        status_path = anima_dir / "status.json"
+        status_path.unlink()
+        if status is not None:
+            status_path.write_text(status, encoding="utf-8")
+        write_shared_hash(anima_dir, "shared_company_name", "old")
+        meta_path = shared_index_meta_path(anima_dir)
+        before = meta_path.read_text(encoding="utf-8")
+        vector_store = MagicMock()
+
+        with (
+            patch("core.memory.rag.repair.is_repair_locked", return_value=False),
+            patch("core.memory.rag.singleton.get_vector_store", return_value=vector_store),
+            patch(_PATCH_INDEXER) as indexer,
+        ):
+            _index_shared_collections([anima_dir], base_dir, full=False, dry_run=False)
+
+        vector_store.delete_collection.assert_not_called()
+        indexer.assert_not_called()
+        assert meta_path.read_text(encoding="utf-8") == before
+
+    def test_company_read_oserror_skips_delete_and_hash_updates(
+        self,
+        anima_dirs: list[Path],
+        base_dir: Path,
+    ) -> None:
+        anima_dir = anima_dirs[0]
+        write_shared_hash(anima_dir, "shared_company_name", "old")
+        meta_path = shared_index_meta_path(anima_dir)
+        before = meta_path.read_text(encoding="utf-8")
+        vector_store = MagicMock()
+
+        with (
+            patch.object(Path, "read_text", side_effect=PermissionError("denied")),
+            patch("core.memory.rag.repair.is_repair_locked", return_value=False),
+            patch("core.memory.rag.singleton.get_vector_store", return_value=vector_store),
+            patch(_PATCH_INDEXER) as indexer,
+        ):
+            _index_shared_collections([anima_dir], base_dir, full=False, dry_run=False)
+
+        vector_store.delete_collection.assert_not_called()
+        indexer.assert_not_called()
+        assert meta_path.read_text(encoding="utf-8") == before
 
     def test_skips_repair_locked_anima(
         self,

--- a/tests/unit/core/memory/test_rag_search_shared_index.py
+++ b/tests/unit/core/memory/test_rag_search_shared_index.py
@@ -21,6 +21,7 @@ from core.memory.rag.shared_meta import (
     read_shared_hash,
     shared_index_meta_path,
     write_shared_hash,
+    write_shared_hashes,
 )
 from core.memory.rag.store import CollectionExistence
 from core.memory.rag_search import (
@@ -180,20 +181,115 @@ class TestReadWriteSharedHash:
         assert read_shared_hash(tmp_path, "shared_common_knowledge_hash") == "shared"
 
     def test_migration_prevents_false_company_reset(self, rag: RAGMemorySearch) -> None:
+        (rag._anima_dir / "status.json").write_text(json.dumps({"company": "acme"}), encoding="utf-8")
         (rag._anima_dir / "index_meta.json").write_text(
             json.dumps({"shared_company_name": "acme"}),
             encoding="utf-8",
         )
         vector_store = MagicMock()
 
-        with patch(
-            "core.memory.rag_search.get_company_resources",
-            return_value=SimpleNamespace(name="acme"),
-        ):
-            rag._reset_shared_for_company_change(vector_store)
+        rag._reset_shared_for_company_change(vector_store)
 
         vector_store.delete_collection.assert_not_called()
         assert read_shared_hash(rag._anima_dir, "shared_company_name") == "acme"
+
+    @pytest.mark.parametrize("status", [None, "{invalid", "[]"])
+    def test_unreadable_company_skips_reset_and_hash_updates(
+        self,
+        rag: RAGMemorySearch,
+        status: str | None,
+    ) -> None:
+        if status is not None:
+            (rag._anima_dir / "status.json").write_text(status, encoding="utf-8")
+        write_shared_hashes(
+            rag._anima_dir,
+            {
+                "shared_company_name": "old",
+                "shared_common_knowledge_hash": "common",
+                "shared_common_skills_hash": "skills",
+                "shared_company_knowledge_hash": "company-knowledge",
+                "shared_company_skills_hash": "company-skills",
+            },
+        )
+        meta_path = shared_index_meta_path(rag._anima_dir)
+        before = meta_path.read_text(encoding="utf-8")
+        vector_store = MagicMock()
+        rag._indexer = SimpleNamespace(vector_store=vector_store)
+
+        rag._check_shared_collections()
+
+        vector_store.delete_collection.assert_not_called()
+        assert meta_path.read_text(encoding="utf-8") == before
+
+    def test_company_read_oserror_skips_reset_and_hash_updates(self, rag: RAGMemorySearch) -> None:
+        (rag._anima_dir / "status.json").write_text("{}", encoding="utf-8")
+        write_shared_hash(rag._anima_dir, "shared_company_name", "old")
+        meta_path = shared_index_meta_path(rag._anima_dir)
+        before = meta_path.read_text(encoding="utf-8")
+        vector_store = MagicMock()
+        rag._indexer = SimpleNamespace(vector_store=vector_store)
+
+        with patch.object(Path, "read_text", side_effect=PermissionError("denied")):
+            rag._check_shared_collections()
+
+        vector_store.delete_collection.assert_not_called()
+        assert meta_path.read_text(encoding="utf-8") == before
+
+    def test_company_change_resets_collections_and_metadata(self, rag: RAGMemorySearch) -> None:
+        (rag._anima_dir / "status.json").write_text(json.dumps({"company": "new"}), encoding="utf-8")
+        write_shared_hash(rag._anima_dir, "shared_company_name", "old")
+        vector_store = MagicMock()
+        vector_store.delete_collection.return_value = True
+
+        assert rag._reset_shared_for_company_change(vector_store) == (True, "new")
+
+        assert [call.args[0] for call in vector_store.delete_collection.call_args_list] == [
+            "shared_common_knowledge",
+            "shared_common_skills",
+        ]
+        assert read_shared_hash(rag._anima_dir, "shared_company_name") == "new"
+        assert read_shared_hash(rag._anima_dir, "shared_common_knowledge_hash") == ""
+        assert read_shared_hash(rag._anima_dir, "shared_common_skills_hash") == ""
+
+    def test_partial_delete_failure_preserves_company_metadata(self, rag: RAGMemorySearch) -> None:
+        (rag._anima_dir / "status.json").write_text(json.dumps({"company": "new"}), encoding="utf-8")
+        write_shared_hashes(
+            rag._anima_dir,
+            {
+                "shared_company_name": "old",
+                "shared_common_knowledge_hash": "common",
+            },
+        )
+        meta_path = shared_index_meta_path(rag._anima_dir)
+        before = meta_path.read_text(encoding="utf-8")
+        vector_store = MagicMock()
+        vector_store.delete_collection.side_effect = [True, False]
+
+        assert rag._reset_shared_for_company_change(vector_store) == (False, "new")
+        assert meta_path.read_text(encoding="utf-8") == before
+
+    def test_checked_company_value_is_reused_for_marker_and_resources(self, rag: RAGMemorySearch) -> None:
+        status_path = rag._anima_dir / "status.json"
+        status_path.write_text(json.dumps({"company": "alpha"}), encoding="utf-8")
+        company_knowledge = rag._anima_dir.parent.parent / "companies" / "alpha" / "knowledge"
+        company_knowledge.mkdir(parents=True)
+        (company_knowledge / "guide.md").write_text("# Alpha", encoding="utf-8")
+        write_shared_hash(rag._anima_dir, "shared_company_name", "old")
+        vector_store = MagicMock()
+
+        def delete_and_change_status(_collection: str) -> bool:
+            status_path.write_text(json.dumps({"company": "beta"}), encoding="utf-8")
+            return True
+
+        vector_store.delete_collection.side_effect = delete_and_change_status
+        rag._indexer = SimpleNamespace(vector_store=vector_store)
+
+        with patch.object(rag, "_index_company_directory") as index_company:
+            rag._check_shared_collections()
+
+        assert read_shared_hash(rag._anima_dir, "shared_company_name") == "alpha"
+        index_company.assert_called_once()
+        assert index_company.call_args.args[1] == company_knowledge
 
 
 # ── _ensure_shared_knowledge_indexed (change detection) ───

--- a/tests/unit/core/memory/test_shared_knowledge_init.py
+++ b/tests/unit/core/memory/test_shared_knowledge_init.py
@@ -40,6 +40,7 @@ class TestSharedKnowledgeInit:
     def anima_dir(self, data_dir: Path) -> Path:
         d = data_dir / "animas" / "test_anima"
         d.mkdir(parents=True)
+        (d / "status.json").write_text("{}", encoding="utf-8")
         for sub in ("knowledge", "episodes", "procedures", "skills", "state"):
             (d / sub).mkdir()
         return d


### PR DESCRIPTION
## 概要
status.json一時読取失敗→「会社変更」誤認→shared_common_knowledge/skills全削除の事故経路を封鎖する。Base: #255（P0-4にstacked）

## 変更
- checked read導入（読取有効でない限り削除もmarker更新もしない）・runtime/CLI両方
- TOCTOU禁止（判定値の単一ソース化）・全delete成功時のみcommit

## 検証
- 対象UT 332 passed / ruff clean（PdM再実行済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)