### PR TITLE
fix(rag): repair reset空振り修正 + swap検証強化 (P0-6)

### DIFF
--- a/cli/commands/repair_rag_cmd.py
+++ b/cli/commands/repair_rag_cmd.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import secrets
 import sys
 
 
@@ -82,6 +83,10 @@ def repair_rag_command(args: argparse.Namespace) -> None:
 
         temp_worker = start_temporary_vector_worker()
 
+    previous_nonce = os.environ.get("ANIMAWORKS_RAG_REPAIR_NONCE")
+    if previous_nonce is None:
+        os.environ["ANIMAWORKS_RAG_REPAIR_NONCE"] = secrets.token_urlsafe(32)
+
     reason = str(getattr(args, "reason", "manual_repair_rag_cli"))
     try:
         if anima:
@@ -117,6 +122,8 @@ def repair_rag_command(args: argparse.Namespace) -> None:
         if failed:
             raise SystemExit(1)
     finally:
+        if previous_nonce is None:
+            os.environ.pop("ANIMAWORKS_RAG_REPAIR_NONCE", None)
         if temp_worker is not None:
             temp_worker.stop()
 

--- a/core/memory/rag/http_store.py
+++ b/core/memory/rag/http_store.py
@@ -223,6 +223,18 @@ class HttpVectorStore(VectorStore):
         self._write_circuit_suppressed.clear()
         return True
 
+    def verify_repair(self, repair_nonce: str, *, expected_chunks: int) -> bool:
+        """Verify a swapped DB through the worker while its repair fence is active."""
+        data = self._post(
+            "/verify-repair",
+            {
+                "anima_name": self._anima_name,
+                "repair_nonce": repair_nonce,
+                "expected_chunks": expected_chunks,
+            },
+        )
+        return data is not None and data.get("status") == "ok"
+
     def delete_collection(self, name: str) -> bool:
         """Delete a collection."""
         return (

--- a/core/memory/rag/repair_rebuild.py
+++ b/core/memory/rag/repair_rebuild.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -36,6 +37,23 @@ def reset_worker_vector_store(anima_name: str) -> bool:
             return store.reset_store()
     except Exception:
         logger.debug("Failed to reset vector worker store for %s", anima_name, exc_info=True)
+    return False
+
+
+def verify_worker_vector_store(anima_name: str, *, expected_chunks: int) -> bool:
+    """Verify the swapped DB through the fenced worker using the repair nonce."""
+    repair_nonce = os.environ.get("ANIMAWORKS_RAG_REPAIR_NONCE")
+    if not repair_nonce:
+        return False
+    try:
+        from core.memory.rag.http_store import HttpVectorStore
+        from core.memory.rag.singleton import get_vector_store
+
+        store = get_vector_store(anima_name)
+        if isinstance(store, HttpVectorStore):
+            return store.verify_repair(repair_nonce, expected_chunks=expected_chunks)
+    except Exception:
+        logger.debug("Failed to verify rebuilt vector store for %s", anima_name, exc_info=True)
     return False
 
 
@@ -123,7 +141,7 @@ def _reindex_into_store(
     *,
     include_shared: bool,
     anima_dir: Path | None = None,
-) -> int:
+) -> tuple[int, dict[str, str]]:
     """Index an anima's memory (and optionally shared collections) into a store."""
     from core.company_resources import get_company_resources
     from core.memory.bm25 import rebuild_longterm_bm25_index
