### PR TITLE
fix(rag): startup preflight修復のnonce配線漏れ修正

### DIFF
--- a/cli/commands/repair_rag_cmd.py
+++ b/cli/commands/repair_rag_cmd.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import secrets
 import sys
 
 
@@ -83,47 +82,44 @@ def repair_rag_command(args: argparse.Namespace) -> None:
 
         temp_worker = start_temporary_vector_worker()
 
-    previous_nonce = os.environ.get("ANIMAWORKS_RAG_REPAIR_NONCE")
-    if previous_nonce is None:
-        os.environ["ANIMAWORKS_RAG_REPAIR_NONCE"] = secrets.token_urlsafe(32)
+    from core.memory.rag.repair_utils import rag_repair_nonce_env
 
     reason = str(getattr(args, "reason", "manual_repair_rag_cli"))
     try:
-        if anima:
-            result = service.repair_anima_if_allowed(
-                anima,
+        with rag_repair_nonce_env():
+            if anima:
+                result = service.repair_anima_if_allowed(
+                    anima,
+                    reason=reason,
+                    collection=None,
+                    source="cli",
+                    include_shared=bool(args.shared),
+                )
+                _print_single_result(result)
+                return
+
+            if all_animas:
+                targets = service.list_repairable_animas()
+            else:
+                targets = service.discover_suspect_animas(window_minutes=window_minutes)
+
+            if not targets:
+                print("No RAG repair targets found.")
+                return
+
+            results = service.repair_animas_if_allowed(
+                targets,
                 reason=reason,
-                collection=None,
                 source="cli",
                 include_shared=bool(args.shared),
             )
-            _print_single_result(result)
-            return
-
-        if all_animas:
-            targets = service.list_repairable_animas()
-        else:
-            targets = service.discover_suspect_animas(window_minutes=window_minutes)
-
-        if not targets:
-            print("No RAG repair targets found.")
-            return
-
-        results = service.repair_animas_if_allowed(
-            targets,
-            reason=reason,
-            source="cli",
-            include_shared=bool(args.shared),
-        )
-        failed = False
-        for result in results.values():
-            failed = failed or not result.ok
-            _print_result_line(result)
-        if failed:
-            raise SystemExit(1)
+            failed = False
+            for result in results.values():
+                failed = failed or not result.ok
+                _print_result_line(result)
+            if failed:
+                raise SystemExit(1)
     finally:
-        if previous_nonce is None:
-            os.environ.pop("ANIMAWORKS_RAG_REPAIR_NONCE", None)
         if temp_worker is not None:
             temp_worker.stop()
 

--- a/cli/commands/server.py
+++ b/cli/commands/server.py
@@ -525,12 +525,15 @@ def _run_rag_startup_preflight(*, force_all_vectordb: bool = False) -> None:
         joined = ", ".join(suspects)
         print(f"RAG startup preflight: repairing suspected vector DB(s): {joined}")
         startup_progress.set_phase("repairing", detail=joined, done_count=0, total_count=len(suspects))
-        results = service.repair_animas_if_allowed(
-            suspects,
-            reason=reason,
-            source="startup_preflight",
-            include_shared=True,
-        )
+        from core.memory.rag.repair_utils import rag_repair_nonce_env
+
+        with rag_repair_nonce_env():
+            results = service.repair_animas_if_allowed(
+                suspects,
+                reason=reason,
+                source="startup_preflight",
+                include_shared=True,
+            )
         for result in results.values():
             if result.ok:
                 logger.warning(

--- a/core/memory/rag/repair_rebuild.py
+++ b/core/memory/rag/repair_rebuild.py
@@ -29,34 +29,81 @@ def _has_active_repair_fence(anima_name: str, *, anima_dir: Path | None = None) 
 def reset_worker_vector_store(anima_name: str) -> bool:
     """Reset the vector worker's cached store for an anima when configured."""
     if not os.environ.get("ANIMAWORKS_VECTOR_URL"):
+        logger.warning(
+            "Vector worker reset skipped for %s: ANIMAWORKS_VECTOR_URL is unset",
+            anima_name,
+        )
         return False
     try:
         from core.memory.rag.http_store import HttpVectorStore
         from core.memory.rag.singleton import get_vector_store
 
         store = get_vector_store(anima_name)
-        if isinstance(store, HttpVectorStore):
-            return store.reset_store()
+        if not isinstance(store, HttpVectorStore):
+            logger.warning(
+                "Vector worker reset failed for %s: store type mismatch (got %s, need HttpVectorStore)",
+                anima_name,
+                type(store).__name__ if store is not None else "None",
+            )
+            return False
+        if not store.reset_store():
+            logger.warning(
+                "Vector worker reset failed for %s: HTTP /reset-store returned failure",
+                anima_name,
+            )
+            return False
+        return True
     except Exception:
-        logger.debug("Failed to reset vector worker store for %s", anima_name, exc_info=True)
-    return False
+        logger.warning(
+            "Vector worker reset failed for %s: exception during reset",
+            anima_name,
+            exc_info=True,
+        )
+        return False
 
 
 def verify_worker_vector_store(anima_name: str, *, expected_chunks: int) -> bool:
     """Verify the swapped DB through the fenced worker using the repair nonce."""
     repair_nonce = os.environ.get("ANIMAWORKS_RAG_REPAIR_NONCE")
     if not repair_nonce:
+        logger.warning(
+            "Vector worker verify skipped for %s: ANIMAWORKS_RAG_REPAIR_NONCE is unset",
+            anima_name,
+        )
+        return False
+    if not os.environ.get("ANIMAWORKS_VECTOR_URL"):
+        logger.warning(
+            "Vector worker verify skipped for %s: ANIMAWORKS_VECTOR_URL is unset",
+            anima_name,
+        )
         return False
     try:
         from core.memory.rag.http_store import HttpVectorStore
         from core.memory.rag.singleton import get_vector_store
 
         store = get_vector_store(anima_name)
-        if isinstance(store, HttpVectorStore):
-            return store.verify_repair(repair_nonce, expected_chunks=expected_chunks)
+        if not isinstance(store, HttpVectorStore):
+            logger.warning(
+                "Vector worker verify failed for %s: store type mismatch (got %s, need HttpVectorStore)",
+                anima_name,
+                type(store).__name__ if store is not None else "None",
+            )
+            return False
+        if not store.verify_repair(repair_nonce, expected_chunks=expected_chunks):
+            logger.warning(
+                "Vector worker verify failed for %s: HTTP /verify-repair returned failure (expected_chunks=%s)",
+                anima_name,
+                expected_chunks,
+            )
+            return False
+        return True
     except Exception:
-        logger.debug("Failed to verify rebuilt vector store for %s", anima_name, exc_info=True)
-    return False
+        logger.warning(
+            "Vector worker verify failed for %s: exception during verify",
+            anima_name,
+            exc_info=True,
+        )
+        return False
 
 
 def quarantine_vectordb(anima_name: str) -> Path | None:

--- a/core/memory/rag/repair_utils.py
+++ b/core/memory/rag/repair_utils.py
@@ -6,11 +6,37 @@ from __future__ import annotations
 
 """Utility functions for RAG corruption detection and repair locking."""
 
+import os
+import secrets
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 from core.platform.locks import acquire_file_lock, release_file_lock
+
+_RAG_REPAIR_NONCE_ENV = "ANIMAWORKS_RAG_REPAIR_NONCE"
+
+
+@contextmanager
+def rag_repair_nonce_env() -> Iterator[str]:
+    """Ensure ``ANIMAWORKS_RAG_REPAIR_NONCE`` is set for the duration of a repair.
+
+    Preserves a pre-existing value; generates a fresh token when unset and
+    restores the previous environment on exit.
+    """
+    previous = os.environ.get(_RAG_REPAIR_NONCE_ENV)
+    if previous is None:
+        os.environ[_RAG_REPAIR_NONCE_ENV] = secrets.token_urlsafe(32)
+    try:
+        yield os.environ[_RAG_REPAIR_NONCE_ENV]
+    finally:
+        if previous is None:
+            os.environ.pop(_RAG_REPAIR_NONCE_ENV, None)
+        else:
+            os.environ[_RAG_REPAIR_NONCE_ENV] = previous
+
 
 KNOWN_MEMORY_SUFFIXES = (
     "_knowledge",

--- a/tests/unit/cli/test_server_rag_preflight.py
+++ b/tests/unit/cli/test_server_rag_preflight.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -41,6 +42,87 @@ def test_rag_startup_preflight_repairs_suspects() -> None:
         source="startup_preflight",
         include_shared=True,
     )
+
+
+def test_rag_startup_preflight_sets_repair_nonce_during_repair(monkeypatch) -> None:
+    """Regression: preflight must set ANIMAWORKS_RAG_REPAIR_NONCE for worker verify."""
+    from cli.commands.server import _run_rag_startup_preflight
+
+    monkeypatch.delenv("ANIMAWORKS_RAG_REPAIR_NONCE", raising=False)
+
+    config = SimpleNamespace(
+        setup_complete=True,
+        rag=SimpleNamespace(
+            repair_enabled=True,
+            startup_repair_preflight_enabled=True,
+            startup_repair_window_minutes=30,
+            quick_check_timeout_seconds=4.0,
+        ),
+    )
+    service = MagicMock()
+    service.discover_suspect_animas.return_value = ["mei"]
+    nonce_at_call: dict[str, str | None] = {}
+
+    def _capture_nonce(*_args, **_kwargs):
+        nonce_at_call["value"] = os.environ.get("ANIMAWORKS_RAG_REPAIR_NONCE")
+        return {
+            "mei": RepairResult(
+                status="success",
+                anima_name="mei",
+                reason="startup_chroma_crash_preflight",
+            )
+        }
+
+    service.repair_animas_if_allowed.side_effect = _capture_nonce
+
+    with (
+        patch("core.config.load_config", return_value=config),
+        patch("core.memory.rag.repair.get_repair_service", return_value=service),
+    ):
+        _run_rag_startup_preflight()
+
+    assert nonce_at_call["value"], "repair nonce must be set while repair_animas_if_allowed runs"
+    assert os.environ.get("ANIMAWORKS_RAG_REPAIR_NONCE") is None, "nonce must be restored after preflight"
+
+
+def test_rag_startup_preflight_preserves_existing_repair_nonce(monkeypatch) -> None:
+    from cli.commands.server import _run_rag_startup_preflight
+
+    monkeypatch.setenv("ANIMAWORKS_RAG_REPAIR_NONCE", "pre-existing-nonce")
+
+    config = SimpleNamespace(
+        setup_complete=True,
+        rag=SimpleNamespace(
+            repair_enabled=True,
+            startup_repair_preflight_enabled=True,
+            startup_repair_window_minutes=30,
+            quick_check_timeout_seconds=4.0,
+        ),
+    )
+    service = MagicMock()
+    service.discover_suspect_animas.return_value = ["mei"]
+    nonce_at_call: dict[str, str | None] = {}
+
+    def _capture_nonce(*_args, **_kwargs):
+        nonce_at_call["value"] = os.environ.get("ANIMAWORKS_RAG_REPAIR_NONCE")
+        return {
+            "mei": RepairResult(
+                status="success",
+                anima_name="mei",
+                reason="startup_chroma_crash_preflight",
+            )
+        }
+
+    service.repair_animas_if_allowed.side_effect = _capture_nonce
+
+    with (
+        patch("core.config.load_config", return_value=config),
+        patch("core.memory.rag.repair.get_repair_service", return_value=service),
+    ):
+        _run_rag_startup_preflight()
+
+    assert nonce_at_call["value"] == "pre-existing-nonce"
+    assert os.environ.get("ANIMAWORKS_RAG_REPAIR_NONCE") == "pre-existing-nonce"
 
 
 def test_rag_startup_preflight_ignores_unclean_exit_without_suspects() -> None:

--- a/tests/unit/core/memory/test_rag_repair.py
+++ b/tests/unit/core/memory/test_rag_repair.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -1541,3 +1542,53 @@ def test_chroma_repair_verification_rejects_wrong_chunk_count() -> None:
 
     with pytest.raises(RuntimeError, match="expected 1 chunks.*found 0"):
         store.verify_rebuilt_data(expected_chunks=1)
+
+
+def test_reset_worker_vector_store_logs_missing_vector_url(monkeypatch, caplog) -> None:
+    import logging
+
+    from core.memory.rag.repair_rebuild import reset_worker_vector_store
+
+    monkeypatch.delenv("ANIMAWORKS_VECTOR_URL", raising=False)
+    with caplog.at_level(logging.WARNING, logger="animaworks.rag.repair"):
+        assert reset_worker_vector_store("rin") is False
+    assert any("ANIMAWORKS_VECTOR_URL is unset" in r.message for r in caplog.records)
+
+
+def test_reset_worker_vector_store_logs_store_type_mismatch(monkeypatch, caplog) -> None:
+    import logging
+
+    from core.memory.rag.repair_rebuild import reset_worker_vector_store
+
+    monkeypatch.setenv("ANIMAWORKS_VECTOR_URL", "http://worker")
+    monkeypatch.setattr("core.memory.rag.singleton.get_vector_store", lambda anima_name=None: object())
+    with caplog.at_level(logging.WARNING, logger="animaworks.rag.repair"):
+        assert reset_worker_vector_store("rin") is False
+    assert any("store type mismatch" in r.message for r in caplog.records)
+
+
+def test_verify_worker_vector_store_logs_missing_nonce(monkeypatch, caplog) -> None:
+    import logging
+
+    from core.memory.rag.repair_rebuild import verify_worker_vector_store
+
+    monkeypatch.delenv("ANIMAWORKS_RAG_REPAIR_NONCE", raising=False)
+    monkeypatch.setenv("ANIMAWORKS_VECTOR_URL", "http://worker")
+    with caplog.at_level(logging.WARNING, logger="animaworks.rag.repair"):
+        assert verify_worker_vector_store("rin", expected_chunks=10) is False
+    assert any("ANIMAWORKS_RAG_REPAIR_NONCE is unset" in r.message for r in caplog.records)
+
+
+def test_rag_repair_nonce_env_sets_and_restores(monkeypatch) -> None:
+    from core.memory.rag.repair_utils import rag_repair_nonce_env
+
+    monkeypatch.delenv("ANIMAWORKS_RAG_REPAIR_NONCE", raising=False)
+    with rag_repair_nonce_env() as nonce:
+        assert nonce
+        assert os.environ["ANIMAWORKS_RAG_REPAIR_NONCE"] == nonce
+    assert "ANIMAWORKS_RAG_REPAIR_NONCE" not in os.environ
+
+    monkeypatch.setenv("ANIMAWORKS_RAG_REPAIR_NONCE", "keep-me")
+    with rag_repair_nonce_env() as nonce:
+        assert nonce == "keep-me"
+    assert os.environ["ANIMAWORKS_RAG_REPAIR_NONCE"] == "keep-me"


### PR DESCRIPTION
## 概要
P0-6 (5deecee4) でswap後のvector worker検証が必須化された際、起動時preflight経路だけ ANIMAWORKS_RAG_REPAIR_NONCE の配線が漏れ、preflight起点のRAG修復が再構築完走後の検証で必ず失敗しrollbackされる退行があった（2026-08-08未明にmei/ritsuで本番実発生）。

## 変更
- rag_repair_nonce_env() contextmanager新設（既存値温存・finally復元）、preflight/CLIで共用
- reset/verify失敗理由（env未設定/store型不一致/HTTP失敗/例外）をWARNINGで区別
- preflight実行中のnonce設定・復元の回帰テスト追加

## 検証
- pytest 405 passed / ruff check・format クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)