### PR TITLE
feat(supervisor): heartbeatレーンのtask runner移行 (PR-2)

### DIFF
--- a/core/supervisor/runner.py
+++ b/core/supervisor/runner.py
@@ -840,6 +840,11 @@ class AnimaRunner:
         if not self.anima:
             raise AnimaNotRunningError("Anima not initialized")
 
+        # Prefer scheduler path so process-isolation flag and overlap guard apply.
+        if self._scheduler_mgr is not None:
+            await self._scheduler_mgr.heartbeat_tick()
+            return {"status": "completed"}
+
         await self.anima.run_heartbeat()
 
         return {"status": "completed"}

--- a/core/supervisor/scheduler_manager.py
+++ b/core/supervisor/scheduler_manager.py
@@ -81,8 +81,10 @@ class SchedulerManager:
         process_config = resolve_process_model_config(anima_dir)
         if not process_config.valid:
             raise ValueError(process_config.error or "invalid process model configuration")
+        self._cron_isolated = bool(process_config.task_process_isolation.cron)
+        self._heartbeat_isolated = bool(process_config.task_process_isolation.heartbeat)
         self._task_runner_supervisor: TaskRunnerSupervisor | None = None
-        if process_config.task_process_isolation.cron:
+        if self._cron_isolated or self._heartbeat_isolated:
             self._task_runner_supervisor = TaskRunnerSupervisor(
                 anima_name=anima_name,
                 anima_dir=anima_dir,
@@ -839,6 +841,19 @@ class SchedulerManager:
         self._heartbeat_running = True
         try:
             logger.info("Scheduled heartbeat: %s", self._anima_name)
+            if self._heartbeat_isolated and self._task_runner_supervisor is not None:
+                isolated = await self._task_runner_supervisor.run_heartbeat()
+                result = isolated.get("result")
+                if not isinstance(result, dict):
+                    raise ValueError("isolated heartbeat result must be an object")
+                self._emit_event(
+                    "anima.heartbeat",
+                    {
+                        "name": self._anima_name,
+                        "result": result,
+                    },
+                )
+                return
             result = await self._anima.run_heartbeat()
             # Notify parent for WebSocket broadcast
             self._emit_event(
@@ -895,7 +910,7 @@ class SchedulerManager:
         success = False
         usage: dict[str, int] | None = None
         try:
-            if self._task_runner_supervisor is not None:
+            if self._cron_isolated and self._task_runner_supervisor is not None:
                 isolated = await self._task_runner_supervisor.run_cron(task)
                 success = bool(isolated.get("success"))
                 isolated_usage = isolated.get("usage")

--- a/core/supervisor/task_runner.py
+++ b/core/supervisor/task_runner.py
@@ -1,6 +1,6 @@
 """Disposable task runner entry point.
 
-Usage: ``python -m core.supervisor.task_runner --anima X --lane cron --job ID``
+Usage: ``python -m core.supervisor.task_runner --anima X --lane cron|heartbeat --job ID``
 """
 
 from __future__ import annotations
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 
 _CONNECT_DEADLINE_SECONDS = 10.0
 _PROGRESS_INTERVAL_SECONDS = 5.0
+_SUPPORTED_LANES = frozenset({"cron", "heartbeat"})
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -119,6 +120,23 @@ async def execute_cron_contract(anima: DigitalAnima, task: CronTask) -> dict[str
         "followup_result": followup,
         "success": success,
         "usage": usage,
+    }
+
+
+async def execute_heartbeat_contract(
+    anima: DigitalAnima,
+    *,
+    cascade_suppressed_senders: list[str] | None = None,
+) -> dict[str, Any]:
+    """Execute the legacy heartbeat contract inside the child process."""
+    senders = set(cascade_suppressed_senders) if cascade_suppressed_senders else None
+    result = await anima.run_heartbeat(cascade_suppressed_senders=senders)
+    result_dict = result.model_dump(mode="json")
+    return {
+        "task_type": "heartbeat",
+        "result": result_dict,
+        "success": result.action not in {"error", "cancelled", "failed"},
+        "usage": result.usage,
     }
 
 
@@ -210,12 +228,43 @@ async def _send_terminal(
         return reconnected
 
 
+async def _prepare_execution(
+    args: argparse.Namespace,
+    identity: IPCV2Identity,
+    params: dict[str, Any],
+) -> asyncio.Task[dict[str, Any]]:
+    """Validate the run contract and return the lane execution task."""
+    if identity.lane not in _SUPPORTED_LANES:
+        raise ValueError(f"unsupported task runner lane: {identity.lane!r}")
+
+    anima = DigitalAnima(
+        anima_dir=get_animas_dir() / args.anima,
+        shared_dir=get_shared_dir(),
+        busy_status_enabled=False,
+    )
+    if identity.lane == "heartbeat":
+        raw_senders = params.get("cascade_suppressed_senders")
+        senders: list[str] | None
+        if raw_senders is None:
+            senders = None
+        elif isinstance(raw_senders, list) and all(isinstance(item, str) for item in raw_senders):
+            senders = list(raw_senders)
+        else:
+            raise ValueError("cascade_suppressed_senders must be a list of strings or null")
+        return asyncio.create_task(execute_heartbeat_contract(anima, cascade_suppressed_senders=senders))
+
+    task_data = params.get("task")
+    if not isinstance(task_data, dict):
+        raise ValueError("run contract requires task")
+    task = CronTask.model_validate(task_data)
+    return asyncio.create_task(execute_cron_contract(anima, task))
+
+
 async def run_task(args: argparse.Namespace, socket_path: Path, identity: IPCV2Identity) -> int:
     state = IPCV2ConnectionState(identity)
     connection, run_envelope = await _connect(socket_path, state)
     request_id = run_envelope.body["request_id"]
     params = run_envelope.body["params"]
-    task_data = params.get("task")
     contract_urls = (params.get("environment") or {}).get("urls")
     if not isinstance(contract_urls, dict) or contract_urls.get("ANIMAWORKS_EMBED_URL") != os.environ.get(
         "ANIMAWORKS_EMBED_URL"
@@ -230,21 +279,16 @@ async def run_task(args: argparse.Namespace, socket_path: Path, identity: IPCV2I
         )
         await connection.close()
         return 2
-    if not isinstance(task_data, dict):
+
+    try:
+        execution = await _prepare_execution(args, identity, params)
+    except ValueError as exc:
         await connection.send_response(
             request_id,
-            error=ipc_v2_error("PROTOCOL_ERROR", "run contract requires task", retryable=False),
+            error=ipc_v2_error("PROTOCOL_ERROR", str(exc), retryable=False),
         )
         await connection.close()
         return 2
-
-    try:
-        anima = DigitalAnima(
-            anima_dir=get_animas_dir() / args.anima,
-            shared_dir=get_shared_dir(),
-            busy_status_enabled=False,
-        )
-        task = CronTask.model_validate(task_data)
     except Exception as exc:
         await connection.send_response(
             request_id,
@@ -252,7 +296,6 @@ async def run_task(args: argparse.Namespace, socket_path: Path, identity: IPCV2I
         )
         await connection.close()
         return 1
-    execution = asyncio.create_task(execute_cron_contract(anima, task))
     progress = asyncio.create_task(_progress_loop(connection, identity))
     expected_parent_pid = int(os.environ.get("ANIMAWORKS_TASK_ROOT_PID", os.getppid()))
     parent_monitor = asyncio.create_task(_parent_monitor(expected_parent_pid))

--- a/core/supervisor/task_runner_supervisor.py
+++ b/core/supervisor/task_runner_supervisor.py
@@ -8,6 +8,7 @@ import os
 import signal
 import sys
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -53,7 +54,7 @@ class TaskRunnerJob:
 
 
 class TaskRunnerSupervisor:
-    """Expose one IPC v2 endpoint and run cron jobs in isolated process groups."""
+    """Expose one IPC v2 endpoint and run jobs in isolated process groups."""
 
     def __init__(self, anima_name: str, anima_dir: Path, shared_dir: Path) -> None:
         self.anima_name = anima_name
@@ -97,28 +98,61 @@ class TaskRunnerSupervisor:
 
     async def run_cron(self, task: CronTask) -> dict[str, Any]:
         """Spawn one cron task runner and return its terminal result."""
+        return await self._run_isolated_job(
+            lane="cron",
+            job_prefix="cron",
+            params_builder=lambda url_env: {
+                "task": task.model_dump(mode="json"),
+                "environment": {"urls": url_env},
+            },
+            log_context=f"task={task.name}",
+        )
+
+    async def run_heartbeat(
+        self,
+        *,
+        cascade_suppressed_senders: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Spawn one heartbeat task runner and return its terminal result."""
+        senders = list(cascade_suppressed_senders) if cascade_suppressed_senders else None
+        return await self._run_isolated_job(
+            lane="heartbeat",
+            job_prefix="heartbeat",
+            params_builder=lambda url_env: {
+                "cascade_suppressed_senders": senders,
+                "environment": {"urls": url_env},
+            },
+            log_context="heartbeat",
+        )
+
+    async def _run_isolated_job(
+        self,
+        *,
+        lane: str,
+        job_prefix: str,
+        params_builder: Callable[[dict[str, str]], dict[str, Any]],
+        log_context: str,
+    ) -> dict[str, Any]:
+        """Spawn one task runner process and return its terminal result."""
         if not self._accepting:
             raise TaskRunnerError("task runner supervisor is shutting down")
         await self._ensure_started()
         url_env = self._required_url_environment()
 
-        job_id = f"cron-{uuid.uuid4()}"
+        job_id = f"{job_prefix}-{uuid.uuid4()}"
         request_id = f"run-{uuid.uuid4()}"
         identity = IPCV2Identity(
             job_id=job_id,
             root_epoch=self.root_epoch,
             attempt=1,
-            lane="cron",
+            lane=lane,
             display_lane="background",
         )
         loop = asyncio.get_running_loop()
         job = TaskRunnerJob(
             identity=identity,
             request_id=request_id,
-            params={
-                "task": task.model_dump(mode="json"),
-                "environment": {"urls": url_env},
-            },
+            params=params_builder(url_env),
             result=loop.create_future(),
             peer_state=IPCV2ConnectionState(identity),
         )
@@ -148,7 +182,7 @@ class TaskRunnerSupervisor:
                 "--anima",
                 self.anima_name,
                 "--lane",
-                "cron",
+                lane,
                 "--job",
                 job_id,
                 env=env,
@@ -160,9 +194,10 @@ class TaskRunnerSupervisor:
             job.pid = process.pid
             job.pgid = process.pid
             logger.info(
-                "Spawned cron task runner anima=%s task=%s job=%s pid=%s pgid=%s",
+                "Spawned %s task runner anima=%s %s job=%s pid=%s pgid=%s",
+                lane,
                 self.anima_name,
-                task.name,
+                log_context,
                 job_id,
                 job.pid,
                 job.pgid,

--- a/tests/unit/core/supervisor/test_heartbeat_process_isolation.py
+++ b/tests/unit/core/supervisor/test_heartbeat_process_isolation.py
@@ -1,0 +1,214 @@
+"""Feature flag and crash semantics for heartbeat process isolation."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from core.schemas import CycleResult
+from core.supervisor.ipc_v2 import IPCV2ConnectionState, IPCV2Identity
+from core.supervisor.scheduler_manager import SchedulerManager
+from core.supervisor.task_runner_supervisor import TaskRunnerJob, TaskRunnerSupervisor
+
+
+def _manager(tmp_path: Path, *, isolated: bool) -> tuple[SchedulerManager, MagicMock]:
+    anima_dir = tmp_path / "animas" / "sakura"
+    anima_dir.mkdir(parents=True)
+    (tmp_path / "shared").mkdir()
+    (anima_dir / "status.json").write_text(
+        json.dumps(
+            {
+                "process_model": "phase2",
+                "task_process_isolation": {"heartbeat": isolated},
+            }
+        ),
+        encoding="utf-8",
+    )
+    anima = MagicMock()
+    anima.shared_dir = tmp_path / "shared"
+    anima.run_heartbeat = AsyncMock(
+        return_value=CycleResult(trigger="heartbeat", action="completed", summary="done")
+    )
+    emit = MagicMock()
+    manager = SchedulerManager(anima, "sakura", anima_dir, emit)
+    return manager, anima
+
+
+@pytest.mark.asyncio
+async def test_flag_false_preserves_legacy_path_without_spawn(tmp_path: Path) -> None:
+    manager, anima = _manager(tmp_path, isolated=False)
+
+    await manager.heartbeat_tick()
+
+    assert manager._task_runner_supervisor is None
+    assert manager._heartbeat_isolated is False
+    anima.run_heartbeat.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_flag_true_uses_child_result_without_root_llm(tmp_path: Path) -> None:
+    manager, anima = _manager(tmp_path, isolated=True)
+    assert manager._task_runner_supervisor is not None
+    assert manager._heartbeat_isolated is True
+    manager._task_runner_supervisor.run_heartbeat = AsyncMock(
+        return_value={
+            "task_type": "heartbeat",
+            "result": {"action": "completed", "summary": "child result"},
+            "success": True,
+            "usage": {"input_tokens": 10},
+        }
+    )
+
+    await manager.heartbeat_tick()
+
+    anima.run_heartbeat.assert_not_awaited()
+    manager._task_runner_supervisor.run_heartbeat.assert_awaited_once_with()
+    manager._emit_event.assert_called_once()
+    assert manager._emit_event.call_args[0][0] == "anima.heartbeat"
+    assert manager._emit_event.call_args[0][1]["result"]["summary"] == "child result"
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_skips_while_already_running_serializes_same_anima(tmp_path: Path) -> None:
+    manager, anima = _manager(tmp_path, isolated=True)
+    assert manager._task_runner_supervisor is not None
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow_heartbeat() -> dict:
+        started.set()
+        await release.wait()
+        return {
+            "task_type": "heartbeat",
+            "result": {"action": "completed", "summary": "first"},
+            "success": True,
+        }
+
+    manager._task_runner_supervisor.run_heartbeat = AsyncMock(side_effect=_slow_heartbeat)
+
+    first = asyncio.create_task(manager.heartbeat_tick())
+    await started.wait()
+
+    # Second fire while first is in flight must be skipped (same-anima serial HB).
+    await manager.heartbeat_tick()
+    anima.run_heartbeat.assert_not_awaited()
+    assert manager._task_runner_supervisor.run_heartbeat.await_count == 1
+
+    release.set()
+    await first
+    assert manager.heartbeat_running is False
+
+    # After completion a new cycle can run.
+    manager._task_runner_supervisor.run_heartbeat = AsyncMock(
+        return_value={
+            "task_type": "heartbeat",
+            "result": {"action": "completed", "summary": "second"},
+            "success": True,
+        }
+    )
+    await manager.heartbeat_tick()
+    manager._task_runner_supervisor.run_heartbeat.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_sigkill_only_reaps_task_group_and_root_can_continue(tmp_path: Path) -> None:
+    shared_dir = tmp_path / "shared"
+    anima_dir = tmp_path / "animas" / "sakura"
+    shared_dir.mkdir(parents=True)
+    anima_dir.mkdir(parents=True)
+    supervisor = TaskRunnerSupervisor("sakura", anima_dir, shared_dir)
+    identity = IPCV2Identity(
+        job_id="job-kill-hb",
+        root_epoch=supervisor.root_epoch,
+        attempt=1,
+        lane="heartbeat",
+        display_lane="background",
+    )
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        "import time; time.sleep(60)",
+        start_new_session=True,
+    )
+    job = TaskRunnerJob(
+        identity=identity,
+        request_id="run-kill-hb",
+        params={},
+        result=asyncio.get_running_loop().create_future(),
+        peer_state=IPCV2ConnectionState(identity),
+        process=process,
+        pid=process.pid,
+        pgid=process.pid,
+    )
+    supervisor.jobs[identity.job_id] = job
+    root_pid = os.getpid()
+
+    os.killpg(process.pid, 9)
+    return_code = await asyncio.wait_for(process.wait(), timeout=2)
+    supervisor.jobs.pop(identity.job_id)
+
+    assert return_code == -9
+    assert os.getpid() == root_pid
+    assert supervisor._accepting is True
+    assert not supervisor.jobs
+
+
+@pytest.mark.asyncio
+async def test_child_crash_is_logged_and_next_tick_can_run(tmp_path: Path) -> None:
+    manager, anima = _manager(tmp_path, isolated=True)
+    assert manager._task_runner_supervisor is not None
+    manager._task_runner_supervisor.run_heartbeat = AsyncMock(
+        side_effect=RuntimeError("child exited before returning a result")
+    )
+
+    await manager.heartbeat_tick()
+
+    anima.run_heartbeat.assert_not_awaited()
+    assert manager.heartbeat_running is False
+
+    manager._task_runner_supervisor.run_heartbeat = AsyncMock(
+        return_value={
+            "task_type": "heartbeat",
+            "result": {"action": "completed", "summary": "recovered"},
+            "success": True,
+        }
+    )
+    await manager.heartbeat_tick()
+    manager._task_runner_supervisor.run_heartbeat.assert_awaited_once()
+    assert manager.heartbeat_running is False
+
+
+@pytest.mark.asyncio
+async def test_cron_only_flag_does_not_isolate_heartbeat(tmp_path: Path) -> None:
+    anima_dir = tmp_path / "animas" / "sakura"
+    anima_dir.mkdir(parents=True)
+    (tmp_path / "shared").mkdir()
+    (anima_dir / "status.json").write_text(
+        json.dumps(
+            {
+                "process_model": "phase2",
+                "task_process_isolation": {"cron": True, "heartbeat": False},
+            }
+        ),
+        encoding="utf-8",
+    )
+    anima = MagicMock()
+    anima.shared_dir = tmp_path / "shared"
+    anima.run_heartbeat = AsyncMock(
+        return_value=CycleResult(trigger="heartbeat", action="completed", summary="legacy")
+    )
+    manager = SchedulerManager(anima, "sakura", anima_dir, MagicMock())
+
+    assert manager._task_runner_supervisor is not None
+    assert manager._cron_isolated is True
+    assert manager._heartbeat_isolated is False
+
+    await manager.heartbeat_tick()
+    anima.run_heartbeat.assert_awaited_once()

--- a/tests/unit/core/supervisor/test_task_runner.py
+++ b/tests/unit/core/supervisor/test_task_runner.py
@@ -142,3 +142,68 @@ def test_missing_embed_url_fails_closed(monkeypatch: pytest.MonkeyPatch, args: a
 
     with pytest.raises(RuntimeError, match="ANIMAWORKS_EMBED_URL"):
         task_runner._required_environment(args)
+
+
+def _heartbeat_contract(identity: IPCV2Identity) -> IPCV2Envelope:
+    return IPCV2Envelope(
+        kind="request",
+        identity=identity,
+        seq=2,
+        body={
+            "request_id": "run-hb-1",
+            "method": "run",
+            "params": {
+                "environment": {"urls": {"ANIMAWORKS_EMBED_URL": "http://embed.test"}},
+                "cascade_suppressed_senders": None,
+            },
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_lane_execution_returns_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    identity = IPCV2Identity(
+        job_id="job-hb",
+        root_epoch=str(uuid.uuid4()),
+        attempt=1,
+        lane="heartbeat",
+        display_lane="background",
+    )
+    args = argparse.Namespace(anima="sakura", lane="heartbeat", job="job-hb")
+    monkeypatch.setenv("ANIMAWORKS_EMBED_URL", "http://embed.test")
+    connection = FakeConnection()
+    monkeypatch.setattr(
+        task_runner,
+        "_connect",
+        AsyncMock(return_value=(connection, _heartbeat_contract(identity))),
+    )
+    monkeypatch.setattr(task_runner, "DigitalAnima", lambda **kwargs: object())
+    monkeypatch.setattr(
+        task_runner,
+        "execute_heartbeat_contract",
+        AsyncMock(
+            return_value={
+                "task_type": "heartbeat",
+                "result": {"action": "completed", "summary": "hb done"},
+                "success": True,
+            }
+        ),
+    )
+
+    exit_code = await task_runner.run_task(args, Path("/tmp/task.sock"), identity)
+
+    assert exit_code == 0
+    assert connection.responses == [
+        (
+            "run-hb-1",
+            {
+                "task_type": "heartbeat",
+                "result": {"action": "completed", "summary": "hb done"},
+                "success": True,
+            },
+            None,
+        )
+    ]
+


### PR DESCRIPTION
## 概要
Phase 2第2弾。PR-1のtask runner基盤を使いheartbeat実行を使い捨て子プロセスへ移行。Base: #256（PR-1にstacked）

## 変更
- flag task_process_isolation.heartbeat（無効時は現行経路・回帰テストあり）
- spawn共通化（_run_isolated_job）・HB直列化維持・SIGKILL障害注入テスト

## 検証
- tests/unit/core/supervisor 441 passed / ruff clean（PdM再実行済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)