@@ -132,11 +150,18 @@ def _reindex_into_store(
 
     anima_dir = Path(anima_dir) if anima_dir is not None else get_animas_dir() / anima_name
     total_chunks = 0
+    shared_hashes: dict[str, str] = {}
     indexer = MemoryIndexer(vector_store, anima_name, anima_dir)
     for memory_type in ("knowledge", "episodes", "procedures", "skills", "facts"):
         memory_dir = anima_dir / memory_type
         if memory_dir.is_dir():
-            total_chunks += indexer.index_directory(memory_dir, memory_type, force=True).chunks_indexed
+            result = indexer.index_directory(memory_dir, memory_type, force=True)
+            if result.files_failed or result.files_unprocessed:
+                raise RebuildVerificationError(
+                    f"failed to fully rebuild {memory_type} for {anima_name}: "
+                    f"failed={result.files_failed} unprocessed={result.files_unprocessed}"
+                )
+            total_chunks += result.chunks_indexed
 
     state_dir = anima_dir / "state"
     if (state_dir / "conversation.json").is_file():
@@ -178,21 +203,61 @@ def _reindex_into_store(
         for label, src_dir, glob, meta_key in shared_sources:
             if not src_dir.is_dir():
                 continue
-            total_chunks += shared_indexer.index_directory(src_dir, label, force=True).chunks_indexed
-            write_shared_hash(anima_dir, src_dir, glob, meta_key)
-    return total_chunks
+            result = shared_indexer.index_directory(src_dir, label, force=True)
+            if result.files_failed or result.files_unprocessed:
+                raise RebuildVerificationError(
+                    f"failed to fully rebuild {meta_key} for {anima_name}: "
+                    f"failed={result.files_failed} unprocessed={result.files_unprocessed}"
+                )
+            total_chunks += result.chunks_indexed
+            from core.memory.rag_search import _compute_dir_hash
+
+            shared_hashes[meta_key] = _compute_dir_hash(src_dir, glob)
+    return total_chunks, shared_hashes
 
 
 def full_reindex(anima_name: str, *, include_shared: bool) -> int:
     """Reindex an anima in place via the vector worker (legacy path)."""
     from core.memory.rag.singleton import get_vector_store
+    from core.paths import get_animas_dir
 
     if not os.environ.get("ANIMAWORKS_VECTOR_URL"):
         raise RuntimeError("RAG reindex requires ANIMAWORKS_VECTOR_URL; run it through the vector worker")
     vector_store = get_vector_store(anima_name)
     if vector_store is None:
         raise RuntimeError(f"Vector store unavailable for {anima_name}")
-    return _reindex_into_store(vector_store, anima_name, include_shared=include_shared)
+    chunks, shared_hashes = _reindex_into_store(vector_store, anima_name, include_shared=include_shared)
+    if shared_hashes:
+        from core.memory.rag.shared_meta import write_shared_hashes
+
+        write_shared_hashes(get_animas_dir() / anima_name, shared_hashes)
+    return chunks
+
+
+def _backup_bm25(anima_dir: Path) -> tuple[Path, set[str]]:
+    from core.memory.bm25 import longterm_bm25_dirty_path, longterm_bm25_index_path
+
+    state_dir = anima_dir / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    backup_dir = Path(tempfile.mkdtemp(prefix=".rag-repair-bm25-", dir=state_dir))
+    existing: set[str] = set()
+    for path in (longterm_bm25_index_path(anima_dir), longterm_bm25_dirty_path(anima_dir)):
+        if path.is_file():
+            existing.add(path.name)
+            shutil.copy2(path, backup_dir / path.name)
+    return backup_dir, existing
+
+
+def _restore_bm25(anima_dir: Path, backup_dir: Path, existing: set[str]) -> None:
+    from core.memory.bm25 import longterm_bm25_dirty_path, longterm_bm25_index_path
+
+    for path in (longterm_bm25_index_path(anima_dir), longterm_bm25_dirty_path(anima_dir)):
+        backup = backup_dir / path.name
+        if path.name in existing:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(backup, path)
+        elif path.exists():
+            path.unlink()
 
 
 def atomic_rebuild_vectordb(
@@ -224,75 +289,116 @@ def atomic_rebuild_vectordb(
     from core.memory.rag.store import create_chroma_vector_store
     from core.paths import get_anima_vectordb_dir
 
-    resolved_anima_dir = Path(anima_dir) if anima_dir is not None else None
-    live = resolved_anima_dir / "vectordb" if resolved_anima_dir is not None else get_anima_vectordb_dir(anima_name)
+    resolved_anima_dir = (
+        Path(anima_dir) if anima_dir is not None else get_anima_vectordb_dir(anima_name).parent
+    )
+    live = resolved_anima_dir / "vectordb"
     staging = live.parent / f"vectordb.staging-{os.getpid()}"
     if staging.exists():
         shutil.rmtree(staging, ignore_errors=True)
     staging.mkdir(parents=True, exist_ok=True)
+    bm25_backup, bm25_existing = _backup_bm25(resolved_anima_dir)
+    archive: Path | None = None
+    swap_started = False
+    succeeded = False
 
-    prev_allow = os.environ.get("ANIMAWORKS_ALLOW_DIRECT_CHROMA")
-    os.environ["ANIMAWORKS_ALLOW_DIRECT_CHROMA"] = "1"
     try:
-        store = create_chroma_vector_store(persist_dir=staging, anima_name=anima_name)
+        prev_allow = os.environ.get("ANIMAWORKS_ALLOW_DIRECT_CHROMA")
+        os.environ["ANIMAWORKS_ALLOW_DIRECT_CHROMA"] = "1"
         try:
-            chunks = _reindex_into_store(
-                store,
-                anima_name,
-                include_shared=include_shared,
-                anima_dir=resolved_anima_dir,
-            )
-            if chunks > 0:
-                collections = store.list_collections_checked()
-                if collections is None:
-                    raise RebuildVerificationError(
-                        f"staged vector DB for {anima_name} is unreadable despite indexing {chunks} chunks"
-                    )
-                if not collections:
-                    raise RebuildVerificationError(
-                        f"staged vector DB for {anima_name} has no collections despite indexing {chunks} chunks"
-                    )
+            store = create_chroma_vector_store(persist_dir=staging, anima_name=anima_name)
+            try:
+                chunks, shared_hashes = _reindex_into_store(
+                    store,
+                    anima_name,
+                    include_shared=include_shared,
+                    anima_dir=resolved_anima_dir,
+                )
+                if chunks > 0:
+                    collections = store.list_collections_checked()
+                    if collections is None:
+                        raise RebuildVerificationError(
+                            f"staged vector DB for {anima_name} is unreadable despite indexing {chunks} chunks"
+                        )
+                    if not collections:
+                        raise RebuildVerificationError(
+                            f"staged vector DB for {anima_name} has no collections despite indexing {chunks} chunks"
+                        )
+            finally:
+                store.close()
+                gc.collect()
         finally:
-            store.close()
-            gc.collect()
-    except BaseException:
-        shutil.rmtree(staging, ignore_errors=True)  # never leave a half-built staging dir
+            if prev_allow is None:
+                os.environ.pop("ANIMAWORKS_ALLOW_DIRECT_CHROMA", None)
+            else:
+                os.environ["ANIMAWORKS_ALLOW_DIRECT_CHROMA"] = prev_allow
+
+        if not _has_active_repair_fence(anima_name, anima_dir=resolved_anima_dir):
+            raise RebuildVerificationError(
+                f"active RAG repair access fence missing for {anima_name}; refusing vector DB swap"
+            )
+        if not reset_worker_vector_store(anima_name):
+            raise RebuildVerificationError(f"vector worker reset failed before swap for {anima_name}")
+        reset_vector_store(anima_name)
+
+        swap_started = True
+        if live.exists():
+            archive_dir = live.parent / "archive"
+            archive_dir.mkdir(parents=True, exist_ok=True)
+            stamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+            archive = archive_dir / f"vectordb-corrupt-{stamp}"
+            suffix = 1
+            while archive.exists():
+                suffix += 1
+                archive = archive_dir / f"vectordb-corrupt-{stamp}-{suffix}"
+            shutil.move(str(live), str(archive))
+        shutil.move(str(staging), str(live))
+
+        if not reset_worker_vector_store(anima_name):
+            raise RebuildVerificationError(f"vector worker reset failed after swap for {anima_name}")
+        reset_vector_store(anima_name)
+        if not verify_worker_vector_store(anima_name, expected_chunks=chunks):
+            raise RebuildVerificationError(f"vector worker verification failed after swap for {anima_name}")
+
+        if shared_hashes:
+            from core.memory.rag.shared_meta import write_shared_hashes
+
+            write_shared_hashes(resolved_anima_dir, shared_hashes)
+        succeeded = True
+        return chunks, archive
+    except BaseException as exc:
+        rollback_errors: list[str] = []
+        if swap_started:
+            try:
+                reset_worker_vector_store(anima_name)
+                reset_vector_store(anima_name)
+                if live.exists():
+                    failed_dir = live.parent / "archive"
+                    failed_dir.mkdir(parents=True, exist_ok=True)
+                    failed_stamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+                    failed_live = failed_dir / f"vectordb-rebuild-failed-{failed_stamp}"
+                    suffix = 1
+                    while failed_live.exists():
+                        suffix += 1
+                        failed_live = failed_dir / f"vectordb-rebuild-failed-{failed_stamp}-{suffix}"
+                    shutil.move(str(live), str(failed_live))
+                if archive is not None and archive.exists():
+                    shutil.move(str(archive), str(live))
+                reset_vector_store(anima_name)
+                if not reset_worker_vector_store(anima_name):
+                    rollback_errors.append("worker reset failed after rollback")
+            except Exception as rollback_exc:
+                rollback_errors.append(str(rollback_exc))
+        try:
+            _restore_bm25(resolved_anima_dir, bm25_backup, bm25_existing)
+        except Exception as rollback_exc:
+            rollback_errors.append(f"BM25 rollback failed: {rollback_exc}")
+        if rollback_errors:
+            raise RebuildVerificationError(
+                f"{exc}; rollback incomplete: {'; '.join(rollback_errors)}"
+            ) from exc
         raise
     finally:
-        if prev_allow is None:
-            os.environ.pop("ANIMAWORKS_ALLOW_DIRECT_CHROMA", None)
-        else:
-            os.environ["ANIMAWORKS_ALLOW_DIRECT_CHROMA"] = prev_allow
-
-    # Atomic swap. Reset the worker so it releases the live handle, archive the
-    # old DB, move staging into place, then reset again so the worker reopens the
-    # new DB. The sibling-drop reset fix keeps these resets from poisoning others.
-    if not _has_active_repair_fence(anima_name, anima_dir=resolved_anima_dir):
-        shutil.rmtree(staging, ignore_errors=True)
-        raise RebuildVerificationError(
-            f"active RAG repair access fence missing for {anima_name}; refusing vector DB swap"
-        )
-    archive: Path | None = None
-    reset_worker_vector_store(anima_name)
-    reset_vector_store(anima_name)
-    if live.exists():
-        archive_dir = live.parent / "archive"
-        archive_dir.mkdir(parents=True, exist_ok=True)
-        stamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
-        archive = archive_dir / f"vectordb-corrupt-{stamp}"
-        suffix = 1
-        while archive.exists():
-            suffix += 1
-            archive = archive_dir / f"vectordb-corrupt-{stamp}-{suffix}"
-        shutil.move(str(live), str(archive))
-    shutil.move(str(staging), str(live))
-    reset_worker_vector_store(anima_name)
-    reset_vector_store(anima_name)
-    return chunks, archive
-
-
-def write_shared_hash(anima_dir: Path, src_dir: Path, glob: str, meta_key: str) -> None:
-    from core.memory.rag.shared_meta import write_shared_hash as write_meta_hash
-    from core.memory.rag_search import _compute_dir_hash
-
-    write_meta_hash(anima_dir, meta_key, _compute_dir_hash(src_dir, glob))
+        if not succeeded:
+            shutil.rmtree(staging, ignore_errors=True)
+        shutil.rmtree(bm25_backup, ignore_errors=True)

--- a/core/memory/rag/repair_service.py
+++ b/core/memory/rag/repair_service.py
@@ -782,7 +782,8 @@ class RAGRepairService:
                     from core.memory.rag.repair_rebuild import reset_worker_vector_store
                     from core.memory.rag.singleton import reset_vector_store
 
-                    reset_worker_vector_store(anima_name)
+                    if not reset_worker_vector_store(anima_name):
+                        raise RuntimeError(f"vector worker reset failed for healthy repair skip: {anima_name}")
                     reset_vector_store(anima_name)
                     repair_state.update_repair_state(
                         anima_name,
@@ -794,6 +795,7 @@ class RAGRepairService:
                         collection=collection,
                         source=source,
                         include_shared=include_shared,
+                        repair_nonce=None,
                         last_success_at=iso(),
                         last_error=None,
                         consecutive_failures=0,
@@ -823,6 +825,7 @@ class RAGRepairService:
                     collection=collection,
                     source=source,
                     include_shared=include_shared,
+                    repair_nonce=os.environ.get("ANIMAWORKS_RAG_REPAIR_NONCE"),
                     last_reason=reason,
                     last_collection=collection,
                     last_source=source,
@@ -843,6 +846,7 @@ class RAGRepairService:
                     pid=None,
                     last_success_at=iso(),
                     last_error=None,
+                    repair_nonce=None,
                     consecutive_failures=0,
                     last_quarantine_path=str(quarantine_path) if quarantine_path else None,
                     last_chunks_indexed=chunks,
@@ -878,6 +882,7 @@ class RAGRepairService:
                     pid=None,
                     last_failure_at=iso(),
                     last_error=str(exc),
+                    repair_nonce=None,
                     consecutive_failures=failures,
                     last_quarantine_path=str(quarantine_path) if quarantine_path else None,
                 )

--- a/core/memory/rag/repair_state.py
+++ b/core/memory/rag/repair_state.py
@@ -63,6 +63,7 @@ def state_with_defaults(state: dict[str, Any] | None = None) -> dict[str, Any]:
         "collection": None,
         "source": None,
         "include_shared": False,
+        "repair_nonce": None,
         "last_error": None,
         "last_quarantine_path": None,
         "last_chunks_indexed": 0,

--- a/core/memory/rag/store.py
+++ b/core/memory/rag/store.py
@@ -574,6 +574,29 @@ class ChromaVectorStore(VectorStore):
             )
             raise
 
+    def verify_rebuilt_data(self, *, expected_chunks: int) -> dict[str, int]:
+        """Run a real similarity query against freshly reopened Chroma data."""
+        collections = self._list_collections_once()
+        if expected_chunks <= 0:
+            return {"collections": len(collections), "query_results": 0}
+        if not collections:
+            raise RuntimeError(f"no collections found despite indexing {expected_chunks} chunks")
+
+        for name in collections:
+            collection = self.client.get_collection(name=name)
+            sample = collection.get(limit=1, include=["embeddings"])
+            ids = sample.get("ids") or []
+            embeddings = sample.get("embeddings")
+            if not ids or embeddings is None or len(embeddings) == 0:
+                continue
+            embedding = list(embeddings[0])
+            queried = collection.query(query_embeddings=[embedding], n_results=1)
+            result_ids = queried.get("ids") or []
+            if result_ids and result_ids[0]:
+                return {"collections": len(collections), "query_results": len(result_ids[0])}
+
+        raise RuntimeError(f"no queryable documents found despite indexing {expected_chunks} chunks")
+
     def _upsert_once(self, collection: str, documents: list[Document]) -> bool:
         coll = self.client.get_or_create_collection(
             name=collection,

--- a/core/memory/rag/vector_worker.py
+++ b/core/memory/rag/vector_worker.py
@@ -10,6 +10,7 @@ import argparse
 import asyncio
 import concurrent.futures
 import functools
+import hmac
 import logging
 import os
 import threading
@@ -21,7 +22,7 @@ from typing import Any
 
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from core.platform.fd_limits import raise_fd_soft_limit
 
@@ -204,6 +205,12 @@ class VectorQuickCheckRequest(BaseModel):
     record_repair: bool = True
 
 
+class VectorRepairVerifyRequest(BaseModel):
+    anima_name: str
+    repair_nonce: str = Field(min_length=1)
+    expected_chunks: int = Field(ge=0)
+
+
 def _set_future_result(future: asyncio.Future[Any], result: Any) -> None:
     if not future.done():
         future.set_result(result)
@@ -265,6 +272,29 @@ def _has_active_repair_state(anima_name: str) -> bool:
     except Exception:
         logger.debug("Failed to read RAG repair state for owner=%s", anima_name, exc_info=True)
         return True
+
+
+def _repair_nonce_matches(anima_name: str, repair_nonce: str) -> bool:
+    from core.memory.rag import repair_state
+
+    state = repair_state.read_state(anima_name)
+    expected = state.get("repair_nonce")
+    return (
+        state.get("status") in repair_state.ACTIVE_REPAIR_STATUSES
+        and isinstance(expected, str)
+        and bool(expected)
+        and hmac.compare_digest(expected, repair_nonce)
+    )
+
+
+def _verify_repair_store(anima_name: str, expected_chunks: int) -> dict[str, int]:
+    from core.memory.rag.singleton import get_vector_store, vector_store_operation
+
+    with vector_store_operation(anima_name):
+        store = get_vector_store(anima_name)
+        if store is None:
+            raise RuntimeError("vector store unavailable")
+        return store.verify_rebuilt_data(expected_chunks=expected_chunks)
 
 
 def _begin_latched_store_recovery(anima_name: str) -> bool:
@@ -714,6 +744,17 @@ def create_app() -> FastAPI:
         _clear_owner_write_circuit_breakers(body.anima_name)
         _clear_owner_self_heal_escalation(body.anima_name)
         return {"status": "ok"}
+
+    @app.post("/verify-repair")
+    async def vector_verify_repair(body: VectorRepairVerifyRequest):
+        if not _repair_nonce_matches(body.anima_name, body.repair_nonce):
+            return JSONResponse(status_code=403, content={"detail": "Invalid RAG repair nonce"})
+        try:
+            result = await run_native(_verify_repair_store, body.anima_name, body.expected_chunks)
+        except Exception as exc:
+            logger.warning("Vector repair verification failed for owner=%s", body.anima_name, exc_info=True)
+            return JSONResponse(status_code=500, content={"detail": str(exc)})
+        return {"status": "ok", **result}
 
     @app.post("/query")
     async def vector_query(body: VectorQueryRequest):

--- a/core/supervisor/_mgr_rag_repair.py
+++ b/core/supervisor/_mgr_rag_repair.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
+import secrets
 import sys
 from pathlib import Path
 
@@ -262,6 +264,7 @@ class RAGRepairMixin:
                     "pid": None,
                     "reason": reason,
                     "include_shared": include_shared,
+                    "repair_nonce": None,
                     "last_error": None if repair_succeeded else current.get("last_error"),
                 },
             )
@@ -348,6 +351,7 @@ class RAGRepairMixin:
                 "pid": None,
                 "reason": reason,
                 "include_shared": include_shared,
+                "repair_nonce": None,
                 "last_error": error,
             },
         )
