### PR TITLE
fix(supervisor): task runner終端ACK待ちで結果喪失修正（phase3全レーン障害）

### DIFF
--- a/core/supervisor/ipc_v2.py
+++ b/core/supervisor/ipc_v2.py
@@ -358,6 +358,19 @@ class IPCV2Connection:
                 await asyncio.wait_for(self.writer.drain(), timeout=IPC_V2_BACKPRESSURE_TIMEOUT)
             self.last_traffic_at = time.monotonic()
 
+    async def wait_for_ack(self, seq: int) -> None:
+        """Wait until the peer acknowledges a sent frame."""
+        if self.state.last_acked_seq >= seq:
+            return
+        try:
+            async with self._window_changed:
+                await asyncio.wait_for(
+                    self._window_changed.wait_for(lambda: self.state.last_acked_seq >= seq),
+                    IPC_V2_BACKPRESSURE_TIMEOUT,
+                )
+        except TimeoutError as exc:
+            raise IPCV2BackpressureTimeout(f"frame {seq} was not acknowledged within 5 seconds") from exc
+
     def is_half_open(self, now: float | None = None) -> bool:
         return (now or time.monotonic()) - self.last_traffic_at >= IPC_V2_HALF_OPEN_TIMEOUT
 

--- a/core/supervisor/task_runner.py
+++ b/core/supervisor/task_runner.py
@@ -447,16 +447,16 @@ async def _send_terminal(
     socket_path: Path,
     state: IPCV2ConnectionState,
     request_id: str,
+    receiver: asyncio.Task[IPCV2Envelope] | None,
     *,
     result: dict[str, Any] | None = None,
     error: dict[str, Any] | None = None,
 ) -> IPCV2Connection:
     """Send a terminal response, reconnecting once if the socket was lost."""
     try:
-        await connection.send_response(request_id, result=result, error=error)
-        return connection
+        terminal_seq = await connection.send_response(request_id, result=result, error=error)
     except IPCV2PayloadTooLarge:
