### PR TITLE
fix(rag): shared checkのsingleflight + TTL + backoff (P0-5)

### DIFF
--- a/core/config/schemas.py
+++ b/core/config/schemas.py
@@ -286,6 +286,9 @@ class RAGConfig(BaseModel):
     # Serialize repairs (1) by default so each rebuild runs in isolation.
     repair_max_concurrent: int = 1
     upsert_quarantine_failure_threshold: int = Field(default=3, ge=1)
+    shared_check_ttl_seconds: float = Field(default=30.0, ge=0)
+    shared_check_backoff_initial_seconds: float = Field(default=5.0, ge=0)
+    shared_check_backoff_max_seconds: float = Field(default=300.0, ge=0)
     startup_repair_preflight_enabled: bool = True
     startup_repair_window_minutes: int = 1440
     quick_check_timeout_seconds: float = 10.0

--- a/core/memory/rag/repair_rebuild.py
+++ b/core/memory/rag/repair_rebuild.py
@@ -288,6 +288,9 @@ def atomic_rebuild_vectordb(
     shutil.move(str(staging), str(live))
     reset_worker_vector_store(anima_name)
     reset_vector_store(anima_name)
+    from core.memory.rag.shared_check_registry import invalidate_shared_checks
+
+    invalidate_shared_checks(anima_name)
     return chunks, archive
 
 

--- a/core/memory/rag/repair_service.py
+++ b/core/memory/rag/repair_service.py
@@ -784,6 +784,9 @@ class RAGRepairService:
 
                     reset_worker_vector_store(anima_name)
                     reset_vector_store(anima_name)
+                    from core.memory.rag.shared_check_registry import invalidate_shared_checks
+
+                    invalidate_shared_checks(anima_name)
                     repair_state.update_repair_state(
                         anima_name,
                         status="success",

--- a/core/memory/rag/shared_check_registry.py
+++ b/core/memory/rag/shared_check_registry.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+# AnimaWorks - Digital Anima Framework
+# Copyright (C) 2026 AnimaWorks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Process-wide singleflight, TTL, and backoff for shared-index checks."""
+
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+SharedCheckKey = tuple[str, str, str, str]
+
+
+class SharedCheckOutcome(StrEnum):
+    """Result of one shared collection check or reindex attempt."""
+
+    SUCCESS = "success"
+    TRANSIENT = "transient"
+    FAILED = "failed"
+
+
+@dataclass
+class _Entry:
+    success_until: float = 0.0
+    retry_at: float = 0.0
+    failures: int = 0
+    last_outcome: SharedCheckOutcome | None = None
+
+
+_condition = threading.Condition()
+_entries: dict[SharedCheckKey, _Entry] = {}
+_in_flight: dict[tuple[str, str, str], SharedCheckKey] = {}
+_owner_epochs: dict[str, int] = {}
+
+
+def shared_store_identity(vector_store: object) -> str:
+    """Return the stable store identity used in shared-check keys."""
+    attributes = getattr(vector_store, "__dict__", {})
+    base_url = attributes.get("_base_url") if isinstance(attributes, dict) else None
+    if isinstance(base_url, str):
+        return base_url.rstrip("/")
+    persist_dir = attributes.get("persist_dir") if isinstance(attributes, dict) else None
+    if isinstance(persist_dir, (str, Path)):
+        return f"file:{Path(persist_dir)}"
+    return f"instance:{id(vector_store)}"
+
+
+def make_shared_check_key(
+    owner: str,
+    vector_store: object,
+    collection: str,
+    source_generation: str,
+) -> SharedCheckKey:
+    """Build a key containing DB owner, store identity, collection, and source generation."""
+    return owner, shared_store_identity(vector_store), collection, source_generation
+
+
+def run_shared_check(
+    key: SharedCheckKey,
+    operation: Callable[[], SharedCheckOutcome],
+    *,
+    ttl_seconds: float,
+    backoff_initial_seconds: float,
+    backoff_max_seconds: float,
+) -> SharedCheckOutcome:
+    """Run one check, waiting for the same collection's active flight when needed."""
+    owner, store_identity, collection, _generation = key
+    flight_key = owner, store_identity, collection
+
+    while True:
+        with _condition:
+            now = time.monotonic()
+            entry = _entries.setdefault(key, _Entry())
+            if entry.success_until > now:
+                return SharedCheckOutcome.SUCCESS
+            if entry.retry_at > now:
+                return SharedCheckOutcome.TRANSIENT
+            active_key = _in_flight.get(flight_key)
+            if active_key is not None:
+                while flight_key in _in_flight:
+                    _condition.wait()
+                completed = _entries.get(key)
+                if active_key == key and completed is not None and completed.last_outcome is not None:
+                    return completed.last_outcome
+                continue
+            entry.last_outcome = None
+            _in_flight[flight_key] = key
+            owner_epoch = _owner_epochs.get(owner, 0)
+            break
+
+    try:
+        outcome = operation()
+    except BaseException:
+        with _condition:
+            if _owner_epochs.get(owner, 0) == owner_epoch:
+                _entries.setdefault(key, _Entry()).last_outcome = SharedCheckOutcome.FAILED
+            _in_flight.pop(flight_key, None)
+            _condition.notify_all()
+        raise
+
+    with _condition:
+        if _owner_epochs.get(owner, 0) == owner_epoch:
+            entry = _entries.setdefault(key, _Entry())
+            now = time.monotonic()
+            entry.last_outcome = outcome
+            if outcome is SharedCheckOutcome.SUCCESS:
+                entry.success_until = now + max(0.0, ttl_seconds)
+                entry.retry_at = 0.0
+                entry.failures = 0
+            elif outcome is SharedCheckOutcome.TRANSIENT:
+                entry.failures += 1
+                delay = backoff_initial_seconds * (2 ** (entry.failures - 1))
+                entry.retry_at = now + min(max(0.0, delay), max(0.0, backoff_max_seconds))
+                entry.success_until = 0.0
+        _in_flight.pop(flight_key, None)
+        _condition.notify_all()
+    return outcome
+
+
+def invalidate_shared_checks(owner: str) -> None:
+    """Invalidate all cached shared checks for one real DB owner."""
+    with _condition:
+        _owner_epochs[owner] = _owner_epochs.get(owner, 0) + 1
+        for key in [key for key in _entries if key[0] == owner]:
+            _entries.pop(key, None)
+        _condition.notify_all()
+
+
+def reset_shared_check_registry() -> None:
+    """Reset process-wide state between tests."""
+    with _condition:
+        _entries.clear()
+        _in_flight.clear()
+        _owner_epochs.clear()
+        _condition.notify_all()

--- a/core/memory/rag/shared_meta.py
+++ b/core/memory/rag/shared_meta.py
@@ -168,6 +168,9 @@ def reset_shared_for_company_change(anima_dir: Path, vector_store, current_compa
             "shared_company_skills_hash": "",
         },
     )
+    from core.memory.rag.shared_check_registry import invalidate_shared_checks
+
+    invalidate_shared_checks(anima_dir.name)
     return True
 
 

--- a/core/memory/rag_search.py
+++ b/core/memory/rag_search.py
@@ -19,6 +19,11 @@ from core.company_resources import (
 )
 from core.config.models import read_anima_company_checked
 from core.memory.fact_observability import warn_rate_limited
+from core.memory.rag.shared_check_registry import (
+    SharedCheckOutcome,
+    make_shared_check_key,
+    run_shared_check,
+)
 from core.memory.rag.shared_meta import read_shared_hash, reset_shared_for_company_change, write_shared_hash
 from core.memory.rag.store import CollectionExistence
 
@@ -216,6 +221,86 @@ class RAGMemorySearch:
             return False, company
         return True, company
 
+    @staticmethod
+    def _shared_check_timing() -> tuple[float, float, float]:
+        """Load shared-check timing with schema defaults as a fail-safe."""
+        try:
+            from core.config import load_config
+
+            rag = load_config().rag
+        except Exception:
+            from core.config.models import RAGConfig
+
+            rag = RAGConfig()
+        return (
+            rag.shared_check_ttl_seconds,
+            rag.shared_check_backoff_initial_seconds,
+            rag.shared_check_backoff_max_seconds,
+        )
+
+    def _ensure_shared_directory_indexed(
+        self,
+        vector_store,
+        directory: Path,
+        memory_type: str,
+        glob: str,
+        meta_key: str,
+        *,
+        shared_anima_dir: Path,
+        missing_log: str | None = None,
+        success_log: str | None = None,
+    ) -> None:
+        """Check and index one shared source through the process-wide registry."""
+        current_hash = _compute_dir_hash(directory, glob)
+        collection = f"shared_{memory_type}"
+        key = make_shared_check_key(
+            self._anima_dir.name,
+            vector_store,
+            collection,
+            f"{meta_key}:{current_hash}",
+        )
+
+        def check() -> SharedCheckOutcome:
+            stored_hash = read_shared_hash(self._anima_dir, meta_key)
+            force = False
+            if current_hash == stored_hash:
+                existence = _shared_collection_exists(vector_store, collection)
+                if existence is CollectionExistence.EXISTS:
+                    return SharedCheckOutcome.SUCCESS
+                if existence is CollectionExistence.UNAVAILABLE:
+                    return SharedCheckOutcome.TRANSIENT
+                if missing_log:
+                    logger.info(missing_log)
+                force = True
+
+            from core.memory.rag import MemoryIndexer
+
+            indexer = MemoryIndexer(
+                vector_store,
+                anima_name="shared",
+                anima_dir=shared_anima_dir,
+                collection_prefix="shared",
+                embedding_model=self._indexer.embedding_model if self._indexer else None,
+            )
+            result = indexer.index_directory(directory, memory_type, force=force)
+            if result.files_failed == 0:
+                write_shared_hash(self._anima_dir, meta_key, current_hash)
+                if success_log and result.chunks_indexed > 0:
+                    logger.info(success_log, result.chunks_indexed)
+                return SharedCheckOutcome.SUCCESS
+            if result.transient_failures > 0:
+                return SharedCheckOutcome.TRANSIENT
+            return SharedCheckOutcome.FAILED
+
+        ttl, backoff_initial, backoff_max = self._shared_check_timing()
+        run_shared_check(
+            key,
+            check,
+            ttl_seconds=ttl,
+            backoff_initial_seconds=backoff_initial,
+            backoff_max_seconds=backoff_max,
+        )
+
     def _ensure_shared_knowledge_indexed(self, vector_store) -> None:
         """Index common_knowledge/ into ``shared_common_knowledge`` collection.
 
@@ -229,43 +314,19 @@ class RAGMemorySearch:
             logger.debug("No common_knowledge files found, skipping shared indexing")
             return
 
-        current_hash = _compute_dir_hash(ck_dir, "*.md")
-        stored_hash = read_shared_hash(self._anima_dir, "shared_common_knowledge_hash")
-        force = False
-        if current_hash == stored_hash:
-            # Verify the shared collection still exists in this anima's
-            # vector store; if missing, fall through with force=True so
-            # the collection gets recreated.
-            existence = _shared_collection_exists(vector_store, "shared_common_knowledge")
-            if existence is CollectionExistence.EXISTS:
-                logger.debug("common_knowledge unchanged (hash match), skipping")
-                return
-            if existence is CollectionExistence.UNAVAILABLE:
-                logger.debug("common_knowledge collection availability unknown; skipping re-index")
-                return
-            logger.info("shared_common_knowledge collection missing despite tracked hash, forcing re-index")
-            force = True
-
         try:
-            from core.memory.rag import MemoryIndexer
             from core.paths import get_data_dir
 
-            data_dir = get_data_dir()
-            shared_indexer = MemoryIndexer(
+            self._ensure_shared_directory_indexed(
                 vector_store,
-                anima_name="shared",
-                anima_dir=data_dir,
-                collection_prefix="shared",
-                embedding_model=self._indexer.embedding_model if self._indexer else None,
+                ck_dir,
+                "common_knowledge",
+                "*.md",
+                "shared_common_knowledge_hash",
+                shared_anima_dir=get_data_dir(),
+                missing_log="shared_common_knowledge collection missing despite tracked hash, forcing re-index",
+                success_log="Indexed %d chunks into shared_common_knowledge",
             )
-            indexed = shared_indexer.index_directory(ck_dir, "common_knowledge", force=force)
-            if indexed.files_failed == 0:
-                write_shared_hash(self._anima_dir, "shared_common_knowledge_hash", current_hash)
-            if indexed.chunks_indexed > 0:
-                logger.info(
-                    "Indexed %d chunks into shared_common_knowledge",
-                    indexed.chunks_indexed,
-                )
         except Exception as e:
             logger.warning("Failed to index shared common_knowledge: %s", e)
 
@@ -282,45 +343,19 @@ class RAGMemorySearch:
             logger.debug("No common_skills files found, skipping shared skills indexing")
             return
 
-        current_hash = _compute_dir_hash(cs_dir, "SKILL.md")
-        stored_hash = read_shared_hash(self._anima_dir, "shared_common_skills_hash")
-        force = False
-        if current_hash == stored_hash:
-            existence = _shared_collection_exists(vector_store, "shared_common_skills")
-            if existence is CollectionExistence.EXISTS:
-                logger.debug("common_skills unchanged (hash match), skipping")
-                return
-            if existence is CollectionExistence.UNAVAILABLE:
-                logger.debug("common_skills collection availability unknown; skipping re-index")
-                return
-            logger.info("shared_common_skills collection missing despite tracked hash, forcing re-index")
-            force = True
-
         try:
-            from core.memory.rag import MemoryIndexer
             from core.paths import get_data_dir
 
-            data_dir = get_data_dir()
-            shared_indexer = MemoryIndexer(
+            self._ensure_shared_directory_indexed(
                 vector_store,
-                anima_name="shared",
-                anima_dir=data_dir,
-                collection_prefix="shared",
-                embedding_model=self._indexer.embedding_model if self._indexer else None,
+                cs_dir,
+                "common_skills",
+                "SKILL.md",
+                "shared_common_skills_hash",
+                shared_anima_dir=get_data_dir(),
+                missing_log="shared_common_skills collection missing despite tracked hash, forcing re-index",
+                success_log="Indexed %d chunks into shared_common_skills",
             )
-            # shared_common_skills is a global collection. Per-anima curator
-            # archive/block/delete state cannot be applied destructively here
-            # without hiding common skills from other Animas, so personal
-            # enforcement happens at retrieval time in MemoryRetriever.
-            # Trust/security metadata remains enforced by MemoryIndexer.
-            indexed = shared_indexer.index_directory(cs_dir, "common_skills", force=force)
-            if indexed.files_failed == 0:
-                write_shared_hash(self._anima_dir, "shared_common_skills_hash", current_hash)
-            if indexed.chunks_indexed > 0:
-                logger.info(
-                    "Indexed %d chunks into shared_common_skills",
-                    indexed.chunks_indexed,
-                )
         except Exception as e:
             logger.warning("Failed to index shared common_skills: %s", e)
 
@@ -362,28 +397,15 @@ class RAGMemorySearch:
         glob: str,
         meta_key: str,
     ) -> None:
-        current_hash = _compute_dir_hash(directory, glob)
-        stored_hash = read_shared_hash(self._anima_dir, meta_key)
-        collection = f"shared_{memory_type}"
-        force = False
-        if current_hash == stored_hash:
-            existence = _shared_collection_exists(vector_store, collection)
-            if existence is not CollectionExistence.MISSING:
-                return
-            force = True
         try:
-            from core.memory.rag import MemoryIndexer
-
-            indexer = MemoryIndexer(
+            self._ensure_shared_directory_indexed(
                 vector_store,
-                anima_name="shared",
-                anima_dir=infer_data_dir(self._anima_dir),
-                collection_prefix="shared",
-                embedding_model=self._indexer.embedding_model if self._indexer else None,
+                directory,
+                memory_type,
+                glob,
+                meta_key,
+                shared_anima_dir=infer_data_dir(self._anima_dir),
             )
-            result = indexer.index_directory(directory, memory_type, force=force)
-            if result.files_failed == 0:
-                write_shared_hash(self._anima_dir, meta_key, current_hash)
         except Exception as exc:
             logger.warning("Failed to index company %s: %s", memory_type, exc)
 

--- a/tests/unit/core/config/test_models.py
+++ b/tests/unit/core/config/test_models.py
@@ -321,6 +321,12 @@ class TestRAGConfig:
         assert rag.facts_reconcile_similarity_threshold == 0.82
         assert rag.facts_reconcile_top_k == 5
 
+    def test_shared_check_timing_defaults(self) -> None:
+        rag = RAGConfig()
+        assert rag.shared_check_ttl_seconds == 30.0
+        assert rag.shared_check_backoff_initial_seconds == 5.0
+        assert rag.shared_check_backoff_max_seconds == 300.0
+
 
 # ── Cache management ──────────────────────────────────────
 

--- a/tests/unit/core/memory/test_rag_repair.py
+++ b/tests/unit/core/memory/test_rag_repair.py
@@ -947,6 +947,55 @@ def test_atomic_rebuild_includes_facts_and_conversation_summary(data_dir: Path, 
     ]
 
 
+def test_atomic_rebuild_invalidates_shared_check_ttl(data_dir: Path, monkeypatch):
+    from core.memory.rag import repair_state
+    from core.memory.rag.repair_rebuild import atomic_rebuild_vectordb
+    from core.memory.rag.shared_check_registry import (
+        SharedCheckOutcome,
+        make_shared_check_key,
+        reset_shared_check_registry,
+        run_shared_check,
+    )
+
+    anima_dir = data_dir / "animas" / "sora"
+    knowledge_dir = anima_dir / "knowledge"
+    knowledge_dir.mkdir(parents=True)
+    (knowledge_dir / "note.md").write_text("content", encoding="utf-8")
+    _patch_atomic_build(monkeypatch, chunks_per_dir=2)
+    monkeypatch.setattr("core.memory.rag.singleton.reset_vector_store", lambda anima_name=None: None)
+    repair_state.update_repair_state("sora", status="repairing", stage="repair")
+
+    store = MagicMock()
+    store._base_url = "http://vector.example/api"
+    key = make_shared_check_key("sora", store, "shared_common_knowledge", "source:hash")
+    calls = 0
+
+    def check() -> SharedCheckOutcome:
+        nonlocal calls
+        calls += 1
+        return SharedCheckOutcome.SUCCESS
+
+    def run() -> None:
+        run_shared_check(
+            key,
+            check,
+            ttl_seconds=30,
+            backoff_initial_seconds=5,
+            backoff_max_seconds=300,
+        )
+
+    reset_shared_check_registry()
+    try:
+        run()
+        run()
+        assert calls == 1
+        atomic_rebuild_vectordb("sora", include_shared=False, anima_dir=anima_dir)
+        run()
+        assert calls == 2
+    finally:
+        reset_shared_check_registry()
+
+
 def test_atomic_rebuild_refuses_swap_without_active_fence(data_dir: Path, monkeypatch):
     from core.memory.rag.repair_rebuild import RebuildVerificationError, atomic_rebuild_vectordb
 

--- a/tests/unit/core/memory/test_rag_search_shared_index.py
+++ b/tests/unit/core/memory/test_rag_search_shared_index.py
@@ -16,6 +16,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from core.memory.rag.indexer import IndexDirectoryResult, MemoryIndexer
+from core.memory.rag.shared_check_registry import (
+    SharedCheckOutcome,
+    invalidate_shared_checks,
+    make_shared_check_key,
+    reset_shared_check_registry,
+    run_shared_check,
+)
 from core.memory.rag.shared_meta import (
     SharedIndexMetaError,
     read_shared_hash,
@@ -28,6 +35,13 @@ from core.memory.rag_search import (
     RAGMemorySearch,
     _compute_dir_hash,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_process_shared_check_registry():
+    reset_shared_check_registry()
+    yield
+    reset_shared_check_registry()
 
 # ── _compute_dir_hash ─────────────────────────────────────
 
@@ -462,6 +476,7 @@ class TestEnsureSharedKnowledgeChangeDetection:
             # Second call: hash matches but collection STILL missing
             # (simulating a vectordb wipe between calls).
             # → must force re-index so collection is recreated.
+            invalidate_shared_checks(rag._anima_dir.name)
             rag._ensure_shared_knowledge_indexed(mock_vs)
             assert MockIdx.call_count == 1
             mock_shared.index_directory.assert_called_once_with(
@@ -576,12 +591,160 @@ class TestEnsureSharedSkillsChangeDetection:
             MockIdx.reset_mock()
             mock_shared.reset_mock()
 
+            invalidate_shared_checks(rag._anima_dir.name)
             rag._ensure_shared_skills_indexed(mock_vs)
             mock_shared.index_directory.assert_called_once_with(
                 common_skills_dir,
                 "common_skills",
                 force=True,
             )
+
+
+class TestSharedCheckRegistry:
+    def test_ttl_skips_then_rechecks_after_expiry(self, monkeypatch) -> None:
+        from core.memory.rag import shared_check_registry
+
+        now = [100.0]
+        monkeypatch.setattr(shared_check_registry.time, "monotonic", lambda: now[0])
+        key = make_shared_check_key("alice", object(), "shared_common_knowledge", "source:hash")
+        calls = 0
+
+        def check() -> SharedCheckOutcome:
+            nonlocal calls
+            calls += 1
+            return SharedCheckOutcome.SUCCESS
+
+        for _ in range(2):
+            run_shared_check(
+                key,
+                check,
+                ttl_seconds=10,
+                backoff_initial_seconds=2,
+                backoff_max_seconds=8,
+            )
+        assert calls == 1
+
+        now[0] = 110.1
+        run_shared_check(
+            key,
+            check,
+            ttl_seconds=10,
+            backoff_initial_seconds=2,
+            backoff_max_seconds=8,
+        )
+        assert calls == 2
+
+    def test_transient_failure_uses_exponential_backoff(self, monkeypatch) -> None:
+        from core.memory.rag import shared_check_registry
+
+        now = [100.0]
+        monkeypatch.setattr(shared_check_registry.time, "monotonic", lambda: now[0])
+        key = make_shared_check_key("alice", object(), "shared_common_knowledge", "source:hash")
+        outcomes = iter(
+            [
+                SharedCheckOutcome.TRANSIENT,
+                SharedCheckOutcome.TRANSIENT,
+                SharedCheckOutcome.SUCCESS,
+            ]
+        )
+        calls = 0
+
+        def check() -> SharedCheckOutcome:
+            nonlocal calls
+            calls += 1
+            return next(outcomes)
+
+        def run() -> None:
+            run_shared_check(
+                key,
+                check,
+                ttl_seconds=10,
+                backoff_initial_seconds=2,
+                backoff_max_seconds=8,
+            )
+
+        run()
+        run()
+        assert calls == 1
+        now[0] = 102.1
+        run()
+        assert calls == 2
+        now[0] = 106.0
+        run()
+        assert calls == 2
+        now[0] = 106.2
+        run()
+        assert calls == 3
+
+    def test_multiple_wrappers_share_one_reindex_flight(
+        self,
+        rag: RAGMemorySearch,
+        common_knowledge_dir: Path,
+    ) -> None:
+        from threading import Event
+
+        (common_knowledge_dir / "guide.md").write_text("# Guide")
+        second = RAGMemorySearch(rag._anima_dir, common_knowledge_dir, rag._common_skills_dir)
+        vector_store = MagicMock()
+        vector_store._base_url = "http://vector.example/api"
+        rag._indexer = SimpleNamespace(embedding_model=None)
+        second._indexer = SimpleNamespace(embedding_model=None)
+        started = Event()
+        release = Event()
+
+        def index_directory(*_args, **_kwargs) -> IndexDirectoryResult:
+            started.set()
+            assert release.wait(timeout=2)
+            return IndexDirectoryResult(chunks_indexed=1, files_indexed=1)
+
+        with (
+            patch.object(rag, "_shared_check_timing", return_value=(0.0, 2.0, 8.0)),
+            patch.object(second, "_shared_check_timing", return_value=(0.0, 2.0, 8.0)),
+            patch("core.memory.rag.MemoryIndexer") as MockIdx,
+            ThreadPoolExecutor(max_workers=2) as executor,
+        ):
+            MockIdx.return_value.index_directory.side_effect = index_directory
+            first_future = executor.submit(rag._ensure_shared_knowledge_indexed, vector_store)
+            assert started.wait(timeout=2)
+            second_future = executor.submit(second._ensure_shared_knowledge_indexed, vector_store)
+            time.sleep(0.05)
+            release.set()
+            first_future.result(timeout=2)
+            second_future.result(timeout=2)
+
+        MockIdx.return_value.index_directory.assert_called_once()
+
+    def test_company_reset_invalidates_positive_ttl(
+        self,
+        rag: RAGMemorySearch,
+        common_knowledge_dir: Path,
+    ) -> None:
+        (common_knowledge_dir / "guide.md").write_text("# Guide")
+        current_hash = _compute_dir_hash(common_knowledge_dir)
+        write_shared_hashes(
+            rag._anima_dir,
+            {
+                "shared_company_name": "old",
+                "shared_common_knowledge_hash": current_hash,
+            },
+        )
+        (rag._anima_dir / "status.json").write_text('{"company": "new"}', encoding="utf-8")
+        vector_store = MagicMock()
+        vector_store._base_url = "http://vector.example/api"
+        vector_store.collection_exists.return_value = CollectionExistence.EXISTS
+        vector_store.delete_collection.return_value = True
+        rag._indexer = SimpleNamespace(embedding_model=None)
+
+        with (
+            patch.object(rag, "_shared_check_timing", return_value=(30.0, 2.0, 8.0)),
+            patch("core.memory.rag.MemoryIndexer") as MockIdx,
+        ):
+            rag._ensure_shared_knowledge_indexed(vector_store)
+            assert rag._reset_shared_for_company_change(vector_store) == (True, "new")
+            MockIdx.return_value.index_directory.return_value = IndexDirectoryResult(files_indexed=1)
+            rag._ensure_shared_knowledge_indexed(vector_store)
+
+        MockIdx.return_value.index_directory.assert_called_once()
 
 
 # ── _get_indexer calls _check_shared_collections ──────────


### PR DESCRIPTION
## 概要
priming1回で複数RAGMemorySearch wrapperがshared再indexを3〜9回重複発火する問題の止血。Base: #257（P0-3にstacked）

## 変更
- process-wide singleflight registry（key=owner+base_url+hash generation・monotonic clock）
- TTL/指数backoff（RAGConfig新設・コードdefault有効）・company reset/repair完了の明示的invalidation

## 検証
- 対象UT 231〜366 passed / ruff clean（PdM再実行済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)