@@ -427,15 +431,40 @@ class RAGRepairMixin:
             cmd.append("--shared")
         timeout = self._rag_repair_timeout_seconds()
         repo_root = Path(__file__).resolve().parents[2]
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            cwd=repo_root,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
+        vector_url = getattr(getattr(self, "vector_worker_manager", None), "base_url", None)
+        if not isinstance(vector_url, str) or not vector_url:
+            return {
+                "ok": False,
+                "status": "failed",
+                "error": "current vector worker URL unavailable",
+            }
+        repair_nonce = secrets.token_urlsafe(32)
         current_stage = self._read_rag_repair_state(anima_name).get("stage")
         if not current_stage or current_stage == "complete":
             current_stage = "repair_process"
+        self._write_rag_repair_state(
+            anima_name,
+            {
+                "status": "repairing",
+                "stage": current_stage,
+                "pid": None,
+                "started_at": repair_state.now_iso(),
+                "reason": reason,
+                "include_shared": include_shared,
+                "repair_nonce": repair_nonce,
+                "last_error": None,
+            },
+        )
+        env = os.environ.copy()
+        env["ANIMAWORKS_VECTOR_URL"] = vector_url
+        env["ANIMAWORKS_RAG_REPAIR_NONCE"] = repair_nonce
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            cwd=repo_root,
+            env=env,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
         self._write_rag_repair_state(
             anima_name,
             {
@@ -445,6 +474,7 @@ class RAGRepairMixin:
                 "started_at": repair_state.now_iso(),
                 "reason": reason,
                 "include_shared": include_shared,
+                "repair_nonce": repair_nonce,
                 "last_error": None,
             },
         )

