### PR TITLE
fix(assets): プロンプト合成の無限リトライループを修正

### DIFF
--- a/core/asset_reconciler.py
+++ b/core/asset_reconciler.py
@@ -275,6 +275,8 @@ async def reconcile_anima_assets(
                 "No prompt available for %s — cannot generate assets",
                 anima_name,
             )
+            # Without cooldown this retries every reconcile tick (~30s) forever
+            _record_failure(anima_name, "no prompt available")
             return {
                 "anima": anima_name,
                 "skipped": True,
@@ -575,7 +577,9 @@ async def _synthesize_prompt_via_llm(
                 system_prompt=system_content,
                 model=model or "",
                 credential=credential,
-                max_tokens=256,
+                # thinking系モデルはreasoningだけで数百トークン消費するため、
+                # 256だとcontentが空のままfinish_reason=lengthになる
+                max_tokens=4096,
             )
             or ""
         ).strip()

--- a/tests/unit/core/test_asset_reconciler.py
+++ b/tests/unit/core/test_asset_reconciler.py
@@ -12,6 +12,16 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _clear_failure_cooldowns():
+    """Isolate the module-level cooldown registry between tests."""
+    from core.asset_reconciler import _failure_cooldowns
+
+    _failure_cooldowns.clear()
+    yield
+    _failure_cooldowns.clear()
+
+
 # ── check_anima_assets ──────────────────────────────────────────
 
 


### PR DESCRIPTION
## 症状
yoruのrealisticアバター欠損時、asset_reconcilerが30秒毎にLLMプロンプト合成を永久リトライ。24時間で2,780回のLLM呼び出しがxserverng2のGPUを常時占有していた。

## 根因（3段の噛み合わせ）
1. `_synthesize_prompt_via_llm` が `max_tokens=256` で合成を依頼
2. yoruのモデル(qwen3.6-35b-a3b-chat, thinking有効)はreasoningだけで256トークンを消費し、contentが空のまま `finish_reason=length`（実機再現済み: reasoning 819字 / content空）
3. 失敗時（`no_prompt`）はcooldown登録がなく、reconcileの30秒tickで無限再試行

## 修正
- `max_tokens` 256→4096（thinking消費後もcontentが出る余裕）
- `no_prompt` 失敗時に既存のcooldown機構(1h)へ登録
- テスト: モジュールレベル `_failure_cooldowns` の相互汚染をautouse fixtureで分離

## テスト
`tests/unit/core/test_asset_reconciler.py` 32件全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)