### PR TITLE
feat(memory): root MemoryService(read系) + IpcVectorStore (PR-6)

### DIFF
--- a/core/memory/rag/direct_access.py
+++ b/core/memory/rag/direct_access.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 # Copyright (C) 2026 AnimaWorks Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Direct ChromaDB access guard for worker-only production routing."""
+"""Direct ChromaDB access guard for approved production owners."""
 
 import os
 
@@ -21,8 +21,8 @@ def require_direct_chroma_allowed() -> None:
     if direct_chroma_allowed():
         return
     raise RuntimeError(
-        "Direct ChromaDB access is disabled outside the vector worker. "
-        f"Set {DIRECT_CHROMA_ENV}=1 only for vector-worker or explicit test processes."
+        "Direct ChromaDB access is disabled outside an approved owner. "
+        f"Set {DIRECT_CHROMA_ENV}=1 only for vector-worker, anima root, or explicit test processes."
     )
 
 

--- a/core/memory/rag/ipc_store.py
+++ b/core/memory/rag/ipc_store.py
@@ -1,0 +1,75 @@
+"""VectorStore reads over root IPC, with writes left on the HTTP worker."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from core.memory.rag.http_store import HttpVectorStore, _parse_documents, _parse_search_results
+
+logger = logging.getLogger(__name__)
+
+MemoryRequester = Callable[[str, dict[str, Any]], dict[str, Any]]
+
+
+class IpcVectorStore(HttpVectorStore):
+    """Split backend: root IPC for reads, existing server proxy for writes."""
+
+    def __init__(self, base_url: str, anima_name: str | None, requester: MemoryRequester) -> None:
+        super().__init__(base_url, anima_name)
+        self._requester = requester
+
+    def _read(self, method: str, params: dict[str, Any]) -> dict[str, Any] | None:
+        try:
+            return self._requester(method, params)
+        except Exception as exc:
+            logger.warning("IPC vector read failed: method=%s anima=%s error=%s", method, self._anima_name, exc)
+            return None
+
+    def list_collections(self) -> list[str]:
+        data = self._read("memory.list_collections_checked", {})
+        collections = data.get("collections") if data else None
+        return (
+            list(collections)
+            if isinstance(collections, list) and all(isinstance(name, str) for name in collections)
+            else []
+        )
+
+    def list_collections_checked(self) -> list[str] | None:
+        data = self._read("memory.list_collections_checked", {})
+        collections = data.get("collections") if data else None
+        if not isinstance(collections, list) or not all(isinstance(name, str) for name in collections):
+            return None
+        return list(collections)
+
+    def query(
+        self,
+        collection: str,
+        embedding: list[float],
+        top_k: int = 10,
+        filter_metadata: dict[str, str | int | float] | None = None,
+    ):
+        params: dict[str, Any] = {"collection": collection, "embedding": embedding, "top_k": top_k}
+        if filter_metadata:
+            params["filter_metadata"] = filter_metadata
+        data = self._read("memory.query", params)
+        return _parse_search_results(data["results"]) if data and isinstance(data.get("results"), list) else []
+
+    def get_by_metadata(
+        self,
+        collection: str,
+        where: dict[str, str | int | float],
+        limit: int = 20,
+    ):
+        data = self._read(
+            "memory.get_by_metadata",
+            {"collection": collection, "where": where, "limit": limit},
+        )
+        return _parse_search_results(data["results"]) if data and isinstance(data.get("results"), list) else []
+
+    def get_by_ids(self, collection: str, ids: list[str]):
+        if not ids:
+            return []
+        data = self._read("memory.get_by_ids", {"collection": collection, "ids": ids})
+        return _parse_documents(data["documents"]) if data and isinstance(data.get("documents"), list) else []

--- a/core/memory/rag/singleton.py
+++ b/core/memory/rag/singleton.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from sentence_transformers import SentenceTransformer
 
     from core.memory.rag.http_store import HttpVectorStore
+    from core.memory.rag.ipc_store import IpcVectorStore, MemoryRequester
     from core.memory.rag.store import VectorStore
 
 logger = logging.getLogger(__name__)
@@ -38,6 +39,8 @@ _native_ops_lock = threading.Lock()
 _vector_stores: dict[str | None, VectorStore | None] = {}
 _vector_store_init_failed: set[str | None] = set()
 _http_stores: dict[tuple[str, str | None], HttpVectorStore] = {}
+_ipc_stores: dict[tuple[str, str | None], IpcVectorStore] = {}
+_ipc_vector_requester: MemoryRequester | None = None
 _embedding_model: SentenceTransformer | None = None
 _embedding_model_name: str | None = None
 _embedding_model_device: str | None = None
@@ -252,6 +255,30 @@ def _get_http_store(base_url: str, anima_name: str | None) -> HttpVectorStore:
     return _http_stores[key]
 
 
+def configure_ipc_vector_requester(requester: MemoryRequester | None) -> None:
+    """Install the task runner's root-memory requester for phase3 reads."""
+    global _ipc_vector_requester
+
+    with _lock:
+        _ipc_vector_requester = requester
+        _ipc_stores.clear()
+
+
+def _get_ipc_store(base_url: str, anima_name: str | None) -> IpcVectorStore | None:
+    requester = _ipc_vector_requester
+    if requester is None:
+        return None
+    normalized_url = base_url.rstrip("/")
+    key = (normalized_url, anima_name)
+    if key not in _ipc_stores:
+        with _lock:
+            if key not in _ipc_stores:
+                from core.memory.rag.ipc_store import IpcVectorStore
+
+                _ipc_stores[key] = IpcVectorStore(normalized_url, anima_name, requester)
+    return _ipc_stores[key]
+
+
 def get_vector_store(anima_name: str | None = None) -> VectorStore | None:
     """Return process-level singleton VectorStore per anima.
 
@@ -271,6 +298,11 @@ def get_vector_store(anima_name: str | None = None) -> VectorStore | None:
     global _direct_disabled_warned, _init_failed
 
     vector_url = os.environ.get("ANIMAWORKS_VECTOR_URL")
+    if os.environ.get("ANIMAWORKS_MEMORY_VIA_ROOT") == "1":
+        if vector_url:
+            return _get_ipc_store(vector_url, anima_name)
+        logger.warning("IPC vector store unavailable: write-side ANIMAWORKS_VECTOR_URL is missing")
+        return None
     if vector_url:
         return _get_http_store(vector_url, anima_name)
 
@@ -916,7 +948,8 @@ def get_embedding_e5_prefix_enabled() -> bool:
 def _reset_for_testing():
     """Reset singletons for test isolation."""
     global _bulk_yield_count, _direct_disabled_warned, _embedding_model, _embedding_model_device, _embedding_model_name
-    global _init_failed, _interactive_waiters, _last_error_reset_monotonic, _vector_store_lifecycle_gate
+    global _init_failed, _interactive_waiters, _ipc_vector_requester, _last_error_reset_monotonic
+    global _vector_store_lifecycle_gate
     from core.gpu import reset_gpu_status_for_testing
 
     with _error_reset_lock:
@@ -926,6 +959,8 @@ def _reset_for_testing():
         _vector_stores.clear()
         _vector_store_init_failed.clear()
         _http_stores.clear()
+        _ipc_stores.clear()
+        _ipc_vector_requester = None
         _embedding_model = None
         _embedding_model_name = None
         _embedding_model_device = None

--- a/core/supervisor/ipc_v2.py
+++ b/core/supervisor/ipc_v2.py
@@ -384,9 +384,18 @@ async def read_ipc_v2_envelope(reader: asyncio.StreamReader) -> IPCV2Envelope:
     return IPCV2Envelope.from_bytes(payload)
 
 
-def ipc_v2_error(code: str, message: str, *, retryable: bool) -> dict[str, Any]:
+def ipc_v2_error(
+    code: str,
+    message: str,
+    *,
+    retryable: bool,
+    retry_after_ms: int | None = None,
+) -> dict[str, Any]:
     """Build the required compact error object."""
-    return {"code": code, "message": message, "retryable": retryable}
+    error: dict[str, Any] = {"code": code, "message": message, "retryable": retryable}
+    if retry_after_ms is not None:
+        error["retry_after_ms"] = retry_after_ms
+    return error
 
 
 __all__ = [

--- a/core/supervisor/memory_service.py
+++ b/core/supervisor/memory_service.py
@@ -1,0 +1,169 @@
+"""Root-owned, read-only vector memory service."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+from core.memory.rag.store import Document, SearchResult, VectorStore
+
+logger = logging.getLogger(__name__)
+
+
+class MemoryServiceUnavailable(RuntimeError):
+    """The root memory service cannot safely answer a read."""
+
+
+class MemoryService:
+    """Serialize one anima's native vector reads on one bounded worker."""
+
+    def __init__(
+        self,
+        anima_name: str,
+        anima_dir: Path,
+        *,
+        queue_limit: int = 64,
+        opener: Callable[[], VectorStore] | None = None,
+        repair_fenced: Callable[[], bool] | None = None,
+    ) -> None:
+        if queue_limit < 1:
+            raise ValueError("queue_limit must be >= 1")
+        self.anima_name = anima_name
+        self.anima_dir = anima_dir
+        self.queue_limit = queue_limit
+        self._opener = opener or self._open_native_store
+        self._repair_fenced = repair_fenced or self._has_active_repair_fence
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix=f"memory-{anima_name}")
+        self._store: VectorStore | None = None
+        self._open_error: Exception | None = None
+        self._pending = 0
+        self._started = False
+
+    async def start(self) -> None:
+        """Open Chroma off the root event loop; failure leaves root available."""
+        if self._started:
+            return
+        self._started = True
+        try:
+            self._store = await asyncio.get_running_loop().run_in_executor(self._executor, self._opener)
+        except Exception as exc:
+            self._open_error = exc
+            logger.warning("Root memory store open failed for %s: %s", self.anima_name, exc)
+
+    async def handle(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        """Run one checked read or raise an explicit unavailable error."""
+        if not self._started:
+            await self.start()
+        if self._store is None:
+            raise MemoryServiceUnavailable(f"memory store unavailable: {self._open_error or 'not open'}")
+        try:
+            fenced = self._repair_fenced()
+        except Exception as exc:
+            raise MemoryServiceUnavailable(f"repair fence state unavailable: {exc}") from exc
+        if fenced:
+            raise MemoryServiceUnavailable("RAG repair in progress")
+        if self._pending >= self.queue_limit:
+            raise MemoryServiceUnavailable("memory queue is full")
+
+        self._pending += 1
+        try:
+            return await asyncio.get_running_loop().run_in_executor(
+                self._executor,
+                self._dispatch,
+                method,
+                params,
+            )
+        except MemoryServiceUnavailable:
+            raise
+        except ValueError:
+            raise
+        except Exception as exc:
+            logger.warning("Root memory read failed for %s: %s", self.anima_name, exc)
+            raise MemoryServiceUnavailable(f"memory read failed: {exc}") from exc
+        finally:
+            self._pending -= 1
+
+    def _dispatch(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        store = self._store
+        if store is None:
+            raise MemoryServiceUnavailable("memory store unavailable")
+        if method == "memory.query":
+            collection = self._string(params, "collection")
+            embedding = params.get("embedding")
+            top_k = params.get("top_k", 10)
+            filter_metadata = params.get("filter_metadata")
+            if not isinstance(embedding, list) or not all(isinstance(value, (int, float)) for value in embedding):
+                raise ValueError("embedding must be a list of numbers")
+            if not isinstance(top_k, int) or isinstance(top_k, bool) or top_k < 1:
+                raise ValueError("top_k must be an integer >= 1")
+            if filter_metadata is not None and not isinstance(filter_metadata, dict):
+                raise ValueError("filter_metadata must be an object or null")
+            query = getattr(store, "_query_once", store.query)
+            return {"results": self._search_results(query(collection, embedding, top_k, filter_metadata))}
+        if method == "memory.list_collections_checked":
+            listing = getattr(store, "_list_collections_once", store.list_collections)
+            return {"collections": list(listing())}
+        if method == "memory.get_by_metadata":
+            collection = self._string(params, "collection")
+            where = params.get("where")
+            limit = params.get("limit", 20)
+            if not isinstance(where, dict):
+                raise ValueError("where must be an object")
+            if not isinstance(limit, int) or isinstance(limit, bool) or limit < 1:
+                raise ValueError("limit must be an integer >= 1")
+            get = getattr(store, "_get_by_metadata_once", store.get_by_metadata)
+            return {"results": self._search_results(get(collection, where, limit))}
+        if method == "memory.get_by_ids":
+            collection = self._string(params, "collection")
+            ids = params.get("ids")
+            if not isinstance(ids, list) or not all(isinstance(value, str) for value in ids):
+                raise ValueError("ids must be a list of strings")
+            get = getattr(store, "_get_by_ids_once", store.get_by_ids)
+            return {"documents": self._documents(get(collection, ids))}
+        raise ValueError(f"unsupported memory method: {method}")
+
+    @staticmethod
+    def _string(params: dict[str, Any], key: str) -> str:
+        value = params.get(key)
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"{key} must be a non-empty string")
+        return value
+
+    @staticmethod
+    def _documents(documents: list[Document]) -> list[dict[str, Any]]:
+        return [{"id": doc.id, "content": doc.content, "metadata": doc.metadata} for doc in documents]
+
+    @classmethod
+    def _search_results(cls, results: list[SearchResult]) -> list[dict[str, Any]]:
+        return [{"document": cls._documents([result.document])[0], "score": result.score} for result in results]
+
+    def _open_native_store(self) -> VectorStore:
+        from core.memory.rag.direct_access import enable_direct_chroma_for_process
+        from core.memory.rag.store import create_chroma_vector_store
+        from core.paths import get_anima_vectordb_dir
+
+        enable_direct_chroma_for_process()
+        return create_chroma_vector_store(
+            persist_dir=get_anima_vectordb_dir(self.anima_name),
+            anima_name=self.anima_name,
+        )
+
+    def _has_active_repair_fence(self) -> bool:
+        from core.memory.rag import repair_state
+
+        state = repair_state.read_state(self.anima_name, animas_dir=self.anima_dir.parent)
+        return state.get("status") in repair_state.ACTIVE_REPAIR_STATUSES
+
+    async def close(self) -> None:
+        """Close the sole native handle after queued reads drain."""
+        store, self._store = self._store, None
+        if store is not None:
+            try:
+                await asyncio.get_running_loop().run_in_executor(self._executor, store.close)
+            except Exception:
+                logger.warning("Failed to close root memory store for %s", self.anima_name, exc_info=True)
+        self._executor.shutdown(wait=False)

--- a/core/supervisor/pending_executor.py
+++ b/core/supervisor/pending_executor.py
@@ -2125,9 +2125,7 @@ class PendingTaskExecutor:
                 task_id,
                 exc,
             )