--- a/core/supervisor/manager.py
+++ b/core/supervisor/manager.py
@@ -97,12 +97,14 @@ class ProcessSupervisor(HealthMixin, RAGRepairMixin, ReconcileMixin, SchedulerMi
         health_config: HealthConfig | None = None,
         reconciliation_config: ReconciliationConfig | None = None,
         ws_manager: Any | None = None,
+        vector_worker_manager: Any | None = None,
     ):
         self.animas_dir = animas_dir
         self.shared_dir = shared_dir
         self.run_dir = run_dir
         self.log_dir = log_dir
         self.ws_manager = ws_manager
+        self.vector_worker_manager = vector_worker_manager
 
         self.restart_policy = restart_policy or RestartPolicy()
         self.health_config = health_config or HealthConfig()

--- a/server/app.py
+++ b/server/app.py
@@ -1025,6 +1025,7 @@ def create_app(
         log_dir=log_dir,
         ws_manager=ws_manager,
         health_config=health_cfg,
+        vector_worker_manager=vector_worker,
     )
 
     # Auto-migrate old Japanese cron.md format to standard cron expressions

--- a/tests/unit/core/memory/test_http_vector_store.py
+++ b/tests/unit/core/memory/test_http_vector_store.py
@@ -355,6 +355,23 @@ def test_reset_store_returns_false_on_old_or_unavailable_worker():
         assert store.reset_store() is False
 
 
