### PR TITLE
fix(cron): STARTログをロック取得後へ移動＋コンフリクトマーカー検査を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[test,all-tools]"
 
+      - name: Check for merge-conflict markers
+        run: python scripts/check_conflict_markers.py
+
       - name: Lint
         run: |
           ruff check core/ cli/ server/

--- a/core/_anima_lifecycle.py
+++ b/core/_anima_lifecycle.py
@@ -198,9 +198,12 @@ class LifecycleMixin:
         cascade_suppressed_senders: set[str] | None = None,
     ) -> CycleResult:
         self._get_interrupt_event("_background").clear()
-        logger.info("[%s] run_heartbeat START", self.name)
+        # START is logged only after the background lock is held: "START" must mean
+        # "running", not "queued behind another background lane".
+        logger.info("[%s] run_heartbeat WAITING_LOCK", self.name)
         try:
             async with self._background_lock:
+                logger.info("[%s] run_heartbeat START", self.name)
                 self._mark_busy_start()
                 _keepalive = asyncio.create_task(self._keepalive_while_busy())
                 self._status_slots["background"] = "checking"
@@ -825,11 +828,12 @@ class LifecycleMixin:
             skills: Optional cron skill references from cron.md.
         """
         self._get_interrupt_event("_background").clear()
-        logger.info("[%s] run_cron_task START task=%s", self.name, task_name)
+        logger.info("[%s] run_cron_task WAITING_LOCK task=%s", self.name, task_name)
         from core.tooling.handler import active_session_type
 
         try:
             async with self._background_lock:
+                logger.info("[%s] run_cron_task START task=%s", self.name, task_name)
                 self._mark_busy_start()
                 _keepalive = asyncio.create_task(self._keepalive_while_busy())
                 self._cron_idle.clear()
@@ -1003,7 +1007,7 @@ class LifecycleMixin:
         Returns:
             Dictionary with execution results (exit_code, stdout, stderr, duration_ms)
         """
-        logger.info("[%s] run_cron_command START task=%s", self.name, task_name)
+        logger.info("[%s] run_cron_command WAITING_LOCK task=%s", self.name, task_name)
         start_ms = time.time_ns() // 1_000_000
 
         stdout = ""
@@ -1014,6 +1018,7 @@ class LifecycleMixin:
 
         try:
             async with self._background_lock:
+                logger.info("[%s] run_cron_command START task=%s", self.name, task_name)
                 self._mark_busy_start()
                 self._cron_idle.clear()
                 self._status_slots["background"] = "working"

--- a/scripts/check_conflict_markers.py
+++ b/scripts/check_conflict_markers.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Fail if unresolved merge-conflict markers are present in runtime source.
+
+The live runtime imports core/ cli/ server/ directly from the checkout, so a
+conflict marker left in any of them makes every newly spawned task runner exit
+with SyntaxError while the resident processes keep running (issue #279).
+
+Used by CI and by the pre-commit hook (scripts/hooks/pre-commit).
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOTS = ("core", "cli", "server")
+MARKER_RE = re.compile(rb"^(<{7}|={7}|>{7})(?: |$)", re.MULTILINE)
+
+
+def main() -> int:
+    hits: list[str] = []
+    for root in ROOTS:
+        for path in Path(root).rglob("*.py"):
+            match = MARKER_RE.search(path.read_bytes())
+            if match:
+                line = path.read_bytes()[: match.start()].count(b"\n") + 1
+                hits.append(f"{path}:{line}: {match.group(1).decode()}")
+    for hit in hits:
+        print(f"conflict marker: {hit}", file=sys.stderr)
+    if hits:
+        print(f"\n{len(hits)} file(s) contain unresolved merge-conflict markers.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Block commits that carry unresolved merge-conflict markers into runtime source.
+# Install once per checkout: git config core.hooksPath scripts/hooks
+exec python3 scripts/check_conflict_markers.py


### PR DESCRIPTION
挙動を変えない範囲だけを入れる。停止経路を新たに作らないことを最優先の制約とした。

## #245 — STARTログの位置

`run_cron_command:1006` / `run_cron_task:828` / `run_heartbeat:201` の START ログが `_background_lock` の取得**前**に出ており、「STARTしたのに END が来ない」を実行中ハングと誤診させていた。取得前を `WAITING_LOCK`、取得後を `START` に分ける。

**タイムアウトも専用レーンも入れていない。** 理由:

- 飢餓の主機序は既に消えている。`process_model` の既定は `phase3`（`core/config/schemas.py:95-100`）で本番14体すべて未指定＝phase3。隔離 cron は子プロセスで走るため親の `_background_lock` を取らない（`scheduler_manager.py:990-1007`）
- issue の実測では飢餓した cron は3.7時間後に **exit 0 で完遂している**。タイムアウトは「遅れて完遂」を「永久に未実行」に変え、失敗が `cron_guard.max_consecutive_failures` に積まれる
- 専用レーンは `_status_slots["background"]` 単一writer・`_cron_idle` の inbox 排他（`_anima_inbox.py:469-473`）・`is_busy` 集約・shutdown drain（`process_handle.py:489-567`）を破壊する

## #279 — コンフリクトマーカー検査

ライブランタイムは `core/ cli/ server/` を作業ツリーから直接 import する（editable install の MAPPING）。phase3 で全レーンが `python -m core.supervisor.task_runner` で spawn されるため、マーカーが1本残ると新規子プロセスが全レーンで SyntaxError 終了し、常駐 root だけが生き残る。予防策は現状ゼロだった（hook無し・`.gitattributes`無し・CI検査無し）。

- `scripts/check_conflict_markers.py` — 約0.04秒
- `scripts/hooks/pre-commit` — `git config core.hooksPath scripts/hooks` で有効化
- CI の Lint 直前に検査ステップ

**ランタイムには一切触れていない。** spawn 前ゲートは誤検知でフリート全停止を招き、防ごうとした事故を自分で起こすため採用しない。

### 既知の限界

pre-commit と CI は「マーカーをコミットする / PR に載せる」経路を塞ぐが、**未解決マージのまま作業ツリーに残っている窓**（今回の事故で実際にレーンが死んでいた 01:40〜06:44）は塞がない。そこを埋めるには「止めずに検知してアラートするだけ」の常駐チェックが要るが、本PRのスコープ外とした。

## 検証

- クリーン時 exit 0 / マーカー入りファイルで該当行を指して exit 1（プローブは削除済み）
- `ast.parse` で `core/_anima_lifecycle.py` の構文確認
- 変更したログ文字列に依存するテスト・スクリプト・ドキュメントが無いことを確認

Refs #245, #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)