-        await connection.send_response(
+        terminal_seq = await connection.send_response(
             request_id,
             error=ipc_v2_error(
                 "PAYLOAD_TOO_LARGE",
@@ -464,15 +464,24 @@ async def _send_terminal(
                 retryable=False,
             ),
         )
-        return connection
     except IPCV2ConnectionError:
         await connection.close()
-        reconnected, replayed_run = await _connect(socket_path, state)
+        connection, replayed_run = await _connect(socket_path, state)
         if replayed_run.body["request_id"] != request_id:
-            await reconnected.close()
+            await connection.close()
             raise
-        await reconnected.send_response(request_id, result=result, error=error)
-        return reconnected
+        terminal_seq = await connection.send_response(request_id, result=result, error=error)
+
+    if receiver is not None:
+        receiver.cancel()
+        await asyncio.gather(receiver, return_exceptions=True)
+    ack_receiver = asyncio.create_task(connection.receive())
+    try:
+        await connection.wait_for_ack(terminal_seq)
+    finally:
+        ack_receiver.cancel()
+        await asyncio.gather(ack_receiver, return_exceptions=True)
+    return connection
 
 
 async def _prepare_execution(
@@ -693,6 +702,7 @@ async def run_task(args: argparse.Namespace, socket_path: Path, identity: IPCV2I
                     socket_path,
                     state,
                     request_id,
+                    receiver,
                     error=ipc_v2_error("CANCELLED", "task runner was cancelled", retryable=True),
                 )
             elif graced and not root_lost:
@@ -701,6 +711,7 @@ async def run_task(args: argparse.Namespace, socket_path: Path, identity: IPCV2I
                     socket_path,
                     state,
                     request_id,
+                    receiver,
                     error=ipc_v2_error("CANCELLED", "task runner shut down under grace", retryable=True),
                 )
             return 1
@@ -714,6 +725,7 @@ async def run_task(args: argparse.Namespace, socket_path: Path, identity: IPCV2I
                 socket_path,
                 state,
                 request_id,
+                receiver,
                 error=ipc_v2_error("EXECUTION_ERROR", str(exc), retryable=False),
             )
             return 1
@@ -722,6 +734,7 @@ async def run_task(args: argparse.Namespace, socket_path: Path, identity: IPCV2I
             socket_path,
             state,
             request_id,
+            receiver,
             result=result,
         )
         return 0

--- a/core/supervisor/task_runner_supervisor.py
+++ b/core/supervisor/task_runner_supervisor.py
@@ -487,7 +487,11 @@ class TaskRunnerSupervisor:
             env["ANIMAWORKS_MEMORY_VIA_ROOT"] = "1"
 
         hang_watch: asyncio.Task[None] | None = None
+        stderr_file = None
         try:
+            stderr_path = self.shared_dir.parent / "logs" / "animas" / self.anima_name / "task-runner.stderr.log"
+            stderr_path.parent.mkdir(parents=True, exist_ok=True)
+            stderr_file = stderr_path.open("ab")
             process = await asyncio.create_subprocess_exec(
                 sys.executable,
                 "-m",
@@ -500,7 +504,7 @@ class TaskRunnerSupervisor:
                 job_id,
                 env=env,
                 stdout=asyncio.subprocess.DEVNULL,
-                stderr=asyncio.subprocess.DEVNULL,
+                stderr=stderr_file,
                 **subprocess_session_kwargs(),
             )
             job.process = process
@@ -563,6 +567,8 @@ class TaskRunnerSupervisor:
                 await job.process.wait()
             raise
         finally:
+            if stderr_file is not None:
+                stderr_file.close()
             if hang_watch is not None:
                 if not job.hang_kill_started:
                     hang_watch.cancel()

--- a/tests/e2e/core/test_phase3_task_runner_results.py
+++ b/tests/e2e/core/test_phase3_task_runner_results.py
@@ -1,0 +1,123 @@
+"""Phase 3 task runners return terminal results after root memory RPCs."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from collections.abc import Callable
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from core.schemas import CronTask
+from core.supervisor import ipc_v2
+from core.supervisor.task_runner_supervisor import TaskRunnerSupervisor
+
+
+class _MockEngineHandler(BaseHTTPRequestHandler):
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        payload = json.loads(self.rfile.read(length))
+        if "embed" in self.path:
+            body = {"embeddings": [[1.0, 0.0, 0.0] for _ in payload.get("texts", [])]}
+        else:
+            body = {
+                "id": "mock-chat",
+                "object": "chat.completion",
+                "created": 0,
+                "model": "mock",
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "mock reply"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            }
+        encoded = json.dumps(body).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def log_message(self, _format: str, *args: object) -> None:
+        pass
+
+
+@pytest.fixture
+def mock_engine_url() -> str:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _MockEngineHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("lane", ["cron", "chat"])
+async def test_phase3_returns_cron_command_and_chat_results(
+    lane: str,
+    data_dir: Path,
+    make_anima: Callable[..., Path],
+    mock_engine_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    anima_dir = make_anima(
+        "phase3-result",
+        model="openai/mock",
+        execution_mode="assisted",
+        credential="openai",
+        api_key="test",
+        api_base_url=f"{mock_engine_url}/v1",
+    )
+    status_path = anima_dir / "status.json"
+    status = json.loads(status_path.read_text(encoding="utf-8"))
+    status["process_model"] = "phase3"
+    status_path.write_text(json.dumps(status), encoding="utf-8")
+    monkeypatch.setenv("ANIMAWORKS_EMBED_URL", f"{mock_engine_url}/embed")
+
+    read_envelope = ipc_v2.read_ipc_v2_envelope
+
+    async def delayed_terminal_response(reader: asyncio.StreamReader) -> ipc_v2.IPCV2Envelope:
+        envelope = await read_envelope(reader)
+        if envelope.kind == "response" and envelope.body["request_id"].startswith("run-"):
+            await asyncio.sleep(0.5)
+        return envelope
+
+    monkeypatch.setattr(ipc_v2, "read_ipc_v2_envelope", delayed_terminal_response)
+
+    supervisor = TaskRunnerSupervisor(
+        "phase3-result",
+        anima_dir,
+        data_dir / "shared",
+        memory_via_root=True,
+    )
+    try:
+        if lane == "cron":
+            result = await supervisor.run_cron(
+                CronTask(
+                    name="phase3-command",
+                    schedule="0 0 1 1 *",
+                    type="command",
+                    command="printf command-result",
+                    trigger_heartbeat=False,
+                )
+            )
+            assert result["result"]["stdout"] == "command-result"
+        else:
+            result = await supervisor.run_chat(
+                kind="message",
+                payload={"message": "hello", "from_person": "human", "thread_id": "default"},
+            )
+            assert result["response"] == "mock reply"
+        assert (data_dir / "logs" / "animas" / "phase3-result" / "task-runner.stderr.log").is_file()
+    finally:
+        await supervisor.close()

--- a/tests/unit/core/supervisor/test_task_runner.py
+++ b/tests/unit/core/supervisor/test_task_runner.py
@@ -36,6 +36,9 @@ class FakeConnection:
         await asyncio.Event().wait()
         raise AssertionError("unreachable")
 
+    async def wait_for_ack(self, _seq: int) -> None:
+        pass
+
     async def close(self) -> None:
         self.closed = True
 
@@ -55,7 +58,7 @@ def _contract(identity: IPCV2Identity) -> IPCV2Envelope:
                     "schedule": "0 9 * * *",
                     "type": "llm",
                     "description": "run daily",
-                }
+                },
             },
         },
     )
@@ -206,4 +209,3 @@ async def test_heartbeat_lane_execution_returns_result(
             None,
         )
     ]
-


### PR DESCRIPTION
## 概要
phase3本番有効化時の全レーン系統失敗（結果喪失exit=0）の根本修正。終端frameのACK待ち+stderr保存+再現E2E。

## 検証
- 新設E2Eで修正前に再現→修正後green・phase2/3 E2E+supervisor 511 passed（PdM再実行済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)