+def test_verify_repair_posts_nonce_and_expected_chunks():
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"status": "ok", "collections": 1, "query_results": 1}
+    mock_client.post.return_value = mock_response
+
+    with patch("httpx.Client", return_value=mock_client):
+        store = _make_store()
+        assert store.verify_repair("repair-secret", expected_chunks=3) is True
+
+    mock_client.post.assert_called_once_with(
+        "/verify-repair",
+        json={"anima_name": "rin", "repair_nonce": "repair-secret", "expected_chunks": 3},
+    )
+
+
 # ── test_close ─────────────────────────────────────────────────────
 
 

--- a/tests/unit/core/memory/test_rag_repair.py
+++ b/tests/unit/core/memory/test_rag_repair.py
@@ -847,7 +847,15 @@ class _FakeBuildStore:
         self.closed = True
 
 
-def _patch_atomic_build(monkeypatch, *, chunks_per_dir=2, collections=None, indexer_calls=None):
+def _patch_atomic_build(
+    monkeypatch,
+    *,
+    chunks_per_dir=2,
+    collections=None,
+    indexer_calls=None,
+    files_failed=0,
+    files_unprocessed=0,
+):
     """Patch the pieces ``atomic_rebuild_vectordb`` builds with (no real chroma)."""
 
     class FakeIndexer:
