### PR TITLE
fix(tasks): checkless blockedタスクの時限自動再開を廃止 (fail closed)

### DIFF
--- a/core/blocked_recovery.py
+++ b/core/blocked_recovery.py
@@ -117,10 +117,11 @@ def _alert_manual_intervention_required(
         target_name=anima_name,
         delegated_task_id=entry.task_id,
         summary=f"Blocked task needs intervention: {anima_name}/{entry.task_id}",
-        instruction=(
-            f"タスク {entry.task_id}（{anima_name}）は unblock_check を持たないため自動再開されない。"
-            f"人手で確認し、完了なら done/cancelled に、継続なら unblock_check を付けて "
-            f"blocked を宣言し直すこと。\n\n{entry.original_instruction}"
+        instruction=t(
+            "blocked_recovery.manual_intervention_instruction",
+            task_id=entry.task_id,
+            anima_name=anima_name,
+            original_instruction=entry.original_instruction,
         ),
         extra_meta={"blocked_task_id": entry.task_id},
     )

--- a/core/blocked_recovery.py
+++ b/core/blocked_recovery.py
@@ -93,7 +93,7 @@ def _record_check_failure(manager: TaskQueueManager, entry: TaskEntry) -> None:
     )
 
 
-def _alert_reprobe_exhausted(
+def _alert_manual_intervention_required(
     manager: TaskQueueManager,
     anima_dir: Path,
     anima_name: str,
@@ -113,13 +113,14 @@ def _alert_reprobe_exhausted(
         return
     _add_alert_task(
         supervisor_dir,
-        kind="blocked_task_reprobe_exhausted",
+        kind="blocked_task_manual_intervention_required",
         target_name=anima_name,
         delegated_task_id=entry.task_id,
         summary=f"Blocked task needs intervention: {anima_name}/{entry.task_id}",
         instruction=(
-            f"Task {entry.task_id} for {anima_name} remains blocked after automatic reprobes. "
-            f"Review the blocker and decide how to proceed.\n\n{entry.original_instruction}"
+            f"タスク {entry.task_id}（{anima_name}）は unblock_check を持たないため自動再開されない。"
+            f"人手で確認し、完了なら done/cancelled に、継続なら unblock_check を付けて "
+            f"blocked を宣言し直すこと。\n\n{entry.original_instruction}"
         ),
         extra_meta={"blocked_task_id": entry.task_id},
     )
@@ -210,12 +211,17 @@ def revalidate_blocked_tasks(anima_dir: Path, anima_name: str) -> list[str]:
                     continue
                 suffix = ""
             else:
-                reprobes = _count(entry.meta, "blocked_reprobe_count")
-                if reprobes >= config.blocked_max_reprobes:
-                    _alert_reprobe_exhausted(manager, anima_dir, anima_name, entry)
-                    continue
+                # checkless: fail closed by default (no automatic pending requeue).
                 age_hours = _age_hours(entry)
                 if age_hours is None or age_hours < config.blocked_reprobe_after_hours:
+                    continue
+                if not config.blocked_checkless_reprobe_enabled:
+                    _alert_manual_intervention_required(manager, anima_dir, anima_name, entry)
+                    continue
+                # Legacy time-based reprobe (opt-in via blocked_checkless_reprobe_enabled).
+                reprobes = _count(entry.meta, "blocked_reprobe_count")
+                if reprobes >= config.blocked_max_reprobes:
+                    _alert_manual_intervention_required(manager, anima_dir, anima_name, entry)
                     continue
                 manager.update_meta(entry.task_id, {"blocked_reprobe_count": reprobes + 1})
                 suffix = t("blocked_recovery.reprobe_instruction")
@@ -223,7 +229,7 @@ def revalidate_blocked_tasks(anima_dir: Path, anima_name: str) -> list[str]:
             pending = manager.update_status(
                 entry.task_id,
                 "pending",
-                summary="auto-unblocked: check passed" if has_check else "auto-unblocked: scheduled reprobe",
+                summary=("auto-unblocked: check passed" if has_check else "auto-unblocked: scheduled reprobe"),
             )
             if pending is None:
                 continue
@@ -237,8 +243,11 @@ def revalidate_blocked_tasks(anima_dir: Path, anima_name: str) -> list[str]:
 
             ActivityLogger(anima_dir).log(
                 "blocked_recovery",
-                summary="Unblock check passed" if has_check else "Scheduled blocked task reprobe",
-                meta={"task_id": entry.task_id, "method": "check" if has_check else "reprobe"},
+                summary=("Unblock check passed" if has_check else "Scheduled blocked task reprobe"),
+                meta={
+                    "task_id": entry.task_id,
+                    "method": "check" if has_check else "reprobe",
+                },
                 safe=True,
             )
         except Exception:

--- a/core/config/schemas.py
+++ b/core/config/schemas.py
@@ -784,6 +784,9 @@ class BackgroundTaskConfig(BaseModel):
     blocked_recovery_scan_minutes: float = Field(default=15.0, ge=1)
     blocked_max_reprobes: int = Field(default=4, ge=0)
     blocked_check_timeout_seconds: int = Field(default=60, ge=1)
+    # False (default) = fail closed: checkless blocked tasks are never auto-reprobed.
+    # True restores the pre-fail-closed time-based pending requeue behavior.
+    blocked_checkless_reprobe_enabled: bool = False
 
 
 def resolve_background_worker_pool_size(

--- a/core/i18n/strings/supervisor.py
+++ b/core/i18n/strings/supervisor.py
@@ -162,6 +162,23 @@ STRINGS: dict[str, dict[str, str]] = {
             "가능하면 unblock_check를 함께 제시하세요."
         ),
     },
+    "blocked_recovery.manual_intervention_instruction": {
+        "ja": (
+            "タスク {task_id}（{anima_name}）は unblock_check を持たないため自動再開されない。"
+            "人手で確認し、完了なら done/cancelled に、継続なら unblock_check を付けて "
+            "blocked を宣言し直すこと。\n\n{original_instruction}"
+        ),
+        "en": (
+            "Task {task_id} ({anima_name}) has no unblock_check, so it will not resume automatically. "
+            "Check it by hand: move it to done/cancelled if finished, or re-declare blocked with an "
+            "unblock_check attached if it continues.\n\n{original_instruction}"
+        ),
+        "ko": (
+            "작업 {task_id}({anima_name})은 unblock_check가 없어 자동으로 재개되지 않습니다. "
+            "직접 확인하여 완료되었으면 done/cancelled로 옮기고, 계속한다면 unblock_check를 붙여 "
+            "blocked를 다시 선언하세요.\n\n{original_instruction}"
+        ),
+    },
     "pending_executor.descriptor_recovery_suffix": {
         "ja": "descriptor消失からの自動復旧。タスクの実態を確認して続行すること。",
         "en": "Automatic recovery from a lost descriptor. Verify the task's actual state before continuing.",

--- a/core/tooling/handler_skills.py
+++ b/core/tooling/handler_skills.py
@@ -662,10 +662,10 @@ class SkillsToolsMixin:
                 "blocked_at": now_iso(),
                 "unblock_check_failures": 0,
             }
-            # Omit when absent or null so an existing unblock_check is preserved:
-            # losing it would strand the task permanently now that checkless tasks
-            # are never auto-reprobed. An explicit empty string still clears it.
-            if unblock_check is not None:
+            # Preserve an omitted check only when re-declaring the same blocked
+            # state. A new blocker must not inherit a stale release condition.
+            current = manager.get_task_by_id(task_id)
+            if unblock_check is not None or current is None or current.status != "blocked":
                 declaration_meta["unblock_check"] = unblock_check
 
         try:

--- a/core/tooling/handler_skills.py
+++ b/core/tooling/handler_skills.py
@@ -660,9 +660,13 @@ class SkillsToolsMixin:
         elif status == "blocked":
             declaration_meta = {
                 "blocked_at": now_iso(),
-                "unblock_check": unblock_check,
                 "unblock_check_failures": 0,
             }
+            # Omit when absent or null so an existing unblock_check is preserved:
+            # losing it would strand the task permanently now that checkless tasks
+            # are never auto-reprobed. An explicit empty string still clears it.
+            if unblock_check is not None:
+                declaration_meta["unblock_check"] = unblock_check
 
         try:
             if declaration_meta:

--- a/tests/unit/core/test_blocked_recovery.py
+++ b/tests/unit/core/test_blocked_recovery.py
@@ -23,6 +23,7 @@ def _config(**overrides):
         "blocked_reprobe_batch_limit": 3,
         "blocked_max_reprobes": 4,
         "blocked_check_timeout_seconds": 60,
+        "blocked_checkless_reprobe_enabled": False,
     }
     defaults.update(overrides)
     return SimpleNamespace(background_task=SimpleNamespace(**defaults))
@@ -284,7 +285,8 @@ def test_failed_check_stays_blocked_and_counts_failure(tmp_path: Path, failure: 
     assert not (anima_dir / "state" / "pending" / f"check-{failure}.json").exists()
 
 
-def test_checkless_task_reprobes_four_times_then_alerts_once(tmp_path: Path) -> None:
+def test_checkless_task_stays_blocked_and_alerts_once(tmp_path: Path) -> None:
+    """Fail closed: checkless tasks never auto-reprobe; alert once past threshold."""
     animas_dir = tmp_path / "animas"
     anima_dir = animas_dir / "worker"
     supervisor_dir = animas_dir / "boss"
@@ -301,41 +303,33 @@ def test_checkless_task_reprobes_four_times_then_alerts_once(tmp_path: Path) -> 
     )
 
     with patch("core.config.models.load_config", return_value=_config()):
-        for expected in range(1, 5):
-            assert revalidate_blocked_tasks(anima_dir, "worker") == ["no-check"]
-            current = manager.get_task_by_id("no-check")
-            assert current is not None
-            assert current.status == "pending"
-            assert current.meta["blocked_reprobe_count"] == expected
-            desc = json.loads((anima_dir / "state" / "pending" / "no-check.json").read_text(encoding="utf-8"))[
-                "description"
-            ]
-            assert "blockerが解消済みか確認" in desc
-
-            (anima_dir / "state" / "pending" / "no-check.json").unlink()
-            manager.update_status("no-check", "blocked")
-            manager.update_meta(
-                "no-check",
-                {"blocked_at": (now_local() - timedelta(hours=7)).isoformat()},
-            )
-
+        assert revalidate_blocked_tasks(anima_dir, "worker") == []
         assert revalidate_blocked_tasks(anima_dir, "worker") == []
         assert revalidate_blocked_tasks(anima_dir, "worker") == []
 
     current = manager.get_task_by_id("no-check")
     assert current is not None
     assert current.status == "blocked"
-    assert current.meta["blocked_recovery_alerted"] is True
+    assert current.meta.get("blocked_recovery_alerted") is True
+    assert "blocked_reprobe_count" not in current.meta
+    assert not (anima_dir / "state" / "pending" / "no-check.json").exists()
     alerts = [
         task
         for task in TaskQueueManager(supervisor_dir).list_tasks()
-        if task.meta.get("kind") == "blocked_task_reprobe_exhausted"
+        if task.meta.get("kind") == "blocked_task_manual_intervention_required"
     ]
     assert len(alerts) == 1
+    assert "unblock_check を持たない" in alerts[0].original_instruction
 
 
-def test_checkless_legacy_task_uses_updated_at(tmp_path: Path) -> None:
-    anima_dir = tmp_path / "animas" / "worker"
+def test_checkless_legacy_task_uses_updated_at_for_alert_only(tmp_path: Path) -> None:
+    """Legacy checkless (no blocked_at) falls back to updated_at; still fail closed."""
+    animas_dir = tmp_path / "animas"
+    anima_dir = animas_dir / "worker"
+    supervisor_dir = animas_dir / "boss"
+    supervisor_dir.mkdir(parents=True)
+    anima_dir.mkdir(parents=True)
+    (anima_dir / "status.json").write_text('{"supervisor": "boss"}', encoding="utf-8")
     manager = _blocked_task(
         anima_dir,
         task_id="legacy-blocked",
@@ -349,11 +343,78 @@ def test_checkless_legacy_task_uses_updated_at(tmp_path: Path) -> None:
         patch("core.config.models.load_config", return_value=_config()),
         patch("core.blocked_recovery.now_local", return_value=future),
     ):
-        assert revalidate_blocked_tasks(anima_dir, "worker") == ["legacy-blocked"]
+        assert revalidate_blocked_tasks(anima_dir, "worker") == []
 
     current = manager.get_task_by_id("legacy-blocked")
     assert current is not None
+    assert current.status == "blocked"
+    assert current.meta.get("blocked_recovery_alerted") is True
+    assert "blocked_reprobe_count" not in current.meta
+    assert not (anima_dir / "state" / "pending" / "legacy-blocked.json").exists()
+    alerts = [
+        task
+        for task in TaskQueueManager(supervisor_dir).list_tasks()
+        if task.meta.get("kind") == "blocked_task_manual_intervention_required"
+    ]
+    assert len(alerts) == 1
+
+
+def test_checkless_reprobe_enabled_restores_legacy_time_based_reprobe(
+    tmp_path: Path,
+) -> None:
+    """blocked_checkless_reprobe_enabled=True restores pre-fail-closed behavior."""
+    anima_dir = tmp_path / "animas" / "worker"
+    manager = _blocked_task(
+        anima_dir,
+        task_id="legacy-on",
+        meta={
+            "blocked_at": (now_local() - timedelta(hours=7)).isoformat(),
+            "task_desc": {"title": "finish", "description": "finish the task"},
+        },
+    )
+
+    with patch(
+        "core.config.models.load_config",
+        return_value=_config(blocked_checkless_reprobe_enabled=True),
+    ):
+        assert revalidate_blocked_tasks(anima_dir, "worker") == ["legacy-on"]
+
+    current = manager.get_task_by_id("legacy-on")
+    assert current is not None
+    assert current.status == "pending"
     assert current.meta["blocked_reprobe_count"] == 1
+    desc = json.loads((anima_dir / "state" / "pending" / "legacy-on.json").read_text(encoding="utf-8"))["description"]
+    assert "blockerが解消済みか確認" in desc
+
+
+def test_checkless_many_tasks_generate_zero_pending_json(tmp_path: Path) -> None:
+    """Many checkless blocked tasks must not produce any pending JSON under fail closed."""
+    anima_dir = tmp_path / "animas" / "worker"
+    for index in range(50):
+        _blocked_task(
+            anima_dir,
+            task_id=f"checkless-{index:02d}",
+            meta={
+                "blocked_at": (now_local() - timedelta(hours=24)).isoformat(),
+                "task_desc": {"title": f"finish-{index}"},
+            },
+        )
+
+    with patch("core.config.models.load_config", return_value=_config()):
+        assert revalidate_blocked_tasks(anima_dir, "worker") == []
+
+    pending_dir = anima_dir / "state" / "pending"
+    pending_files = list(pending_dir.glob("*.json")) if pending_dir.is_dir() else []
+    assert pending_files == []
+    manager = TaskQueueManager(anima_dir)
+    for index in range(50):
+        current = manager.get_task_by_id(f"checkless-{index:02d}")
+        assert current is not None
+        assert current.status == "blocked"
+
+
+def test_blocked_checkless_reprobe_enabled_default_is_false() -> None:
+    assert BackgroundTaskConfig().blocked_checkless_reprobe_enabled is False
 
 
 def test_recovery_can_be_disabled(tmp_path: Path) -> None:

--- a/tests/unit/test_task_tools.py
+++ b/tests/unit/test_task_tools.py
@@ -167,6 +167,24 @@ class TestTaskToolHandler:
         )
         assert repeated["meta"]["unblock_check"] == "test -w ."
 
+        handler.handle(
+            "update_task",
+            {
+                "task_id": task["task_id"],
+                "status": "in_progress",
+            },
+        )
+        new_blocker = json.loads(
+            handler.handle(
+                "update_task",
+                {
+                    "task_id": task["task_id"],
+                    "status": "blocked",
+                },
+            )
+        )
+        assert new_blocker["meta"]["unblock_check"] is None
+
     def test_handle_update_nonexistent(self, handler):
         result = handler.handle(
             "update_task",

--- a/tests/unit/test_task_tools.py
+++ b/tests/unit/test_task_tools.py
@@ -40,7 +40,9 @@ class TestTaskToolSchemas:
     def test_list_tasks_schema(self):
         task_tools = _task_tools()
         list_tasks = next(t for t in task_tools if t["name"] == "list_tasks")
-        assert "required" not in list_tasks["parameters"] or "status" not in list_tasks["parameters"].get("required", [])
+        assert "required" not in list_tasks["parameters"] or "status" not in list_tasks["parameters"].get(
+            "required", []
+        )
 
     def test_build_tool_list_includes_task_tools(self):
         tools = build_tool_list(include_task_tools=True)
@@ -68,13 +70,16 @@ class TestTaskToolHandler:
         return ToolHandler(anima_dir, memory)
 
     def test_handle_backlog_task(self, handler):
-        result = handler.handle("backlog_task", {
-            "source": "human",
-            "original_instruction": "Test instruction",
-            "assignee": "rin",
-            "summary": "Test summary",
-            "deadline": "1h",
-        })
+        result = handler.handle(
+            "backlog_task",
+            {
+                "source": "human",
+                "original_instruction": "Test instruction",
+                "assignee": "rin",
+                "summary": "Test summary",
+                "deadline": "1h",
+            },
+        )
         data = json.loads(result)
         assert data["source"] == "human"
         assert data["assignee"] == "rin"
@@ -82,103 +87,150 @@ class TestTaskToolHandler:
         assert "task_id" in data
 
     def test_handle_backlog_task_missing_instruction(self, handler):
-        result = handler.handle("backlog_task", {
-            "source": "human",
-            "assignee": "rin",
-            "summary": "s",
-            "deadline": "1h",
-        })
+        result = handler.handle(
+            "backlog_task",
+            {
+                "source": "human",
+                "assignee": "rin",
+                "summary": "s",
+                "deadline": "1h",
+            },
+        )
         data = json.loads(result)
         assert data["status"] == "error"
 
     def test_handle_update_task(self, handler):
         # First add a task
-        add_result = json.loads(handler.handle("backlog_task", {
-            "source": "human",
-            "original_instruction": "test",
-            "assignee": "rin",
-            "summary": "s",
-            "deadline": "1h",
-        }))
+        add_result = json.loads(
+            handler.handle(
+                "backlog_task",
+                {
+                    "source": "human",
+                    "original_instruction": "test",
+                    "assignee": "rin",
+                    "summary": "s",
+                    "deadline": "1h",
+                },
+            )
+        )
         task_id = add_result["task_id"]
 
         # Update it
-        result = handler.handle("update_task", {
-            "task_id": task_id,
-            "status": "in_progress",
-        })
+        result = handler.handle(
+            "update_task",
+            {
+                "task_id": task_id,
+                "status": "in_progress",
+            },
+        )
         data = json.loads(result)
         assert data["status"] == "in_progress"
 
     def test_handle_update_task_blocked_saves_unblock_check(self, handler):
-        task = json.loads(handler.handle("backlog_task", {
-            "source": "human",
-            "original_instruction": "test",
-            "assignee": "rin",
-            "summary": "s",
-            "deadline": "1h",
-        }))
+        task = json.loads(
+            handler.handle(
+                "backlog_task",
+                {
+                    "source": "human",
+                    "original_instruction": "test",
+                    "assignee": "rin",
+                    "summary": "s",
+                    "deadline": "1h",
+                },
+            )
+        )
 
-        result = json.loads(handler.handle("update_task", {
-            "task_id": task["task_id"],
-            "status": "blocked",
-            "unblock_check": "test -w .",
-        }))
+        result = json.loads(
+            handler.handle(
+                "update_task",
+                {
+                    "task_id": task["task_id"],
+                    "status": "blocked",
+                    "unblock_check": "test -w .",
+                },
+            )
+        )
 
         assert result["status"] == "blocked"
         assert result["meta"]["unblock_check"] == "test -w ."
         datetime.fromisoformat(result["meta"]["blocked_at"])
 
-        repeated = json.loads(handler.handle("update_task", {
-            "task_id": task["task_id"],
-            "status": "blocked",
-        }))
-        assert repeated["meta"]["unblock_check"] is None
+        # Omitting unblock_check must preserve the existing value (not null it out).
+        repeated = json.loads(
+            handler.handle(
+                "update_task",
+                {
+                    "task_id": task["task_id"],
+                    "status": "blocked",
+                },
+            )
+        )
+        assert repeated["meta"]["unblock_check"] == "test -w ."
 
     def test_handle_update_nonexistent(self, handler):
-        result = handler.handle("update_task", {
-            "task_id": "nonexistent",
-            "status": "done",
-        })
+        result = handler.handle(
+            "update_task",
+            {
+                "task_id": "nonexistent",
+                "status": "done",
+            },
+        )
         data = json.loads(result)
         assert data["status"] == "error"
 
     def test_handle_list_tasks(self, handler):
-        handler.handle("backlog_task", {
-            "source": "human",
-            "original_instruction": "t1",
-            "assignee": "a",
-            "summary": "s1",
-            "deadline": "1h",
-        })
-        handler.handle("backlog_task", {
-            "source": "anima",
-            "original_instruction": "t2",
-            "assignee": "b",
-            "summary": "s2",
-            "deadline": "2h",
-        })
+        handler.handle(
+            "backlog_task",
+            {
+                "source": "human",
+                "original_instruction": "t1",
+                "assignee": "a",
+                "summary": "s1",
+                "deadline": "1h",
+            },
+        )
+        handler.handle(
+            "backlog_task",
+            {
+                "source": "anima",
+                "original_instruction": "t2",
+                "assignee": "b",
+                "summary": "s2",
+                "deadline": "2h",
+            },
+        )
         result = json.loads(handler.handle("list_tasks", {}))
         assert len(result) == 2
 
     def test_handle_list_tasks_with_filter(self, handler):
-        add_result = json.loads(handler.handle("backlog_task", {
-            "source": "human",
-            "original_instruction": "t1",
-            "assignee": "a",
-            "summary": "s1",
-            "deadline": "1h",
-        }))
-        handler.handle("update_task", {
-            "task_id": add_result["task_id"],
-            "status": "done",
-        })
-        handler.handle("backlog_task", {
-            "source": "human",
-            "original_instruction": "t2",
-            "assignee": "b",
-            "summary": "s2",
-            "deadline": "2h",
-        })
+        add_result = json.loads(
+            handler.handle(
+                "backlog_task",
+                {
+                    "source": "human",
+                    "original_instruction": "t1",
+                    "assignee": "a",
+                    "summary": "s1",
+                    "deadline": "1h",
+                },
+            )
+        )
+        handler.handle(
+            "update_task",
+            {
+                "task_id": add_result["task_id"],
+                "status": "done",
+            },
+        )
+        handler.handle(
+            "backlog_task",
+            {
+                "source": "human",
+                "original_instruction": "t2",
+                "assignee": "b",
+                "summary": "s2",
+                "deadline": "2h",
+            },
+        )
         result = json.loads(handler.handle("list_tasks", {"status": "pending"}))
         assert len(result) == 1


### PR DESCRIPTION
## 背景

`unblock_check` を持たない blocked タスクを経過時間だけで `pending` に戻す挙動（既定6h・最大4回）が、anima が終端宣言したタスクを掘り起こして再実行しようとしていた。

本番の checkless タスク6件（全て aoi）の中身は全部これ:

```
[PROD 16:00:23/16/8] BLOCKED終端済。E=16/X=8/O=0..8/M=16..24。...
[terminal=BLOCKED] STG 17:30:01/6/0 row 4e6efdda. ...
```

過去には59件が一斉に再投入され、重複オーナー・重複外部送信・本番系の二重実行の危険を生んだ。

## 変更

- checkless は `pending` に戻さない。閾値超過時に介入アラートを **1回だけ** 出す（`blocked_task_manual_intervention_required`、`blocked_recovery_alerted` で重複防止）
- `background_task.blocked_checkless_reprobe_enabled`（既定 `false`）。`true` で旧挙動に戻る — **デプロイ不要のロールバック経路**
- `update_task(status="blocked")` で `unblock_check` が未指定/null のとき既存値を保持。fail closed 下ではこれが唯一の永久停止経路になるため必須の同時修正（明示的な空文字列でのクリアは維持）

**check 付きタスクの挙動は一切変更していない**（exit 0 → pending、非0/bwrap不在 → blocked 維持）。

## 意図的に入れなかったもの

issue が要求していた terminal/superseded/external-send/production-mutation/second-writer のスコープ判定。これを機械判定できる meta フィールドは実在せず（実測した meta キーに risk/scope 系ゼロ）、free-text ヒューリスティックは誤判定が大きい。fail closed にすれば全 checkless が止まるので要件自体が不要になる。

## 検証

- `pytest tests/unit/core/test_blocked_recovery.py tests/unit/test_task_tools.py -q` → **29 passed**
- ruff check / format --check クリーン
- カバー: checkless が blocked 維持かつ pending JSON 生成0 / アラート1回のみ / 50件でも生成0 / opt-in で旧挙動復帰 / 既定値 false / check 付きの既存挙動

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)