-            raise RuntimeError(
-                "INTERRUPTED: background task runner child exited without a result."
-            ) from exc
+            raise RuntimeError("INTERRUPTED: background task runner child exited without a result.") from exc
 
     async def _execute_llm_task(
         self,
@@ -2168,9 +2166,7 @@ class PendingTaskExecutor:
                     keepalive_task = asyncio.ensure_future(keepalive_result)
             self._anima._status_slots["background"] = "task_exec"
             self._anima._task_slots["background"] = task_id
-            if pool_capable or (
-                self._task_isolated and self._task_runner_supervisor is not None
-            ):
+            if pool_capable or (self._task_isolated and self._task_runner_supervisor is not None):
                 # Worker lease also gates concurrent isolated children (pool size).
                 result = await self._run_task_in_worker(
                     task_desc,

--- a/core/supervisor/runner.py
+++ b/core/supervisor/runner.py
@@ -889,11 +889,7 @@ class AnimaRunner:
         consolidation_type = params.get("consolidation_type", "daily")
 
         # background lane isolation: run consolidation inside a task-runner child.
-        supervisor = (
-            self._scheduler_mgr._task_runner_supervisor
-            if self._scheduler_mgr is not None
-            else None
-        )
+        supervisor = self._scheduler_mgr._task_runner_supervisor if self._scheduler_mgr is not None else None
         background_isolated = bool(
             self._scheduler_mgr is not None and getattr(self._scheduler_mgr, "_background_isolated", False)
         )

--- a/core/supervisor/scheduler_manager.py
+++ b/core/supervisor/scheduler_manager.py
@@ -99,6 +99,7 @@ class SchedulerManager:
                 max_concurrent=pool_size,
                 busy_hang_threshold_sec=float(load_config().server.busy_hang_threshold),
                 busy_status_owner=anima,
+                memory_via_root=process_config.process_model == "phase3",
             )
 
         # Polling-based heartbeat state (used when effective_interval > 60)

--- a/core/supervisor/task_runner.py
+++ b/core/supervisor/task_runner.py
@@ -11,6 +11,8 @@ import logging
 import os
 import re
 import sys
+import threading
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -38,6 +40,50 @@ _SUPPORTED_LANES = frozenset({"cron", "heartbeat", "task", "background"})
 
 # Module-level registry of open StreamingJournal instances for grace flush.
 _ACTIVE_JOURNALS: list[Any] = []
+
+
+class _MemoryRpcClient:
+    """Bridge synchronous VectorStore reads to the task runner's async IPC."""
+
+    def __init__(self, connection: IPCV2Connection) -> None:
+        self.connection = connection
+        self.loop = asyncio.get_running_loop()
+        self.loop_thread = threading.get_ident()
+        self.pending: dict[str, asyncio.Future[dict[str, Any]]] = {}
+
+    def request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        if threading.get_ident() == self.loop_thread:
+            raise RuntimeError("synchronous memory read attempted on the task runner event loop")
+        future = asyncio.run_coroutine_threadsafe(self._request(method, params), self.loop)
+        return future.result(timeout=120.0)
+
+    async def _request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        request_id = f"memory-{uuid.uuid4()}"
+        response = self.loop.create_future()
+        self.pending[request_id] = response
+        try:
+            await self.connection.send_request(request_id, method, params)
+            return await asyncio.wait_for(response, timeout=120.0)
+        finally:
+            self.pending.pop(request_id, None)
+
+    def accept_response(self, envelope: IPCV2Envelope) -> bool:
+        request_id = envelope.body["request_id"]
+        response = self.pending.get(request_id)
+        if response is None:
+            return False
+        error = envelope.body.get("error")
+        if error is not None:
+            response.set_exception(RuntimeError(f"{error['code']}: {error['message']}"))
+        else:
+            response.set_result(envelope.body["result"])
+        return True
+
+    def close(self) -> None:
+        for response in self.pending.values():
+            if not response.done():
+                response.set_exception(RuntimeError("root memory IPC closed"))
+        self.pending.clear()
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -416,6 +462,13 @@ async def run_task(args: argparse.Namespace, socket_path: Path, identity: IPCV2I
         await connection.close()
         return 2
 
+    memory_client: _MemoryRpcClient | None = None
+    if os.environ.get("ANIMAWORKS_MEMORY_VIA_ROOT") == "1":
+        from core.memory.rag.singleton import configure_ipc_vector_requester
+
+        memory_client = _MemoryRpcClient(connection)
+        configure_ipc_vector_requester(memory_client.request)
+
     try:
         execution = await _prepare_execution(args, identity, params)
     except ValueError as exc:
@@ -435,9 +488,7 @@ async def run_task(args: argparse.Namespace, socket_path: Path, identity: IPCV2I
     progress = asyncio.create_task(_progress_loop(connection, identity))
     expected_parent_pid = int(os.environ.get("ANIMAWORKS_TASK_ROOT_PID", os.getppid()))
     parent_monitor = asyncio.create_task(_parent_monitor(expected_parent_pid))
-    receiver: asyncio.Task[IPCV2Envelope] | None = asyncio.create_task(
-        asyncio.wait_for(connection.receive(), timeout=15.0)
-    )
+    receiver: asyncio.Task[IPCV2Envelope] | None = asyncio.create_task(connection.receive())
     cancelled = False
     graced = False
     root_lost = False
@@ -456,9 +507,15 @@ async def run_task(args: argparse.Namespace, socket_path: Path, identity: IPCV2I
             if receiver is not None and receiver in done:
                 try:
                     control = receiver.result()
-                except (IPCV2ConnectionError, TimeoutError):
+                except IPCV2ConnectionError:
                     receiver = None
                     progress.cancel()
+                    continue
+                if control.kind == "response":
+                    if memory_client is None or not memory_client.accept_response(control):
+                        execution.cancel()
+                        raise IPCV2ConnectionError("unexpected response from anima root")
+                    receiver = asyncio.create_task(connection.receive())
                     continue
                 if control.kind == "event" and control.body["event"] == "grace":
                     # A-07: stop work (finally flushes journals) → grace_ack → exit.
@@ -479,7 +536,7 @@ async def run_task(args: argparse.Namespace, socket_path: Path, identity: IPCV2I
                     execution.cancel()
                     cancelled = True
                     break
-                receiver = asyncio.create_task(asyncio.wait_for(connection.receive(), timeout=15.0))
+                receiver = asyncio.create_task(connection.receive())
 
         if cancelled or root_lost:
             try:
@@ -525,6 +582,11 @@ async def run_task(args: argparse.Namespace, socket_path: Path, identity: IPCV2I
         )
         return 0
     finally:
+        if memory_client is not None:
+            from core.memory.rag.singleton import configure_ipc_vector_requester
+
+            memory_client.close()
+            configure_ipc_vector_requester(None)
         progress.cancel()
         parent_monitor.cancel()
         if receiver is not None:

--- a/core/supervisor/task_runner_supervisor.py
+++ b/core/supervisor/task_runner_supervisor.py
@@ -26,6 +26,7 @@ from core.supervisor.ipc_v2 import (
     ipc_v2_error,
     read_ipc_v2_envelope,
 )
+from core.supervisor.memory_service import MemoryService, MemoryServiceUnavailable
 from core.supervisor.transport import cleanup_ipc_endpoint, start_ipc_server
 
 logger = logging.getLogger(__name__)
@@ -74,6 +75,7 @@ class TaskRunnerSupervisor:
         max_concurrent: int | None = None,
         busy_hang_threshold_sec: float = 900.0,
         busy_status_owner: Any | None = None,
+        memory_via_root: bool = False,
     ) -> None:
         self.anima_name = anima_name
         self.anima_dir = anima_dir
@@ -81,6 +83,7 @@ class TaskRunnerSupervisor:
         self.root_epoch = str(uuid.uuid4())
         self.socket_path = shared_dir.parent / "run" / "sockets" / f"{anima_name}.task-v2.sock"
         self._server: asyncio.Server | None = None
+        self._memory_service = MemoryService(anima_name, anima_dir) if memory_via_root else None
         self._start_lock = asyncio.Lock()
         self._jobs: dict[str, TaskRunnerJob] = {}
         self._accepting = True
@@ -113,6 +116,8 @@ class TaskRunnerSupervisor:
             return
         async with self._start_lock:
             if self._server is None:
+                if self._memory_service is not None:
+                    await self._memory_service.start()
                 self._server, endpoint = await start_ipc_server(
                     self.socket_path,
                     self._handle_connection,
@@ -296,6 +301,8 @@ class TaskRunnerSupervisor:
                 "ANIMAWORKS_TASK_ROOT_PID": str(os.getpid()),
             }
         )
+        if self._memory_service is not None:
+            env["ANIMAWORKS_MEMORY_VIA_ROOT"] = "1"
 
         hang_watch: asyncio.Task[None] | None = None
         try:
@@ -536,6 +543,9 @@ class TaskRunnerSupervisor:
 
             while True:
                 envelope = await asyncio.wait_for(connection.receive(), timeout=15.0)
+                if envelope.kind == "request":
+                    await self._handle_memory_request(connection, envelope)
+                    continue
                 if envelope.kind == "response":
                     if envelope.body["request_id"] != job.request_id:
                         raise IPCV2ProtocolError("response request_id does not match the run contract")
@@ -573,6 +583,42 @@ class TaskRunnerSupervisor:
             else:
                 writer.close()
                 await writer.wait_closed()
+
+    async def _handle_memory_request(self, connection: IPCV2Connection, envelope: Any) -> None:
+        request_id = envelope.body["request_id"]
+        method = envelope.body["method"]
+        params = envelope.body["params"]
+        if not method.startswith("memory."):
+            await connection.send_response(
+                request_id,
+                error=ipc_v2_error("PROTOCOL_ERROR", f"unsupported task request: {method}", retryable=False),
+            )
+            return
+        if self._memory_service is None:
+            await connection.send_response(
+                request_id,
+                error=ipc_v2_error("UNAVAILABLE", "root memory service is disabled", retryable=True),
+            )
+            return
+        try:
+            result = await self._memory_service.handle(method, params)
+        except MemoryServiceUnavailable as exc:
+            await connection.send_response(
+                request_id,
+                error=ipc_v2_error(
+                    "UNAVAILABLE",
+                    str(exc),
+                    retryable=True,
+                    retry_after_ms=250,
+                ),
+            )
+        except ValueError as exc:
+            await connection.send_response(
+                request_id,
+                error=ipc_v2_error("PROTOCOL_ERROR", str(exc), retryable=False),
+            )
+        else:
+            await connection.send_response(request_id, result=result)
 
     async def close(self) -> None:
         """Stop accepting jobs, grace active runners, then reap process groups."""
@@ -624,6 +670,8 @@ class TaskRunnerSupervisor:
             self._server.close()
             await self._server.wait_closed()
             self._server = None
+        if self._memory_service is not None:
+            await self._memory_service.close()
         cleanup_ipc_endpoint(self.socket_path)
         self._recover_task_journals()
 

--- a/tests/unit/core/memory/test_singleton_vector_url.py
+++ b/tests/unit/core/memory/test_singleton_vector_url.py
@@ -12,7 +12,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from core.memory.rag.http_store import HttpVectorStore
-from core.memory.rag.singleton import _reset_for_testing, get_vector_store
+from core.memory.rag.ipc_store import IpcVectorStore
+from core.memory.rag.singleton import _reset_for_testing, configure_ipc_vector_requester, get_vector_store
 from core.memory.rag.store import ChromaVectorStore
 
 
@@ -32,6 +33,23 @@ def test_returns_http_store_when_env_set():
         assert isinstance(store, HttpVectorStore)
         assert store._anima_name == "test_anima"
         assert store._base_url == "http://localhost:18500/api/internal/vector"
+
+
+def test_phase3_returns_ipc_store_for_reads() -> None:
+    requester = MagicMock(return_value={"collections": []})
+    configure_ipc_vector_requester(requester)
+    with patch.dict(
+        os.environ,
+        {
+            "ANIMAWORKS_VECTOR_URL": "http://localhost:18500/api/internal/vector",
+            "ANIMAWORKS_MEMORY_VIA_ROOT": "1",
+        },
+    ):
+        store = get_vector_store("test_anima")
+
+    assert isinstance(store, IpcVectorStore)
+    assert store.list_collections_checked() == []
+    requester.assert_called_once_with("memory.list_collections_checked", {})
 
 
 def test_returns_none_when_vector_url_and_direct_allow_are_not_set(monkeypatch):

--- a/tests/unit/core/supervisor/test_heartbeat_process_isolation.py
+++ b/tests/unit/core/supervisor/test_heartbeat_process_isolation.py
@@ -41,6 +41,26 @@ def _manager(tmp_path: Path, *, isolated: bool) -> tuple[SchedulerManager, Magic
 
 
 @pytest.mark.asyncio
+async def test_phase3_starts_root_memory_service_but_phase2_does_not(tmp_path: Path) -> None:
+    manager, _ = _manager(tmp_path, isolated=True)
+    assert manager._task_runner_supervisor is not None
+    assert manager._task_runner_supervisor._memory_service is None
+    await manager.shutdown_task_runners()
+
+    phase3_dir = tmp_path / "phase3" / "animas" / "sakura"
+    phase3_dir.mkdir(parents=True)
+    shared = tmp_path / "phase3" / "shared"
+    shared.mkdir()
+    (phase3_dir / "status.json").write_text('{"process_model":"phase3"}', encoding="utf-8")
+    anima = MagicMock(shared_dir=shared)
+    phase3 = SchedulerManager(anima, "sakura", phase3_dir, MagicMock())
+
+    assert phase3._task_runner_supervisor is not None
+    assert phase3._task_runner_supervisor._memory_service is not None
+    await phase3.shutdown_task_runners()
+
+
+@pytest.mark.asyncio
 async def test_flag_false_preserves_legacy_path_without_spawn(tmp_path: Path) -> None:
     manager, anima = _manager(tmp_path, isolated=False)
 

--- a/tests/unit/core/supervisor/test_memory_service.py
+++ b/tests/unit/core/supervisor/test_memory_service.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.memory.rag.ipc_store import IpcVectorStore
+from core.memory.rag.store import CollectionExistence, Document, SearchResult
+from core.supervisor.ipc_v2 import IPCV2Connection, IPCV2ConnectionState, IPCV2Identity, ipc_v2_error
+from core.supervisor.memory_service import MemoryService, MemoryServiceUnavailable
+from core.supervisor.task_runner import _MemoryRpcClient
+
+
+def _store() -> MagicMock:
+    store = MagicMock()
+    store._query_once.return_value = [SearchResult(Document("doc-1", "hello", metadata={"kind": "knowledge"}), 0.9)]
+    store._list_collections_once.return_value = ["sakura_knowledge"]
+    store._get_by_metadata_once.return_value = [
+        SearchResult(Document("doc-2", "matched", metadata={"kind": "knowledge"}), 1.0)
+    ]
+    store._get_by_ids_once.return_value = [Document("doc-1", "hello", metadata={"kind": "knowledge"})]
+    return store
+
+
+@pytest.mark.asyncio
+async def test_memory_service_checked_reads(tmp_path: Path) -> None:
+    store = _store()
+    service = MemoryService("sakura", tmp_path / "sakura", opener=lambda: store)
+
+    query = await service.handle(
+        "memory.query",
+        {"collection": "sakura_knowledge", "embedding": [0.1, 0.2], "top_k": 3},
+    )
+    listed = await service.handle("memory.list_collections_checked", {})
+    metadata = await service.handle(
+        "memory.get_by_metadata",
+        {"collection": "sakura_knowledge", "where": {"kind": "knowledge"}, "limit": 2},
+    )
+    documents = await service.handle(
+        "memory.get_by_ids",
+        {"collection": "sakura_knowledge", "ids": ["doc-1"]},
+    )
+
+    assert query["results"][0]["document"]["id"] == "doc-1"
+    assert listed == {"collections": ["sakura_knowledge"]}
+    assert metadata["results"][0]["document"]["content"] == "matched"
+    assert documents["documents"][0]["metadata"] == {"kind": "knowledge"}
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_memory_service_rejects_invalid_request_as_protocol_error(tmp_path: Path) -> None:
+    service = MemoryService("sakura", tmp_path / "sakura", opener=_store)
+
+    with pytest.raises(ValueError, match="embedding"):
+        await service.handle(
+            "memory.query",
+            {"collection": "sakura_knowledge", "embedding": "not-a-vector"},
+        )
+    await service.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fenced", [True, False])
+async def test_memory_service_unavailable_is_not_an_empty_success(tmp_path: Path, fenced: bool) -> None:
+    opener = (lambda: _store()) if fenced else MagicMock(side_effect=RuntimeError("broken DB"))
+    service = MemoryService(
+        "sakura",
+        tmp_path / "sakura",
+        opener=opener,
+        repair_fenced=lambda: fenced,
+    )
+
+    with pytest.raises(MemoryServiceUnavailable):
+        await service.handle("memory.list_collections_checked", {})
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_memory_service_queue_overflow_is_unavailable(tmp_path: Path) -> None:
+    store = _store()
+    entered = threading.Event()
+    release = threading.Event()
+
+    def blocked_list() -> list[str]:
+        entered.set()
+        release.wait(timeout=2)
+        return []
+
+    store._list_collections_once.side_effect = blocked_list
+    service = MemoryService("sakura", tmp_path / "sakura", queue_limit=1, opener=lambda: store)
+    first = asyncio.create_task(service.handle("memory.list_collections_checked", {}))
+    await asyncio.to_thread(entered.wait, 1)
+
+    with pytest.raises(MemoryServiceUnavailable, match="queue is full"):
+        await service.handle("memory.list_collections_checked", {})
+
+    release.set()
+    assert await first == {"collections": []}
+    await service.close()
+
+
+@pytest.mark.asyncio
+async def test_memory_ipc_round_trip_and_checked_unavailable(tmp_path: Path) -> None:
+    native = _store()
+    service = MemoryService("sakura", tmp_path / "sakura", opener=lambda: native)
+    identity = IPCV2Identity(
+        job_id="job-memory",
+        root_epoch=str(uuid.uuid4()),
+        attempt=1,
+        lane="cron",
+        display_lane="background",
+    )
+    server_state = IPCV2ConnectionState(identity)
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        connection = IPCV2Connection(reader, writer, server_state)
+        try:
+            for _ in range(2):
+                request = await connection.receive()
+                try:
+                    result = await service.handle(request.body["method"], request.body["params"])
+                except MemoryServiceUnavailable as exc:
+                    await connection.send_response(
+                        request.body["request_id"],
+                        error=ipc_v2_error("UNAVAILABLE", str(exc), retryable=True),
+                    )
+                else:
+                    await connection.send_response(request.body["request_id"], result=result)
+        finally:
+            await connection.close()
+
+    server = await asyncio.start_server(handle, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    connection = IPCV2Connection(reader, writer, IPCV2ConnectionState(identity))
+    rpc = _MemoryRpcClient(connection)
+    store = IpcVectorStore("http://vector.invalid", "sakura", rpc.request)
+
+    async def receive_responses() -> None:
+        for _ in range(2):
+            assert rpc.accept_response(await connection.receive())
+
+    receiver = asyncio.create_task(receive_responses())
+    results = await asyncio.to_thread(store.query, "sakura_knowledge", [0.1])
+    assert results[0].document.id == "doc-1"
+
+    service._repair_fenced = lambda: True
+    assert await asyncio.to_thread(store.list_collections_checked) is None
+    await receiver
+
+    rpc.close()
+    await connection.close()
+    server.close()
+    await server.wait_closed()
+    await service.close()
+
+
+def test_ipc_vector_store_keeps_writes_on_http() -> None:
+    store = IpcVectorStore("http://vector.invalid", "sakura", MagicMock())
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    store._client = MagicMock()
+    store._client.post.return_value = response
+
+    assert store.create_collection("sakura_knowledge") is True
+    store._client.post.assert_called_once_with(
+        "/create-collection",
+        json={"anima_name": "sakura", "collection": "sakura_knowledge"},
+    )
+
+
+def test_ipc_vector_store_collection_existence_is_three_state() -> None:
+    available = IpcVectorStore(
+        "http://vector.invalid",
+        "sakura",
+        lambda _method, _params: {"collections": ["sakura_knowledge"]},
+    )
+    unavailable = IpcVectorStore(
+        "http://vector.invalid",
+        "sakura",
+        MagicMock(side_effect=RuntimeError("root down")),
+    )
+
+    assert available.collection_exists("sakura_knowledge") is CollectionExistence.EXISTS
+    assert available.collection_exists("missing") is CollectionExistence.MISSING
+    assert unavailable.collection_exists("sakura_knowledge") is CollectionExistence.UNAVAILABLE


### PR DESCRIPTION
## 概要
Phase 3第一歩。rootに自anima専用read系MemoryServiceを実装し、task runnerのvector readをflagでroot IPCへ切替可能に。write系・排他完成はPR-7。

## 検証
- supervisor+memory 3130 passed / ruff+format clean（PdM再実行済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)