@@ -857,7 +865,12 @@ def _patch_atomic_build(monkeypatch, *, chunks_per_dir=2, collections=None, inde
         def index_directory(self, *args, **kwargs):
             if indexer_calls is not None:
                 indexer_calls.append((self.anima_name, str(args[1])))
-            return IndexDirectoryResult(chunks_indexed=chunks_per_dir, files_indexed=1)
+            return IndexDirectoryResult(
+                chunks_indexed=chunks_per_dir,
+                files_indexed=0 if files_failed else 1,
+                files_failed=files_failed,
+                files_unprocessed=files_unprocessed,
+            )
 
         def index_conversation_summary(self, *args, **kwargs):
             return chunks_per_dir
@@ -868,6 +881,10 @@ def _patch_atomic_build(monkeypatch, *, chunks_per_dir=2, collections=None, inde
         lambda *a, **k: _FakeBuildStore(collections=collections),
     )
     monkeypatch.setattr("core.memory.rag.repair_rebuild.reset_worker_vector_store", lambda anima_name: True)
+    monkeypatch.setattr(
+        "core.memory.rag.repair_rebuild.verify_worker_vector_store",
+        lambda anima_name, expected_chunks: True,
+    )
 
 
 def test_repair_rebuilds_swaps_and_archives(data_dir: Path, monkeypatch):
@@ -1308,3 +1325,117 @@ def test_repair_if_allowed_retries_before_failure_limit(data_dir: Path):
 
     assert result.status == "success"
     service.repair_anima.assert_called_once()
+
+
+def test_atomic_rebuild_reset_failure_keeps_live_db(data_dir: Path, monkeypatch) -> None:
+    anima_dir = data_dir / "animas" / "sora"
+    (anima_dir / "knowledge").mkdir(parents=True)
+    (anima_dir / "knowledge" / "topic.md").write_text("content", encoding="utf-8")
+    (anima_dir / "state").mkdir()
+    live = anima_dir / "vectordb"
+    live.mkdir()
+    (live / "live.bin").write_text("old-vector", encoding="utf-8")
+
+    _patch_atomic_build(monkeypatch)
+    monkeypatch.setattr("core.memory.rag.repair_rebuild.reset_worker_vector_store", lambda _name: False)
+    monkeypatch.setattr("core.memory.rag.singleton.reset_vector_store", lambda _name=None: None)
+
+    result = RAGRepairService(enabled=True).repair_anima("sora", reason="hnsw_corruption", source="test")
+
+    assert result.status == "failed"
+    assert "reset failed before swap" in (result.error or "")
+    assert (live / "live.bin").read_text(encoding="utf-8") == "old-vector"
+    assert not (anima_dir / "archive").exists()
+
+
+def test_atomic_rebuild_verify_failure_rolls_back_vector_and_bm25(data_dir: Path, monkeypatch) -> None:
+    from core.memory.bm25 import longterm_bm25_dirty_path, longterm_bm25_index_path
+
+    anima_dir = data_dir / "animas" / "sora"
+    (anima_dir / "knowledge").mkdir(parents=True)
+    (anima_dir / "knowledge" / "topic.md").write_text("content", encoding="utf-8")
+    (anima_dir / "state").mkdir()
+    live = anima_dir / "vectordb"
+    live.mkdir()
+    (live / "live.bin").write_text("old-vector", encoding="utf-8")
+    longterm_bm25_index_path(anima_dir).write_text("old-bm25", encoding="utf-8")
+    longterm_bm25_dirty_path(anima_dir).write_text("dirty", encoding="utf-8")
+
+    _patch_atomic_build(monkeypatch)
+    monkeypatch.setattr(
+        "core.memory.rag.repair_rebuild.verify_worker_vector_store",
+        lambda _name, expected_chunks: False,
+    )
+    monkeypatch.setattr("core.memory.rag.singleton.reset_vector_store", lambda _name=None: None)
+
+    result = RAGRepairService(enabled=True).repair_anima("sora", reason="hnsw_corruption", source="test")
+
+    assert result.status == "failed"
+    assert "verification failed after swap" in (result.error or "")
+    assert (live / "live.bin").read_text(encoding="utf-8") == "old-vector"
+    assert longterm_bm25_index_path(anima_dir).read_text(encoding="utf-8") == "old-bm25"
+    assert longterm_bm25_dirty_path(anima_dir).read_text(encoding="utf-8") == "dirty"
+    assert list((anima_dir / "archive").glob("vectordb-rebuild-failed-*"))
+    assert not list((anima_dir / "archive").glob("vectordb-corrupt-*"))
+
+
+def test_atomic_rebuild_partial_failure_does_not_swap_or_write_shared_hash(data_dir: Path, monkeypatch) -> None:
+    anima_dir = data_dir / "animas" / "sora"
+    (anima_dir / "state").mkdir(parents=True)
+    live = anima_dir / "vectordb"
+    live.mkdir()
+    (live / "live.bin").write_text("old-vector", encoding="utf-8")
+    common = data_dir / "common_knowledge"
+    common.mkdir(exist_ok=True)
+    (common / "topic.md").write_text("content", encoding="utf-8")
+
+    _patch_atomic_build(monkeypatch, chunks_per_dir=0, files_failed=1)
+    monkeypatch.setattr("core.memory.rag.singleton.reset_vector_store", lambda _name=None: None)
+
+    result = RAGRepairService(enabled=True).repair_anima(
+        "sora",
+        reason="hnsw_corruption",
+        source="test",
+        include_shared=True,
+    )
+
+    assert result.status == "failed"
+    assert "failed to fully rebuild" in (result.error or "")
+    assert (live / "live.bin").read_text(encoding="utf-8") == "old-vector"
+    assert read_shared_hash(anima_dir, "shared_common_knowledge_hash") is None
+    assert not list(anima_dir.glob("vectordb.staging-*"))
+
+
+def test_healthy_skip_reset_failure_is_recorded_as_repair_failure(data_dir: Path, monkeypatch) -> None:
+    anima_dir = data_dir / "animas" / "sora"
+    (anima_dir / "state").mkdir(parents=True)
+    (anima_dir / "vectordb").mkdir()
+    monkeypatch.setattr("core.memory.rag.repair_rebuild.reset_worker_vector_store", lambda _name: False)
+    monkeypatch.setattr("core.memory.rag.singleton.reset_vector_store", lambda _name=None: None)
+
+    service = RAGRepairService(enabled=True)
+    service._sqlite_quick_check_ok = MagicMock(return_value=True)  # type: ignore[method-assign]
+    result = service.repair_anima("sora", reason="sqlite_malformed", source="test")
+
+    assert result.status == "failed"
+    assert "healthy repair skip" in (result.error or "")
+    state = json.loads((anima_dir / "state" / "rag_repair.json").read_text(encoding="utf-8"))
+    assert state["status"] == "failed"
+
+
+def test_chroma_repair_verification_runs_real_query() -> None:
+    from core.memory.rag.store import ChromaVectorStore
+
+    collection = MagicMock()
+    collection.get.return_value = {"ids": ["doc-1"], "embeddings": [[0.1, 0.2]]}
+    collection.query.return_value = {"ids": [["doc-1"]]}
+    store = ChromaVectorStore.__new__(ChromaVectorStore)
+    store.client = MagicMock()
+    store.client.list_collections.return_value = [MagicMock(name="knowledge")]
+    store.client.list_collections.return_value[0].name = "knowledge"
+    store.client.get_collection.return_value = collection
+
+    result = store.verify_rebuilt_data(expected_chunks=1)
+
+    assert result == {"collections": 1, "query_results": 1}
+    collection.query.assert_called_once_with(query_embeddings=[[0.1, 0.2]], n_results=1)

--- a/tests/unit/core/memory/test_vector_worker_app.py
+++ b/tests/unit/core/memory/test_vector_worker_app.py
@@ -549,6 +549,38 @@ def test_vector_worker_reset_store_clears_cache_and_owner_breakers(monkeypatch) 
     assert "other:knowledge" in vector_worker._write_circuit_breakers
 
 
+def test_vector_worker_repair_verify_requires_nonce_and_bypasses_fence(monkeypatch, data_dir) -> None:
+    monkeypatch.delenv("ANIMAWORKS_VECTOR_URL", raising=False)
+    state_path = data_dir / "animas" / "sora" / "state" / "rag_repair.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps({"status": "repairing", "repair_nonce": "repair-secret"}),
+        encoding="utf-8",
+    )
+
+    from core.memory.rag.vector_worker import create_app
+
+    store = MagicMock()
+    store.verify_rebuilt_data.return_value = {"collections": 1, "query_results": 1}
+    with (
+        patch("core.memory.rag.singleton.get_vector_store", return_value=store),
+        TestClient(create_app()) as client,
+    ):
+        rejected = client.post(
+            "/verify-repair",
+            json={"anima_name": "sora", "repair_nonce": "wrong", "expected_chunks": 1},
+        )
+        verified = client.post(
+            "/verify-repair",
+            json={"anima_name": "sora", "repair_nonce": "repair-secret", "expected_chunks": 1},
+        )
+
+    assert rejected.status_code == 403
+    assert verified.status_code == 200
+    assert verified.json() == {"status": "ok", "collections": 1, "query_results": 1}
+    store.verify_rebuilt_data.assert_called_once_with(expected_chunks=1)
+
+
 def test_vector_worker_read_endpoints(monkeypatch) -> None:
     monkeypatch.delenv("ANIMAWORKS_VECTOR_URL", raising=False)
 

