### PR TITLE
feat(image): codex CLI最優先の画像生成経路とAPIフォールバックを追加

### DIFF
--- a/core/config/schemas.py
+++ b/core/config/schemas.py
@@ -515,6 +515,7 @@ class ImageGenConfig(BaseModel):
 
     backend: Literal["api", "diffusers"] = "api"
     image_style: Literal["anime", "realistic"] = "realistic"
+    prefer_codex: bool = True  # codex CLIがあれば画像生成に最優先で使う
     style_reference: str | None = None  # Path to organization-wide style reference image
     style_prefix: str = ""  # Common style tags prepended to character prompt
     style_suffix: str = ""  # Common style tags appended to character prompt

--- a/core/tools/_image_clients.py
+++ b/core/tools/_image_clients.py
@@ -40,6 +40,8 @@ from core.tools.image import (
     NOVELAI_API_URL,
     NOVELAI_ENCODE_URL,
     NOVELAI_MODEL,
+    CodexFirstClient,
+    CodexImageClient,
     FalTextToImageClient,
     FluxKontextClient,
     LocalDiffusersClient,
@@ -48,6 +50,7 @@ from core.tools.image import (
     _convert_anime_to_realistic,
     _image_to_data_uri,
     _retry,
+    codex_available,
 )
 
 __all__ = [
@@ -84,4 +87,7 @@ __all__ = [
     "FluxKontextClient",
     "FalTextToImageClient",
     "MeshyClient",
+    "CodexImageClient",
+    "CodexFirstClient",
+    "codex_available",
 ]

--- a/core/tools/_image_pipeline.py
+++ b/core/tools/_image_pipeline.py
@@ -9,7 +9,6 @@
 
 from __future__ import annotations
 
-import os
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -25,7 +24,6 @@ from core.tools._image_clients import (
     _REALISTIC_CHAT_ICON_PROMPT,
     _REALISTIC_EXPRESSION_GUIDANCE,
     _REALISTIC_EXPRESSION_PROMPTS,
-    LocalDiffusersClient,
 )
 from core.tools._image_glb import (
     _download_armature_animation,
@@ -267,12 +265,9 @@ class ImageGenPipeline:
 
         self._assets_dir.mkdir(parents=True, exist_ok=True)
 
-        if self._use_diffusers:
-            kontext = LocalDiffusersClient(self._config)
-        else:
-            from core.tools.image_gen import FluxKontextClient
+        from core.tools.image_gen import _build_reference_client
 
-            kontext = FluxKontextClient()
+        kontext = _build_reference_client(self._config)
         if self._is_realistic:
             guidance = _REALISTIC_EXPRESSION_GUIDANCE.get(expression, 4.5)
         else:
@@ -340,7 +335,7 @@ class ImageGenPipeline:
         Returns:
             PipelineResult with paths and error info.
         """
-        from core.tools.image_gen import FalTextToImageClient, FluxKontextClient, MeshyClient, NovelAIClient
+        from core.tools.image_gen import MeshyClient, _build_fullbody_client, _build_reference_client
 
         self._assets_dir.mkdir(parents=True, exist_ok=True)
         if steps:
@@ -372,26 +367,8 @@ class ImageGenPipeline:
             else:
                 try:
                     _notify("fullbody", "generating", 0)
-                    if self._use_diffusers:
-                        logger.info("Step 1: Generating full-body with local Diffusers …")
-                        client: NovelAIClient | FalTextToImageClient | LocalDiffusersClient = LocalDiffusersClient(
-                            self._config,
-                        )
-                    elif self._is_realistic:
-                        if not os.environ.get("FAL_KEY"):
-                            raise RuntimeError("FAL_KEY required for realistic image generation.")
-                        logger.info("Step 1: Generating realistic full-body with Fal Flux Pro …")
-                        client: NovelAIClient | FalTextToImageClient = FalTextToImageClient()
-                    elif os.environ.get("NOVELAI_TOKEN"):
-                        logger.info("Step 1: Generating full-body with NovelAI …")
-                        client = NovelAIClient()
-                    elif os.environ.get("FAL_KEY"):
-                        logger.info(
-                            "Step 1: Generating full-body with Fal Flux Pro (fallback) …",
-                        )
-                        client = FalTextToImageClient()
-                    else:
-                        raise RuntimeError("No image generation API key configured. Set NOVELAI_TOKEN or FAL_KEY.")
+                    client = _build_fullbody_client(self._config)
+                    logger.info("Step 1: Generating full-body with %s …", type(client).__name__)
 
                     # ── A: Load style reference for Vibe Transfer ──
                     # Direct vibe_image parameter takes precedence over config.
@@ -563,7 +540,7 @@ class ImageGenPipeline:
                     if self._config.style_suffix:
                         prompt = prompt + self._config.style_suffix
                     logger.info("Step 3: Generating icon from bustup …")
-                    kontext = FluxKontextClient()
+                    kontext = _build_reference_client(self._config)
                     raw = kontext.generate_from_reference(
                         reference_image=bust_bytes,
                         prompt=prompt,
@@ -597,12 +574,8 @@ class ImageGenPipeline:
             else:
                 try:
                     _notify("chibi", "generating", 0)
-                    if self._use_diffusers:
-                        logger.info("Step 4: Generating chibi with local Diffusers …")
-                        kontext = LocalDiffusersClient(self._config)
-                    else:
-                        logger.info("Step 4: Generating chibi with Flux Kontext …")
-                        kontext = FluxKontextClient()
+                    kontext = _build_reference_client(self._config)
+                    logger.info("Step 4: Generating chibi with %s …", type(kontext).__name__)
                     chibi_bytes = kontext.generate_from_reference(
                         reference_image=fullbody_bytes,
                         prompt=_CHIBI_PROMPT,

--- a/core/tools/image/__init__.py
+++ b/core/tools/image/__init__.py
@@ -27,6 +27,7 @@ from .constants import (
     NOVELAI_ENCODE_URL,
     NOVELAI_MODEL,
 )
+from .codex import CodexFirstClient, CodexImageClient, codex_available
 from .diffusers_local import LocalDiffusersClient
 from .fal import FalTextToImageClient, FluxKontextClient
 from .meshy import MeshyClient
@@ -78,4 +79,7 @@ __all__ = [
     "FluxKontextClient",
     "FalTextToImageClient",
     "MeshyClient",
+    "CodexImageClient",
+    "CodexFirstClient",
+    "codex_available",
 ]

--- a/core/tools/image/__init__.py
+++ b/core/tools/image/__init__.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+from .codex import CodexFirstClient, CodexImageClient, codex_available
 from .constants import (
     _DEFAULT_ANIMATIONS,
     _DOWNLOAD_TIMEOUT,
@@ -27,7 +28,6 @@ from .constants import (
     NOVELAI_ENCODE_URL,
     NOVELAI_MODEL,
 )
-from .codex import CodexFirstClient, CodexImageClient, codex_available
 from .diffusers_local import LocalDiffusersClient
 from .fal import FalTextToImageClient, FluxKontextClient
 from .meshy import MeshyClient

--- a/core/tools/image/codex.py
+++ b/core/tools/image/codex.py
@@ -1,0 +1,250 @@
+# AnimaWorks - Digital Anima Framework
+# Copyright (C) 2026 AnimaWorks Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file is part of AnimaWorks core/server, licensed under Apache-2.0.
+# See LICENSE for the full license text.
+
+"""Codex CLI image generation client (image_gen tool via local codex)."""
+
+from __future__ import annotations
+
+import io
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from PIL import Image
+
+from core.tools._base import logger
+
+_CODEX_TIMEOUT = 900  # seconds; generous margin for one image
+
+_ASPECT_SIZES: dict[str, tuple[int, int]] = {
+    "1:1": (1024, 1024),
+    "3:4": (1024, 1365),
+}
+
+
+def codex_available() -> bool:
+    """Return True if the codex CLI is installed on PATH."""
+    return shutil.which("codex") is not None
+
+
+def _cover_crop_resize(image_bytes: bytes, target_size: tuple[int, int]) -> bytes:
+    """Resize with cover-crop so output matches *target_size* without stretch."""
+    img = Image.open(io.BytesIO(image_bytes)).convert("RGBA")
+    tw, th = target_size
+    if img.size == (tw, th):
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        return buf.getvalue()
+
+    scale = max(tw / img.width, th / img.height)
+    nw = max(1, round(img.width * scale))
+    nh = max(1, round(img.height * scale))
+    img = img.resize((nw, nh), Image.Resampling.LANCZOS)
+    left = max(0, (nw - tw) // 2)
+    top = max(0, (nh - th) // 2)
+    img = img.crop((left, top, left + tw, top + th))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _build_spec(
+    *,
+    prompt: str,
+    image_style: str = "anime",
+    negative_prompt: str = "",
+    orientation: str = "portrait",
+    reference_roles: list[str] | None = None,
+) -> str:
+    """Build a Japanese markdown spec prompt for codex image_gen."""
+    if image_style == "realistic":
+        style_line = "フォトリアリスティックな実写調"
+    else:
+        style_line = "アニメ調イラスト"
+    style_line = f"{style_line}。構図は{orientation}"
+
+    lines = [
+        "# 画像生成仕様書",
+        "",
+        "## 使用ツール",
+        "組み込みの `image_gen` ツールを使う。SVG/HTML/CSS/手描きスクリプトでの代替は不可。",
+        "",
+        "## 被写体",
+        prompt,
+        "",
+        "## スタイル",
+        style_line,
+        "",
+    ]
+    if negative_prompt:
+        lines.extend(
+            [
+                "## 避けるもの",
+                negative_prompt,
+                "",
+            ]
+        )
+    if reference_roles:
+        lines.append("## 参照画像の役割")
+        for role in reference_roles:
+            lines.append(f"- {role}")
+        lines.append("")
+    lines.extend(
+        [
+            "## 出力契約",
+            "生成した画像をカレントディレクトリに `out.png` という名前のPNGで保存して終了する。他のファイルは作らない。",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+class CodexImageClient:
+    """Image client that drives the local ``codex`` CLI ``image_gen`` tool."""
+
+    def __init__(self, image_config: Any = None) -> None:
+        self._image_config = image_config
+        self._image_style = getattr(image_config, "image_style", "anime") if image_config is not None else "anime"
+
+    def generate_fullbody(
+        self,
+        prompt: str,
+        negative_prompt: str = "",
+        width: int = 1024,
+        height: int = 1536,
+        seed: int | None = None,
+        vibe_image: bytes | None = None,
+        vibe_strength: float | None = None,
+        vibe_info_extracted: float | None = None,
+        face_reference_image: bytes | None = None,
+        **_ignored: Any,
+    ) -> bytes:
+        """Generate a full-body character image via codex."""
+        del seed, vibe_strength, vibe_info_extracted  # not used by codex path
+        refs: list[bytes] = []
+        roles: list[str] = []
+        if vibe_image:
+            refs.append(vibe_image)
+            roles.append(f"参照画像{len(refs)}の画風に合わせる")
+        if face_reference_image:
+            refs.append(face_reference_image)
+            roles.append(f"参照画像{len(refs)}の人物の顔立ちを反映する")
+
+        orientation = "portrait" if height >= width else "square"
+        if width == height:
+            orientation = "square"
+        spec = _build_spec(
+            prompt=prompt,
+            image_style=self._image_style,
+            negative_prompt=negative_prompt,
+            orientation=orientation,
+            reference_roles=roles or None,
+        )
+        return self._run(spec, refs, (width, height))
+
+    def generate_from_reference(
+        self,
+        reference_image: bytes,
+        prompt: str,
+        aspect_ratio: str = "1:1",
+        **_ignored: Any,
+    ) -> bytes:
+        """Generate an image from a reference image via codex."""
+        target = _ASPECT_SIZES.get(aspect_ratio, (1024, 1024))
+        tw, th = target
+        orientation = "square" if tw == th else "portrait"
+        roles = ["参照画像1のキャラクターの同一性（髪型・髪色・瞳・服装）を維持する"]
+        spec = _build_spec(
+            prompt=prompt,
+            image_style=self._image_style,
+            orientation=orientation,
+            reference_roles=roles,
+        )
+        return self._run(spec, [reference_image], target)
+
+    def _run(
+        self,
+        spec: str,
+        reference_images: list[bytes],
+        target_size: tuple[int, int],
+    ) -> bytes:
+        """Run codex in a temp dir, then cover-crop to *target_size*."""
+        with tempfile.TemporaryDirectory(prefix="aw-codex-img-") as tmp:
+            tmp_path = Path(tmp)
+            cmd: list[str] = [
+                "codex",
+                "exec",
+                "--skip-git-repo-check",
+                "-s",
+                "workspace-write",
+                "-C",
+                str(tmp_path),
+            ]
+            for i, ref in enumerate(reference_images):
+                ref_path = tmp_path / f"ref_{i}.png"
+                ref_path.write_bytes(ref)
+                # -i resolves relative paths against the invoking cwd (not -C),
+                # so pass absolute paths.
+                cmd.extend(["-i", str(ref_path)])
+            # -i is variadic and would swallow the prompt; "--" ends option parsing.
+            cmd.extend(["--", spec])
+
+            try:
+                completed = subprocess.run(
+                    cmd,
+                    timeout=_CODEX_TIMEOUT,
+                    capture_output=True,
+                    check=False,
+                )
+            except subprocess.TimeoutExpired as exc:
+                raise RuntimeError(f"codex image generation timed out after {_CODEX_TIMEOUT}s") from exc
+
+            if completed.returncode != 0:
+                stderr_tail = (completed.stderr or b"")[-500:].decode("utf-8", errors="replace")
+                raise RuntimeError(f"codex image generation failed (rc={completed.returncode}): {stderr_tail}")
+
+            out_path = tmp_path / "out.png"
+            if not out_path.exists() or out_path.stat().st_size == 0:
+                stderr_tail = (completed.stderr or b"")[-500:].decode("utf-8", errors="replace")
+                raise RuntimeError(f"codex did not produce out.png: {stderr_tail}")
+
+            return _cover_crop_resize(out_path.read_bytes(), target_size)
+
+
+class CodexFirstClient:
+    """Try codex first; on failure defer to a lazily-built fallback client."""
+
+    def __init__(
+        self,
+        fallback_factory: Callable[[], Any],
+        image_config: Any = None,
+    ) -> None:
+        self._fallback_factory = fallback_factory
+        self._image_config = image_config
+        self._fallback: Any | None = None
+
+    def _get_fallback(self) -> Any:
+        if self._fallback is None:
+            self._fallback = self._fallback_factory()
+        return self._fallback
+
+    def generate_fullbody(self, *args: Any, **kwargs: Any) -> bytes:
+        try:
+            return CodexImageClient(self._image_config).generate_fullbody(*args, **kwargs)
+        except Exception as exc:
+            logger.warning("codex image generation failed, falling back to API: %s", exc)
+            return self._get_fallback().generate_fullbody(*args, **kwargs)
+
+    def generate_from_reference(self, *args: Any, **kwargs: Any) -> bytes:
+        try:
+            return CodexImageClient(self._image_config).generate_from_reference(*args, **kwargs)
+        except Exception as exc:
+            logger.warning("codex image generation failed, falling back to API: %s", exc)
+            return self._get_fallback().generate_from_reference(*args, **kwargs)

--- a/core/tools/image/codex.py
+++ b/core/tools/image/codex.py
@@ -63,43 +63,43 @@ def _build_spec(
     orientation: str = "portrait",
     reference_roles: list[str] | None = None,
 ) -> str:
-    """Build a Japanese markdown spec prompt for codex image_gen."""
+    """Build a markdown spec prompt for codex image_gen."""
     if image_style == "realistic":
-        style_line = "フォトリアリスティックな実写調"
+        style_line = "Photorealistic, live-action look"
     else:
-        style_line = "アニメ調イラスト"
-    style_line = f"{style_line}。構図は{orientation}"
+        style_line = "Anime-style illustration"
+    style_line = f"{style_line}. Composition: {orientation}."
 
     lines = [
-        "# 画像生成仕様書",
+        "# Image generation spec",
         "",
-        "## 使用ツール",
-        "組み込みの `image_gen` ツールを使う。SVG/HTML/CSS/手描きスクリプトでの代替は不可。",
+        "## Tool",
+        "Use the built-in `image_gen` tool. Substituting SVG/HTML/CSS or hand-drawn scripts is not acceptable.",
         "",
-        "## 被写体",
+        "## Subject",
         prompt,
         "",
-        "## スタイル",
+        "## Style",
         style_line,
         "",
     ]
     if negative_prompt:
         lines.extend(
             [
-                "## 避けるもの",
+                "## Avoid",
                 negative_prompt,
                 "",
             ]
         )
     if reference_roles:
-        lines.append("## 参照画像の役割")
+        lines.append("## Reference image roles")
         for role in reference_roles:
             lines.append(f"- {role}")
         lines.append("")
     lines.extend(
         [
-            "## 出力契約",
-            "生成した画像をカレントディレクトリに `out.png` という名前のPNGで保存して終了する。他のファイルは作らない。",
+            "## Output contract",
+            "Save the generated image as a PNG named `out.png` in the current directory, then finish. Do not create any other files.",
             "",
         ]
     )
@@ -132,10 +132,10 @@ class CodexImageClient:
         roles: list[str] = []
         if vibe_image:
             refs.append(vibe_image)
-            roles.append(f"参照画像{len(refs)}の画風に合わせる")
+            roles.append(f"Match the art style of reference image {len(refs)}")
         if face_reference_image:
             refs.append(face_reference_image)
-            roles.append(f"参照画像{len(refs)}の人物の顔立ちを反映する")
+            roles.append(f"Reflect the facial features of the person in reference image {len(refs)}")
 
         orientation = "portrait" if height >= width else "square"
         if width == height:
@@ -160,7 +160,7 @@ class CodexImageClient:
         target = _ASPECT_SIZES.get(aspect_ratio, (1024, 1024))
         tw, th = target
         orientation = "square" if tw == th else "portrait"
-        roles = ["参照画像1のキャラクターの同一性（髪型・髪色・瞳・服装）を維持する"]
+        roles = ["Preserve the identity of the character in reference image 1 (hairstyle, hair color, eyes, outfit)"]
         spec = _build_spec(
             prompt=prompt,
             image_style=self._image_style,

--- a/core/tools/image_gen.py
+++ b/core/tools/image_gen.py
@@ -70,6 +70,8 @@ from core.tools._image_clients import (
     NOVELAI_API_URL,
     NOVELAI_ENCODE_URL,
     NOVELAI_MODEL,
+    CodexFirstClient,
+    CodexImageClient,
     FalTextToImageClient,
     FluxKontextClient,
     LocalDiffusersClient,
@@ -77,6 +79,7 @@ from core.tools._image_clients import (
     NovelAIClient,
     _image_to_data_uri,
     _retry,
+    codex_available,
 )
 
 # ── Re-exports: _image_glb ────────────────────────────────
@@ -147,9 +150,8 @@ def _use_diffusers_backend(image_config: Any) -> bool:
     return getattr(image_config, "backend", "api") == "diffusers"
 
 
-def _build_fullbody_client(image_config: Any) -> Any:
-    if _use_diffusers_backend(image_config):
-        return LocalDiffusersClient(image_config)
+def _build_fullbody_api_client(image_config: Any) -> Any:
+    """Select the API fullbody client (NovelAI / Fal). Used as codex fallback."""
     if getattr(image_config, "image_style", "anime") == "realistic":
         if not os.environ.get("FAL_KEY"):
             raise RuntimeError("FAL_KEY required for realistic image generation.")
@@ -161,9 +163,25 @@ def _build_fullbody_client(image_config: Any) -> Any:
     raise RuntimeError("No image generation backend configured. Enable Diffusers or set NOVELAI_TOKEN/FAL_KEY.")
 
 
+def _build_fullbody_client(image_config: Any) -> Any:
+    if _use_diffusers_backend(image_config):
+        return LocalDiffusersClient(image_config)
+    if getattr(image_config, "prefer_codex", True) and codex_available():
+        return CodexFirstClient(
+            fallback_factory=lambda: _build_fullbody_api_client(image_config),
+            image_config=image_config,
+        )
+    return _build_fullbody_api_client(image_config)
+
+
 def _build_reference_client(image_config: Any) -> Any:
     if _use_diffusers_backend(image_config):
         return LocalDiffusersClient(image_config)
+    if getattr(image_config, "prefer_codex", True) and codex_available():
+        return CodexFirstClient(
+            fallback_factory=FluxKontextClient,
+            image_config=image_config,
+        )
     return FluxKontextClient()
 
 
@@ -276,7 +294,7 @@ def dispatch(tool_name: str, args: dict[str, Any]) -> Any:
             prompt = config.style_prefix + prompt
         if config.style_suffix:
             prompt = prompt + config.style_suffix
-        client = FluxKontextClient()
+        client = _build_reference_client(config)
         img = client.generate_from_reference(
             reference_image=ref_path.read_bytes(),
             prompt=prompt,

--- a/tests/unit/tools/conftest.py
+++ b/tests/unit/tools/conftest.py
@@ -1,0 +1,20 @@
+# AnimaWorks - Digital Anima Framework
+# Copyright (C) 2026 AnimaWorks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fixtures for tools unit tests.
+
+Disable codex-first selection by default so existing image-gen tests that
+patch NovelAI/Flux clients keep working on machines where codex is installed.
+Individual tests can re-enable via monkeypatch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _disable_codex_image_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("core.tools.image_gen.codex_available", lambda: False)
+    monkeypatch.setattr("core.tools.image.codex.codex_available", lambda: False)

--- a/tests/unit/tools/test_codex_image_client.py
+++ b/tests/unit/tools/test_codex_image_client.py
@@ -1,0 +1,242 @@
+# AnimaWorks - Digital Anima Framework
+# Copyright (C) 2026 AnimaWorks Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for codex-first image generation clients."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PIL import Image
+
+from core.config.models import ImageGenConfig
+from core.tools.image.codex import (
+    CodexFirstClient,
+    CodexImageClient,
+    codex_available,
+)
+from core.tools.image_gen import _build_fullbody_client, _build_reference_client
+
+
+def _png_bytes(width: int, height: int, color: tuple[int, int, int, int] = (10, 20, 30, 255)) -> bytes:
+    img = Image.new("RGBA", (width, height), color)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _decode_size(data: bytes) -> tuple[int, int]:
+    with Image.open(io.BytesIO(data)) as img:
+        return img.size
+
+
+def _mock_codex_writes_png(
+    size: tuple[int, int] = (64, 64),
+    *,
+    returncode: int = 0,
+    missing_out: bool = False,
+) -> Any:
+    """Return a subprocess.run side_effect that writes out.png under -C dir."""
+
+    def _run(cmd: list[str], **kwargs: Any) -> MagicMock:
+        tmpdir: Path | None = None
+        for i, part in enumerate(cmd):
+            if part == "-C" and i + 1 < len(cmd):
+                tmpdir = Path(cmd[i + 1])
+                break
+        assert tmpdir is not None, f"no -C in cmd: {cmd}"
+        if not missing_out and returncode == 0:
+            (tmpdir / "out.png").write_bytes(_png_bytes(*size))
+        result = MagicMock()
+        result.returncode = returncode
+        result.stderr = b"stderr tail from mock"
+        result.stdout = b""
+        return result
+
+    return _run
+
+
+class TestCodexAvailable:
+    def test_true_when_which_finds_binary(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("core.tools.image.codex.shutil.which", lambda _n: "/usr/bin/codex")
+        assert codex_available() is True
+
+    def test_false_when_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("core.tools.image.codex.shutil.which", lambda _n: None)
+        assert codex_available() is False
+
+
+class TestCodexImageClient:
+    def test_generate_fullbody_resizes_to_target(self) -> None:
+        client = CodexImageClient(ImageGenConfig(image_style="anime"))
+        with patch("core.tools.image.codex.subprocess.run", side_effect=_mock_codex_writes_png((80, 120))):
+            out = client.generate_fullbody(prompt="1girl, black hair", width=1024, height=1536)
+        assert isinstance(out, bytes)
+        assert _decode_size(out) == (1024, 1536)
+
+    def test_cover_crop_from_square_to_portrait(self) -> None:
+        """Square mock output must become 1024x1536 without stretch."""
+        client = CodexImageClient()
+        with patch("core.tools.image.codex.subprocess.run", side_effect=_mock_codex_writes_png((200, 200))):
+            out = client.generate_fullbody(prompt="subject", width=1024, height=1536)
+        assert _decode_size(out) == (1024, 1536)
+
+    def test_generate_from_reference_aspect_1_1(self) -> None:
+        client = CodexImageClient(ImageGenConfig(image_style="realistic"))
+        ref = _png_bytes(32, 32)
+        with patch("core.tools.image.codex.subprocess.run", side_effect=_mock_codex_writes_png((90, 90))):
+            out = client.generate_from_reference(reference_image=ref, prompt="icon", aspect_ratio="1:1")
+        assert _decode_size(out) == (1024, 1024)
+
+    def test_generate_from_reference_aspect_3_4(self) -> None:
+        client = CodexImageClient()
+        ref = _png_bytes(32, 48)
+        with patch("core.tools.image.codex.subprocess.run", side_effect=_mock_codex_writes_png((100, 100))):
+            out = client.generate_from_reference(reference_image=ref, prompt="bust", aspect_ratio="3:4")
+        assert _decode_size(out) == (1024, 1365)
+
+    def test_missing_out_png_raises_runtime_error(self) -> None:
+        client = CodexImageClient()
+        with (
+            patch(
+                "core.tools.image.codex.subprocess.run",
+                side_effect=_mock_codex_writes_png(missing_out=True),
+            ),
+            pytest.raises(RuntimeError, match="out.png"),
+        ):
+            client.generate_fullbody(prompt="x")
+
+    def test_nonzero_returncode_raises_runtime_error(self) -> None:
+        client = CodexImageClient()
+        with (
+            patch(
+                "core.tools.image.codex.subprocess.run",
+                side_effect=_mock_codex_writes_png(returncode=1),
+            ),
+            pytest.raises(RuntimeError, match="failed"),
+        ):
+            client.generate_fullbody(prompt="x")
+
+    def test_vibe_and_face_refs_attached(self) -> None:
+        client = CodexImageClient()
+        captured: dict[str, Any] = {}
+
+        def _run(cmd: list[str], **kwargs: Any) -> MagicMock:
+            captured["cmd"] = cmd
+            return _mock_codex_writes_png((32, 32))(cmd, **kwargs)
+
+        vibe = _png_bytes(8, 8, (1, 0, 0, 255))
+        face = _png_bytes(8, 8, (0, 1, 0, 255))
+        with patch("core.tools.image.codex.subprocess.run", side_effect=_run):
+            client.generate_fullbody(
+                prompt="char",
+                vibe_image=vibe,
+                face_reference_image=face,
+                width=64,
+                height=64,
+            )
+        cmd = captured["cmd"]
+        assert cmd.count("-i") == 2
+        # -i paths must be absolute (resolved against invoking cwd, not -C)
+        img_paths = [cmd[i + 1] for i, part in enumerate(cmd) if part == "-i"]
+        assert all(Path(p).is_absolute() for p in img_paths)
+        assert [Path(p).name for p in img_paths] == ["ref_0.png", "ref_1.png"]
+        # "--" must precede the prompt so variadic -i does not swallow it
+        assert cmd[-2] == "--"
+
+
+class TestCodexFirstClient:
+    def test_fallback_on_missing_out(self) -> None:
+        fallback = MagicMock()
+        fallback.generate_fullbody.return_value = b"FALLBACK-FULL"
+        client = CodexFirstClient(fallback_factory=lambda: fallback)
+
+        with patch(
+            "core.tools.image.codex.subprocess.run",
+            side_effect=_mock_codex_writes_png(missing_out=True),
+        ):
+            out = client.generate_fullbody(prompt="p", width=100, height=200)
+
+        assert out == b"FALLBACK-FULL"
+        fallback.generate_fullbody.assert_called_once()
+        kwargs = fallback.generate_fullbody.call_args.kwargs
+        assert kwargs["prompt"] == "p"
+        assert kwargs["width"] == 100
+        assert kwargs["height"] == 200
+
+    def test_fallback_on_nonzero_rc_for_reference(self) -> None:
+        fallback = MagicMock()
+        fallback.generate_from_reference.return_value = b"FALLBACK-REF"
+        client = CodexFirstClient(fallback_factory=lambda: fallback)
+        ref = _png_bytes(16, 16)
+
+        with patch(
+            "core.tools.image.codex.subprocess.run",
+            side_effect=_mock_codex_writes_png(returncode=2),
+        ):
+            out = client.generate_from_reference(reference_image=ref, prompt="icon", aspect_ratio="1:1")
+
+        assert out == b"FALLBACK-REF"
+        fallback.generate_from_reference.assert_called_once()
+        call_kw = fallback.generate_from_reference.call_args.kwargs
+        assert call_kw["prompt"] == "icon"
+        assert call_kw["aspect_ratio"] == "1:1"
+        assert call_kw["reference_image"] == ref
+
+    def test_success_does_not_call_fallback_factory(self) -> None:
+        factory = MagicMock(side_effect=RuntimeError("factory should not run"))
+        client = CodexFirstClient(fallback_factory=factory)
+        with patch("core.tools.image.codex.subprocess.run", side_effect=_mock_codex_writes_png((40, 40))):
+            out = client.generate_fullbody(prompt="ok", width=64, height=64)
+        assert _decode_size(out) == (64, 64)
+        factory.assert_not_called()
+
+
+class TestClientBuilders:
+    def test_codex_unavailable_uses_api_clients(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("core.tools.image_gen.codex_available", lambda: False)
+        monkeypatch.setenv("NOVELAI_TOKEN", "tok")
+        monkeypatch.setenv("FAL_KEY", "fal-tok")
+        cfg = ImageGenConfig(image_style="anime", backend="api", prefer_codex=True)
+        fullbody = _build_fullbody_client(cfg)
+        ref = _build_reference_client(cfg)
+        from core.tools.image.fal import FluxKontextClient
+        from core.tools.image.novelai import NovelAIClient
+
+        assert isinstance(fullbody, NovelAIClient)
+        assert isinstance(ref, FluxKontextClient)
+
+    def test_prefer_codex_false_skips_codex(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("core.tools.image_gen.codex_available", lambda: True)
+        monkeypatch.setenv("NOVELAI_TOKEN", "tok")
+        monkeypatch.setenv("FAL_KEY", "fal-tok")
+        cfg = ImageGenConfig(image_style="anime", backend="api", prefer_codex=False)
+        fullbody = _build_fullbody_client(cfg)
+        ref = _build_reference_client(cfg)
+        from core.tools.image.fal import FluxKontextClient
+        from core.tools.image.novelai import NovelAIClient
+
+        assert isinstance(fullbody, NovelAIClient)
+        assert isinstance(ref, FluxKontextClient)
+        assert not isinstance(fullbody, CodexFirstClient)
+
+    def test_prefer_codex_true_and_available_wraps(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("core.tools.image_gen.codex_available", lambda: True)
+        cfg = ImageGenConfig(image_style="anime", backend="api", prefer_codex=True)
+        fullbody = _build_fullbody_client(cfg)
+        ref = _build_reference_client(cfg)
+        assert isinstance(fullbody, CodexFirstClient)
+        assert isinstance(ref, CodexFirstClient)
+
+    def test_diffusers_backend_ignores_codex(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("core.tools.image_gen.codex_available", lambda: True)
+        cfg = ImageGenConfig(backend="diffusers", prefer_codex=True)
+        from core.tools.image.diffusers_local import LocalDiffusersClient
+
+        assert isinstance(_build_fullbody_client(cfg), LocalDiffusersClient)
+        assert isinstance(_build_reference_client(cfg), LocalDiffusersClient)

--- a/tests/unit/tools/test_diffusers_local_backend.py
+++ b/tests/unit/tools/test_diffusers_local_backend.py
@@ -14,7 +14,7 @@ def test_pipeline_uses_local_diffusers_for_fullbody(tmp_path: Path) -> None:
     config = ImageGenConfig(image_style="anime", backend="diffusers")
     pipeline = ImageGenPipeline(tmp_path, config=config)
 
-    with patch("core.tools._image_pipeline.LocalDiffusersClient") as mock_cls:
+    with patch("core.tools.image_gen.LocalDiffusersClient") as mock_cls:
         mock_client = MagicMock()
         mock_client.generate_fullbody.return_value = b"PNG-DATA"
         mock_cls.return_value = mock_client
@@ -35,7 +35,7 @@ def test_realistic_diffusers_fullbody_enforces_single_subject(tmp_path: Path) ->
     config = ImageGenConfig(image_style="realistic", backend="diffusers")
     pipeline = ImageGenPipeline(tmp_path, config=config)
 
-    with patch("core.tools._image_pipeline.LocalDiffusersClient") as mock_cls:
+    with patch("core.tools.image_gen.LocalDiffusersClient") as mock_cls:
         mock_client = MagicMock()
         mock_client.generate_fullbody.return_value = b"PNG-DATA"
         mock_cls.return_value = mock_client
@@ -60,7 +60,7 @@ def test_pipeline_uses_local_diffusers_for_bustup_expression(tmp_path: Path) -> 
     config = ImageGenConfig(image_style="anime", backend="diffusers")
     pipeline = ImageGenPipeline(tmp_path, config=config)
 
-    with patch("core.tools._image_pipeline.LocalDiffusersClient") as mock_cls:
+    with patch("core.tools.image_gen.LocalDiffusersClient") as mock_cls:
         mock_client = MagicMock()
         mock_client.generate_from_reference.return_value = b"BUSTUP-DATA"
         mock_cls.return_value = mock_client


### PR DESCRIPTION
## 概要

キャラクター画像アセット生成（fullbody/bustup/icon/chibi、アニメ・実写）で、ローカルの codex CLI（組み込み image_gen）を最優先で使い、失敗時に既存API（NovelAI / fal / FluxKontext）へフォールバックする経路を追加。codexがインストールされていればAPIキー無しでアセット生成が動く。

## 変更点

- `core/tools/image/codex.py` 新規: `CodexImageClient`（仕様書markdownを codex exec に渡して生成）と `CodexFirstClient`（失敗時の遅延フォールバック）
- クライアント選択を `_build_fullbody_client` / `_build_reference_client` に一本化（`_image_pipeline` 内の重複分岐を削除）。優先順位: diffusers（明示設定）> codex > API
- `ImageGenConfig.prefer_codex: bool = True` 追加
- codexは出力サイズを守らないため Pillow の cover-crop で正確なサイズに整形

## 実装上の注意（実機検証で発見）

- codex exec の `-i` は可変長のため、プロンプトは `--` 区切りで渡す（直後に置くと画像として食われる）
- `-i` の相対パスは `-C` ではなく呼び出し元cwd基準 → 絶対パスで渡す

## 検証

- 新規ユニットテスト16件 + 画像系既存157件 pass、ruff クリーン
- 実codexで実地スモーク: 素の生成と参照画像つき編集（1024×1024厳守）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)