### PR TITLE
feat(supervisor): ハング監視タスク単位化 + busy集約 (PR-4)

### DIFF
--- a/core/anima.py
+++ b/core/anima.py
@@ -163,6 +163,7 @@ class DigitalAnima(
         self._last_activity: datetime | None = None
         self._last_progress_at: datetime | None = None
         self._busy_since: datetime | None = None
+        self._isolated_busy_jobs_provider: Callable[[], dict[str, Any]] | None = None
         self._on_lock_released: Callable[[], None] | None = None
 
         # Idle compaction timer (per-thread)
@@ -316,11 +317,31 @@ class DigitalAnima(
 
     # ── Progress tracking ────────────────────────────────────────
 
+    def _set_isolated_busy_jobs_provider(self, provider: Callable[[], dict[str, Any]]) -> None:
+        """Include root-owned isolated jobs in the existing busy marker."""
+        self._isolated_busy_jobs_provider = provider
+
+    def _isolated_busy_jobs(self) -> dict[str, Any]:
+        provider = getattr(self, "_isolated_busy_jobs_provider", None)
+        if provider is None:
+            return {}
+        try:
+            return provider()
+        except Exception:
+            logger.debug("[%s] Failed to collect isolated busy jobs", self.name, exc_info=True)
+            return {}
+
     def _has_active_busy_lock(self) -> bool:
         """Return True while any local execution lane is actively holding work."""
         any_conversation_locked = any(lock.locked() for lock in self._conversation_locks.values())
         active_workers = bool(getattr(self, "_active_background_workers", {}))
-        return any_conversation_locked or self._background_lock.locked() or self._inbox_lock.locked() or active_workers
+        return (
+            any_conversation_locked
+            or self._background_lock.locked()
+            or self._inbox_lock.locked()
+            or active_workers
+            or bool(self._isolated_busy_jobs())
+        )
 
     def _mark_busy_start(self) -> None:
         """Reset progress timestamp at the start of a new busy period.
@@ -372,6 +393,11 @@ class DigitalAnima(
                     lanes.append("inbox")
                 for slot_id, task_id in getattr(self, "_active_background_workers", {}).items():
                     lanes.append(f"background-worker:{slot_id}:{task_id}")
+                for job in self._isolated_busy_jobs().values():
+                    identity = getattr(job, "identity", None)
+                    lane = getattr(identity, "display_lane", None)
+                    if lane and lane not in lanes:
+                        lanes.append(str(lane))
             except Exception:
                 logger.debug("[%s] Failed to collect busy status lanes", self.name, exc_info=True)
             payload = {

--- a/core/supervisor/_mgr_health.py
+++ b/core/supervisor/_mgr_health.py
@@ -17,6 +17,7 @@ from datetime import datetime as _dt
 from pathlib import Path
 from typing import Any
 
+from core.config.resolver import resolve_process_model_config
 from core.supervisor.process_handle import ProcessHandle, ProcessState
 from core.time_utils import ensure_aware, now_local
 
@@ -33,6 +34,14 @@ class HealthMixin:
     def is_consolidating(self, anima_name: str) -> bool:
         """Return True if the anima is currently running daily/weekly consolidation."""
         return anima_name in getattr(self, "_consolidating", set())
+
+    def _runner_busy_hang_exempt(self, anima_name: str) -> bool:
+        """Return whether task-level monitoring owns busy-hang recovery."""
+        animas_dir = getattr(self, "animas_dir", None)
+        if animas_dir is None:
+            return False
+        config = resolve_process_model_config(Path(animas_dir) / anima_name)
+        return config.valid and any(config.task_process_isolation.model_dump().values())
 
     def _busy_sidecar_path(self, anima_name: str) -> Path | None:
         """Return the IPC-independent busy marker path, if run_dir is available."""
@@ -342,6 +351,8 @@ class HealthMixin:
                 )
                 asyncio.create_task(self._handle_process_failure(anima_name, handle))
                 return
+            if self._runner_busy_hang_exempt(anima_name):
+                return
             # Streaming stall detection: progress-aware, mirroring
             # _handle_busy_health.  A long stream is healthy as long as the
             # runner keeps reporting progress (busy sidecar last_progress_at,
@@ -461,6 +472,10 @@ class HealthMixin:
 
         if success:
             if is_busy:
+                if self._runner_busy_hang_exempt(anima_name):
+                    handle.stats.missed_pings = 0
+                    handle.stats.last_busy_since = None
+                    return
                 self._handle_busy_health(
                     anima_name,
                     handle,
@@ -475,7 +490,7 @@ class HealthMixin:
 
         # Ping failed
         busy_sidecar = self._read_busy_sidecar(anima_name, handle)
-        if busy_sidecar is not None:
+        if busy_sidecar is not None and not self._runner_busy_hang_exempt(anima_name):
             logger.debug(
                 "Ping failed for %s, but busy sidecar is present; using progress-aware health check",
                 anima_name,

--- a/core/supervisor/scheduler_manager.py
+++ b/core/supervisor/scheduler_manager.py
@@ -86,12 +86,7 @@ class SchedulerManager:
         self._task_isolated = bool(process_config.task_process_isolation.task)
         self._background_isolated = bool(process_config.task_process_isolation.background)
         self._task_runner_supervisor: TaskRunnerSupervisor | None = None
-        if (
-            self._cron_isolated
-            or self._heartbeat_isolated
-            or self._task_isolated
-            or self._background_isolated
-        ):
+        if self._cron_isolated or self._heartbeat_isolated or self._task_isolated or self._background_isolated:
             pool_size: int | None = None
             try:
                 pool_size = int(getattr(anima, "_background_worker_pool_size", 1) or 1)
@@ -102,6 +97,8 @@ class SchedulerManager:
                 anima_dir=anima_dir,
                 shared_dir=Path(anima.shared_dir),
                 max_concurrent=pool_size,
+                busy_hang_threshold_sec=float(load_config().server.busy_hang_threshold),
+                busy_status_owner=anima,
             )
 
         # Polling-based heartbeat state (used when effective_interval > 60)

--- a/core/supervisor/task_runner_supervisor.py
+++ b/core/supervisor/task_runner_supervisor.py
@@ -32,6 +32,8 @@ logger = logging.getLogger(__name__)
 
 _TASK_RUNNER_CONNECT_TIMEOUT = 10.0
 _TASK_RUNNER_EXIT_TIMEOUT = 5.0
+_TASK_RUNNER_TERM_TIMEOUT = 5.0
+_HANG_CHECK_INTERVAL_MAX = 5.0
 
 OnSpawned = Callable[["TaskRunnerJob"], Awaitable[None] | None]
 
@@ -54,6 +56,8 @@ class TaskRunnerJob:
     pgid: int | None = None
     connection: IPCV2Connection | None = None
     last_progress: dict[str, Any] = field(default_factory=dict)
+    last_progress_at: float = 0.0
+    hang_kill_started: bool = False
     grace_acked: asyncio.Event = field(default_factory=asyncio.Event)
     process_start_time: float | None = None
 
@@ -68,6 +72,8 @@ class TaskRunnerSupervisor:
         shared_dir: Path,
         *,
         max_concurrent: int | None = None,
+        busy_hang_threshold_sec: float = 900.0,
+        busy_status_owner: Any | None = None,
     ) -> None:
         self.anima_name = anima_name
         self.anima_dir = anima_dir
@@ -78,6 +84,15 @@ class TaskRunnerSupervisor:
         self._start_lock = asyncio.Lock()
         self._jobs: dict[str, TaskRunnerJob] = {}
         self._accepting = True
+        self._busy_hang_threshold_sec = max(0.0, float(busy_hang_threshold_sec))
+        self._hang_check_interval = min(
+            _HANG_CHECK_INTERVAL_MAX,
+            max(0.05, self._busy_hang_threshold_sec / 2),
+        )
+        self._busy_status_owner = busy_status_owner
+        set_provider = getattr(busy_status_owner, "_set_isolated_busy_jobs_provider", None)
+        if callable(set_provider):
+            set_provider(lambda: self._jobs)
         # Cap concurrent child processes for task/background lanes (pool size).
         pool = max_concurrent if isinstance(max_concurrent, int) and max_concurrent >= 1 else None
         self._max_concurrent = pool
@@ -262,6 +277,7 @@ class TaskRunnerSupervisor:
             params=params_builder(url_env),
             result=loop.create_future(),
             peer_state=IPCV2ConnectionState(identity),
+            last_progress_at=loop.time(),
         )
         self._jobs[job_id] = job
 
@@ -281,6 +297,7 @@ class TaskRunnerSupervisor:
             }
         )
 
+        hang_watch: asyncio.Task[None] | None = None
         try:
             process = await asyncio.create_subprocess_exec(
                 sys.executable,
@@ -300,6 +317,7 @@ class TaskRunnerSupervisor:
             job.process = process
             job.pid = process.pid
             job.pgid = process.pid
+            self._mark_busy_start()
             try:
                 import psutil
 
@@ -322,6 +340,7 @@ class TaskRunnerSupervisor:
                     await maybe
 
             process_wait = asyncio.create_task(process.wait())
+            hang_watch = asyncio.create_task(self._watch_job(job))
             done, _ = await asyncio.wait(
                 {job.result, process_wait},
                 return_when=asyncio.FIRST_COMPLETED,
@@ -360,9 +379,86 @@ class TaskRunnerSupervisor:
                 await job.process.wait()
             raise
         finally:
+            if hang_watch is not None:
+                if not job.hang_kill_started:
+                    hang_watch.cancel()
+                await asyncio.gather(hang_watch, return_exceptions=True)
             self._jobs.pop(job_id, None)
+            self._clear_busy_if_idle()
             # A-07: recover orphan streaming journals after every task ends.
             self._recover_task_journals()
+
+    async def _watch_job(self, job: TaskRunnerJob) -> None:
+        """Kill only this task-runner group after progress stops."""
+        while job.identity.job_id in self._jobs:
+            await asyncio.sleep(self._hang_check_interval)
+            process = job.process
+            if process is None or process.returncode is not None:
+                return
+            idle_sec = asyncio.get_running_loop().time() - job.last_progress_at
+            if idle_sec <= self._busy_hang_threshold_sec:
+                continue
+            job.hang_kill_started = True
+            logger.error(
+                "Task runner hang: anima=%s job=%s lane=%s pid=%s pgid=%s idle=%.1fs threshold=%.1fs",
+                self.anima_name,
+                job.identity.job_id,
+                job.identity.lane,
+                job.pid,
+                job.pgid,
+                idle_sec,
+                self._busy_hang_threshold_sec,
+            )
+            await self._terminate_hung_job(job)
+            return
+
+    async def _terminate_hung_job(self, job: TaskRunnerJob) -> None:
+        """Terminate a hung task group, escalating to SIGKILL after grace."""
+        process = job.process
+        if process is None:
+            return
+        self._terminate_job_group(job)
+        try:
+            await asyncio.wait_for(asyncio.shield(process.wait()), timeout=_TASK_RUNNER_TERM_TIMEOUT)
+        except TimeoutError:
+            pass
+        if self._job_group_exists(job):
+            self._kill_job_group(job)
+        if process.returncode is None:
+            await process.wait()
+
+    @staticmethod
+    def _job_group_exists(job: TaskRunnerJob) -> bool:
+        if os.name != "posix" or not job.pgid:
+            return bool(job.process is not None and job.process.returncode is None)
+        try:
+            os.killpg(job.pgid, 0)
+        except ProcessLookupError:
+            return False
+        return True
+
+    def _mark_busy_start(self) -> None:
+        owner = self._busy_status_owner
+        if owner is None:
+            return
+        callback = getattr(owner, "_mark_busy_start" if len(self._jobs) == 1 else "_mark_busy_progress", None)
+        if callable(callback):
+            callback()
+
+    def _mark_busy_progress(self) -> None:
+        callback = getattr(self._busy_status_owner, "_mark_busy_progress", None)
+        if callable(callback):
+            callback()
+
+    def _record_progress(self, job: TaskRunnerJob, data: dict[str, Any]) -> None:
+        job.last_progress = data
+        job.last_progress_at = asyncio.get_running_loop().time()
+        self._mark_busy_progress()
+
+    def _clear_busy_if_idle(self) -> None:
+        callback = getattr(self._busy_status_owner, "_clear_busy_status_sidecar_if_idle", None)
+        if callable(callback):
+            callback()
 
     def _recover_task_journals(self) -> None:
         """Best-effort orphan StreamingJournal recovery after a child exits."""
@@ -452,9 +548,9 @@ class TaskRunnerSupervisor:
                         job.result.set_result(terminal)
                     continue
                 if envelope.kind == "event" and envelope.body["event"] == "progress":
-                    job.last_progress = envelope.body["data"]
                     if envelope.identity.display_lane != job.identity.display_lane:
                         raise IPCV2ProtocolError("progress display_lane does not match registry")
+                    self._record_progress(job, envelope.body["data"])
                     continue
                 if envelope.kind == "event" and envelope.body["event"] == "grace_ack":
                     job.grace_acked.set()
@@ -534,12 +630,12 @@ class TaskRunnerSupervisor:
     @staticmethod
     def _terminate_job_group(job: TaskRunnerJob) -> None:
         process = job.process
-        if process is None or process.returncode is not None:
+        if process is None:
             return
         try:
             if os.name == "posix" and job.pgid:
                 os.killpg(job.pgid, signal.SIGTERM)
-            else:
+            elif process.returncode is None:
                 process.terminate()
         except ProcessLookupError:
             return
@@ -547,12 +643,12 @@ class TaskRunnerSupervisor:
     @staticmethod
     def _kill_job_group(job: TaskRunnerJob) -> None:
         process = job.process
-        if process is None or process.returncode is not None:
+        if process is None:
             return
         try:
             if os.name == "posix" and job.pgid:
                 os.killpg(job.pgid, signal.SIGKILL)
-            else:
+            elif process.returncode is None:
                 process.kill()
         except ProcessLookupError:
             return

--- a/tests/unit/core/supervisor/test_progress_aware_health.py
+++ b/tests/unit/core/supervisor/test_progress_aware_health.py
@@ -115,11 +115,13 @@ class TestProgressAwareBusyHang:
         """Process busy with recent progress should NOT be killed."""
         handle = _make_handle(tmp_path)
         now = now_jst()
-        handle.ping = AsyncMock(return_value={
-            "success": True,
-            "is_busy": True,
-            "last_progress_at": (now - timedelta(seconds=30)).isoformat(),
-        })
+        handle.ping = AsyncMock(
+            return_value={
+                "success": True,
+                "is_busy": True,
+                "last_progress_at": (now - timedelta(seconds=30)).isoformat(),
+            }
+        )
 
         sup = _make_supervisor()
         hang_calls: list[str] = []
@@ -139,11 +141,13 @@ class TestProgressAwareBusyHang:
         """Process busy with no progress for >15min should be killed."""
         handle = _make_handle(tmp_path)
         now = now_jst()
-        handle.ping = AsyncMock(return_value={
-            "success": True,
-            "is_busy": True,
-            "last_progress_at": (now - timedelta(minutes=16)).isoformat(),
-        })
+        handle.ping = AsyncMock(
+            return_value={
+                "success": True,
+                "is_busy": True,
+                "last_progress_at": (now - timedelta(minutes=16)).isoformat(),
+            }
+        )
 
         sup = _make_supervisor()
         hang_calls: list[str] = []
@@ -160,14 +164,48 @@ class TestProgressAwareBusyHang:
         assert hang_calls[0] == "test-anima"
 
     @pytest.mark.asyncio
+    async def test_isolated_root_is_not_busy_hang_target(self, tmp_path: Path):
+        """Task-level monitoring owns busy hangs when any isolation flag is enabled."""
+        anima_dir = tmp_path / "animas" / "test-anima"
+        anima_dir.mkdir(parents=True)
+        (anima_dir / "status.json").write_text(
+            json.dumps(
+                {
+                    "process_model": "phase2",
+                    "task_process_isolation": {"cron": True},
+                }
+            ),
+            encoding="utf-8",
+        )
+        handle = _make_handle(tmp_path)
+        handle.ping = AsyncMock(
+            return_value={
+                "success": True,
+                "is_busy": True,
+                "last_progress_at": (now_jst() - timedelta(minutes=16)).isoformat(),
+            }
+        )
+        sup = _make_supervisor()
+        sup.animas_dir = tmp_path / "animas"
+        sup._handle_process_hang = AsyncMock()
+
+        await sup._check_process_health("test-anima", handle)
+        await asyncio.sleep(0)
+
+        sup._handle_process_hang.assert_not_called()
+        assert handle.stats.missed_pings == 0
+
+    @pytest.mark.asyncio
     async def test_busy_without_progress_info_fallback(self, tmp_path: Path):
         """Process busy without last_progress_at should use fallback timer."""
         handle = _make_handle(tmp_path)
-        handle.ping = AsyncMock(return_value={
-            "success": True,
-            "is_busy": True,
-            "last_progress_at": None,
-        })
+        handle.ping = AsyncMock(
+            return_value={
+                "success": True,
+                "is_busy": True,
+                "last_progress_at": None,
+            }
+        )
 
         sup = _make_supervisor()
         hang_calls: list[str] = []
@@ -194,21 +232,25 @@ class TestProgressAwareBusyHang:
         handle = _make_handle(tmp_path)
 
         # First: busy (no progress info)
-        handle.ping = AsyncMock(return_value={
-            "success": True,
-            "is_busy": True,
-            "last_progress_at": None,
-        })
+        handle.ping = AsyncMock(
+            return_value={
+                "success": True,
+                "is_busy": True,
+                "last_progress_at": None,
+            }
+        )
         sup = _make_supervisor()
         sup._handle_process_hang = AsyncMock()
         await sup._check_process_health("test-anima", handle)
         assert handle.stats.last_busy_since is not None
 
         # Then: idle
-        handle.ping = AsyncMock(return_value={
-            "success": True,
-            "is_busy": False,
-        })
+        handle.ping = AsyncMock(
+            return_value={
+                "success": True,
+                "is_busy": False,
+            }
+        )
         await sup._check_process_health("test-anima", handle)
         assert handle.stats.last_busy_since is None
 
@@ -217,11 +259,13 @@ class TestProgressAwareBusyHang:
         """Custom busy_hang_threshold_sec should be respected."""
         handle = _make_handle(tmp_path)
         now = now_jst()
-        handle.ping = AsyncMock(return_value={
-            "success": True,
-            "is_busy": True,
-            "last_progress_at": (now - timedelta(minutes=6)).isoformat(),
-        })
+        handle.ping = AsyncMock(
+            return_value={
+                "success": True,
+                "is_busy": True,
+                "last_progress_at": (now - timedelta(minutes=6)).isoformat(),
+            }
+        )
 
         # 5-minute threshold (300s)
         config = HealthConfig(busy_hang_threshold_sec=300.0)
@@ -242,11 +286,13 @@ class TestProgressAwareBusyHang:
         """Process at exactly 15 min should NOT be killed (> not >=)."""
         handle = _make_handle(tmp_path)
         now = now_jst()
-        handle.ping = AsyncMock(return_value={
-            "success": True,
-            "is_busy": True,
-            "last_progress_at": (now - timedelta(seconds=899)).isoformat(),
-        })
+        handle.ping = AsyncMock(
+            return_value={
+                "success": True,
+                "is_busy": True,
+                "last_progress_at": (now - timedelta(seconds=899)).isoformat(),
+            }
+        )
 
         sup = _make_supervisor()
         hang_calls: list[str] = []
@@ -265,9 +311,11 @@ class TestProgressAwareBusyHang:
         handle = _make_handle(tmp_path)
         handle.stats.last_busy_since = now_jst() - timedelta(minutes=5)
 
-        handle.ping = AsyncMock(return_value={
-            "success": False,
-        })
+        handle.ping = AsyncMock(
+            return_value={
+                "success": False,
+            }
+        )
 
         sup = _make_supervisor()
         sup._handle_process_hang = AsyncMock()
@@ -280,22 +328,26 @@ class TestProgressAwareBusyHang:
         """A fresh child busy marker should prevent false hang kills when IPC ping times out."""
         handle = _make_handle(tmp_path)
         handle.stats.missed_pings = 1
-        handle.ping = AsyncMock(return_value={
-            "success": False,
-        })
+        handle.ping = AsyncMock(
+            return_value={
+                "success": False,
+            }
+        )
 
         run_dir = tmp_path / "run"
         sidecar = run_dir / "animas" / "test-anima.busy.json"
         sidecar.parent.mkdir(parents=True)
         sidecar.write_text(
-            json.dumps({
-                "anima": "test-anima",
-                "pid": handle.get_pid(),
-                "is_busy": True,
-                "busy_since": (now_jst() - timedelta(minutes=1)).isoformat(),
-                "last_progress_at": (now_jst() - timedelta(seconds=20)).isoformat(),
-                "updated_at": now_jst().isoformat(),
-            }),
+            json.dumps(
+                {
+                    "anima": "test-anima",
+                    "pid": handle.get_pid(),
+                    "is_busy": True,
+                    "busy_since": (now_jst() - timedelta(minutes=1)).isoformat(),
+                    "last_progress_at": (now_jst() - timedelta(seconds=20)).isoformat(),
+                    "updated_at": now_jst().isoformat(),
+                }
+            ),
             encoding="utf-8",
         )
 
@@ -312,22 +364,26 @@ class TestProgressAwareBusyHang:
     async def test_ping_failure_with_stale_busy_sidecar_killed(self, tmp_path: Path):
         """A stale busy marker still triggers progress-aware hang recovery."""
         handle = _make_handle(tmp_path)
-        handle.ping = AsyncMock(return_value={
-            "success": False,
-        })
+        handle.ping = AsyncMock(
+            return_value={
+                "success": False,
+            }
+        )
 
         run_dir = tmp_path / "run"
         sidecar = run_dir / "animas" / "test-anima.busy.json"
         sidecar.parent.mkdir(parents=True)
         sidecar.write_text(
-            json.dumps({
-                "anima": "test-anima",
-                "pid": handle.get_pid(),
-                "is_busy": True,
-                "busy_since": (now_jst() - timedelta(minutes=20)).isoformat(),
-                "last_progress_at": (now_jst() - timedelta(minutes=16)).isoformat(),
-                "updated_at": (now_jst() - timedelta(minutes=16)).isoformat(),
-            }),
+            json.dumps(
+                {
+                    "anima": "test-anima",
+                    "pid": handle.get_pid(),
+                    "is_busy": True,
+                    "busy_since": (now_jst() - timedelta(minutes=20)).isoformat(),
+                    "last_progress_at": (now_jst() - timedelta(minutes=16)).isoformat(),
+                    "updated_at": (now_jst() - timedelta(minutes=16)).isoformat(),
+                }
+            ),
             encoding="utf-8",
         )
 
@@ -345,22 +401,26 @@ class TestProgressAwareBusyHang:
         """Stale marker from a previous PID must not suppress normal missed-ping recovery."""
         handle = _make_handle(tmp_path)
         handle.stats.missed_pings = HealthConfig().max_missed_pings
-        handle.ping = AsyncMock(return_value={
-            "success": False,
-        })
+        handle.ping = AsyncMock(
+            return_value={
+                "success": False,
+            }
+        )
 
         run_dir = tmp_path / "run"
         sidecar = run_dir / "animas" / "test-anima.busy.json"
         sidecar.parent.mkdir(parents=True)
         sidecar.write_text(
-            json.dumps({
-                "anima": "test-anima",
-                "pid": int(handle.get_pid()) + 1,
-                "is_busy": True,
-                "busy_since": now_jst().isoformat(),
-                "last_progress_at": now_jst().isoformat(),
-                "updated_at": now_jst().isoformat(),
-            }),
+            json.dumps(
+                {
+                    "anima": "test-anima",
+                    "pid": int(handle.get_pid()) + 1,
+                    "is_busy": True,
+                    "busy_since": now_jst().isoformat(),
+                    "last_progress_at": now_jst().isoformat(),
+                    "updated_at": now_jst().isoformat(),
+                }
+            ),
             encoding="utf-8",
         )
 
@@ -379,10 +439,12 @@ class TestProgressAwareBusyHang:
         handle = _make_handle(tmp_path)
         handle.stats.last_busy_since = now_jst()
 
-        handle.ping = AsyncMock(return_value={
-            "success": True,
-            "is_busy": False,
-        })
+        handle.ping = AsyncMock(
+            return_value={
+                "success": True,
+                "is_busy": False,
+            }
+        )
 
         sup = _make_supervisor()
         sup._handle_process_hang = AsyncMock()

--- a/tests/unit/core/supervisor/test_task_runner_hang_busy.py
+++ b/tests/unit/core/supervisor/test_task_runner_hang_busy.py
@@ -1,0 +1,217 @@
+"""Task-level hang recovery and root-owned busy marker tests."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import signal
+import sys
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from core.anima import DigitalAnima
+from core.supervisor import task_runner, task_runner_supervisor
+from core.supervisor.ipc_v2 import IPCV2ConnectionState, IPCV2Identity
+from core.supervisor.task_runner_supervisor import TaskRunnerJob, TaskRunnerSupervisor
+
+
+def _job(
+    supervisor: TaskRunnerSupervisor,
+    process: asyncio.subprocess.Process | None,
+    *,
+    job_id: str = "job-hang",
+) -> TaskRunnerJob:
+    identity = IPCV2Identity(
+        job_id=job_id,
+        root_epoch=supervisor.root_epoch,
+        attempt=1,
+        lane="task",
+        display_lane="background",
+    )
+    return TaskRunnerJob(
+        identity=identity,
+        request_id=f"run-{job_id}",
+        params={},
+        result=asyncio.get_running_loop().create_future(),
+        peer_state=IPCV2ConnectionState(identity),
+        process=process,
+        pid=process.pid if process else 999_999,
+        pgid=process.pid if process else 999_999,
+        last_progress_at=asyncio.get_running_loop().time(),
+    )
+
+
+def _group_exists(pgid: int) -> bool:
+    try:
+        os.killpg(pgid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+@pytest.mark.skipif(os.name != "posix", reason="process-group assertion requires POSIX")
+@pytest.mark.asyncio
+async def test_stalled_job_kills_only_target_group(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    child_pid_path = tmp_path / "descendant.pid"
+    code = (
+        "import signal,subprocess,sys,time;"
+        "child=subprocess.Popen([sys.executable,'-c',"
+        "'import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)']);"
+        "open(sys.argv[1],'w').write(str(child.pid));"
+        "time.sleep(60)"
+    )
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        code,
+        str(child_pid_path),
+        start_new_session=True,
+    )
+    supervisor = TaskRunnerSupervisor(
+        "sakura",
+        tmp_path / "animas" / "sakura",
+        tmp_path / "shared",
+        busy_hang_threshold_sec=0.05,
+    )
+    job = _job(supervisor, process)
+    job.last_progress_at -= 1.0
+    supervisor.jobs[job.identity.job_id] = job
+    root_pid = os.getpid()
+    monkeypatch.setattr(task_runner_supervisor, "_TASK_RUNNER_TERM_TIMEOUT", 0.1)
+
+    try:
+        for _ in range(100):
+            if child_pid_path.exists():
+                break
+            await asyncio.sleep(0.01)
+        assert child_pid_path.exists()
+
+        await asyncio.wait_for(supervisor._watch_job(job), timeout=3.0)
+
+        assert job.pid == process.pid
+        assert job.pid != root_pid
+        assert job.hang_kill_started
+        assert process.returncode == -signal.SIGTERM
+        assert os.getpid() == root_pid
+        for _ in range(100):
+            if not _group_exists(job.pgid or 0):
+                break
+            await asyncio.sleep(0.01)
+        assert not _group_exists(job.pgid or 0)
+    finally:
+        if _group_exists(process.pid):
+            os.killpg(process.pid, signal.SIGKILL)
+        await process.wait()
+
+
+@pytest.mark.asyncio
+async def test_continuing_progress_is_not_killed(tmp_path: Path) -> None:
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        "import time; time.sleep(60)",
+        start_new_session=True,
+    )
+    supervisor = TaskRunnerSupervisor(
+        "sakura",
+        tmp_path / "animas" / "sakura",
+        tmp_path / "shared",
+        busy_hang_threshold_sec=0.12,
+    )
+    job = _job(supervisor, process, job_id="job-progress")
+    supervisor.jobs[job.identity.job_id] = job
+    watch = asyncio.create_task(supervisor._watch_job(job))
+    try:
+        for _ in range(5):
+            await asyncio.sleep(0.04)
+            job.last_progress_at = asyncio.get_running_loop().time()
+        assert not watch.done()
+        assert not job.hang_kill_started
+        assert process.returncode is None
+    finally:
+        watch.cancel()
+        await asyncio.gather(watch, return_exceptions=True)
+        process.kill()
+        await process.wait()
+
+
+@pytest.mark.asyncio
+async def test_progress_writes_root_owned_busy_sidecar(tmp_path: Path) -> None:
+    owner = object.__new__(DigitalAnima)
+    owner.name = "sakura"
+    owner.shared_dir = tmp_path / "shared"
+    owner._busy_status_enabled = True
+    owner._conversation_locks = {}
+    owner._background_lock = asyncio.Lock()
+    owner._inbox_lock = asyncio.Lock()
+    owner._active_background_workers = {}
+    owner._last_progress_at = None
+    owner._busy_since = None
+
+    supervisor = TaskRunnerSupervisor(
+        "sakura",
+        tmp_path / "animas" / "sakura",
+        owner.shared_dir,
+        busy_status_owner=owner,
+    )
+    job = _job(supervisor, None)
+    supervisor.jobs[job.identity.job_id] = job
+    supervisor._mark_busy_start()
+    before = job.last_progress_at
+    supervisor._record_progress(job, {"pid": job.pid, "lane": "task"})
+
+    sidecar = tmp_path / "run" / "animas" / "sakura.busy.json"
+    payload = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert payload["pid"] == os.getpid()
+    assert payload["pid"] != job.pid
+    assert payload["lanes"] == ["background"]
+    assert job.last_progress_at > before
+    assert datetime.fromisoformat(payload["last_progress_at"])
+
+    supervisor.jobs.pop(job.identity.job_id)
+    supervisor._clear_busy_if_idle()
+    assert not sidecar.exists()
+
+
+@pytest.mark.asyncio
+async def test_task_runner_disables_its_busy_writer(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def make_anima(**kwargs: object) -> object:
+        captured.update(kwargs)
+        return object()
+
+    identity = IPCV2Identity(
+        job_id="job-cron",
+        root_epoch="epoch",
+        attempt=1,
+        lane="cron",
+        display_lane="background",
+    )
+    params = {
+        "task": {
+            "name": "daily",
+            "schedule": "0 9 * * *",
+            "type": "llm",
+            "description": "daily",
+        }
+    }
+    monkeypatch.setattr(task_runner, "DigitalAnima", make_anima)
+    monkeypatch.setattr(task_runner, "execute_cron_contract", AsyncMock(return_value={"success": True}))
+
+    execution = await task_runner._prepare_execution(
+        argparse.Namespace(anima="sakura", lane="cron", job="job-cron"),
+        identity,
+        params,
+    )
+    await execution
+
+    assert captured["busy_status_enabled"] is False


### PR DESCRIPTION
## 概要
Phase 2第4弾。busy-hang killをtask runner単位に置換（誤検知の巻き添え根絶）し、busy sidecarの書き手をrootへ一本化。Base: PR-3

## 検証
- supervisor+startup+i18n 471 passed / ruff clean（PdM再実行・format済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)