--- a/tests/unit/core/supervisor/test_supervised_rag_repair.py
+++ b/tests/unit/core/supervisor/test_supervised_rag_repair.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -21,6 +22,7 @@ def _make_supervisor(tmp_path: Path):
         animas_dir=animas_dir,
         shared_dir=shared_dir,
         run_dir=run_dir,
+        vector_worker_manager=SimpleNamespace(base_url="http://127.0.0.1:43931"),
     )
 
 
@@ -294,6 +296,7 @@ async def test_reconcile_defers_restart_requested_during_rag_repair(tmp_path: Pa
 async def test_repair_cli_process_passes_reason_to_subprocess(tmp_path: Path, monkeypatch) -> None:
     sup = _make_supervisor(tmp_path)
     anima_dir = _create_anima(sup)
+    monkeypatch.setenv("ANIMAWORKS_VECTOR_URL", "http://127.0.0.1:40379")
     captured: dict[str, object] = {}
 
     class FakeProc:
@@ -303,9 +306,10 @@ async def test_repair_cli_process_passes_reason_to_subprocess(tmp_path: Path, mo
         async def communicate(self):
             return b"ok", b""
 
-    async def fake_create_subprocess_exec(*cmd, cwd, stdout, stderr):
+    async def fake_create_subprocess_exec(*cmd, cwd, env, stdout, stderr):
         captured["cmd"] = cmd
         captured["cwd"] = cwd
+        captured["env"] = env
         captured["stdout"] = stdout
         captured["stderr"] = stderr
         return FakeProc()
@@ -325,8 +329,13 @@ async def test_repair_cli_process_passes_reason_to_subprocess(tmp_path: Path, mo
     assert "--reason" in cmd
     assert cmd[cmd.index("--reason") + 1] == "sqlite_malformed"
     assert "--shared" in cmd
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["ANIMAWORKS_VECTOR_URL"] == "http://127.0.0.1:43931"
+    assert env["ANIMAWORKS_RAG_REPAIR_NONCE"]
     state = _read_state(anima_dir)
     assert state["pid"] == 12345
+    assert state["repair_nonce"] == env["ANIMAWORKS_RAG_REPAIR_NONCE"]
 
 
 @pytest.mark.asyncio
@@ -352,7 +361,7 @@ async def test_repair_cli_process_timeout_kills_subprocess(tmp_path: Path, monke
 
     proc = FakeProc()
 
-    async def fake_create_subprocess_exec(*cmd, cwd, stdout, stderr):
+    async def fake_create_subprocess_exec(*cmd, cwd, env, stdout, stderr):
         return proc
 
     monkeypatch.setattr("asyncio.create_subprocess_exec", fake_create_subprocess_exec)


### PR DESCRIPTION
## 概要
supervised repairが旧ポートworkerへreset-storeを送り無言空振りする欠陥（本番で現に発生中）の修正。Base: #257

## 変更
- 現worker base_url+repair nonceの明示注入・reset失敗のrepair失敗化（healthy-skip含む）
- fence内専用/verify-repair（nonce検証・再open+実query）・失敗時vector+BM25ロールバック
- 部分失敗でのhash/swap成功禁止・chunks=0 swap阻止

## 検証
- 対象UT 118 passed（i18nチェック含む）/ ruff clean（PdM再実行済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)