### PR TITLE
style: ruff auto-fix leftovers (pr5-fault-e2e)

### DIFF
--- a/core/supervisor/pending_executor.py
+++ b/core/supervisor/pending_executor.py
@@ -2125,9 +2125,7 @@ class PendingTaskExecutor:
                 task_id,
                 exc,
             )
-            raise RuntimeError(
-                "INTERRUPTED: background task runner child exited without a result."
-            ) from exc
+            raise RuntimeError("INTERRUPTED: background task runner child exited without a result.") from exc
 
     async def _execute_llm_task(
         self,
@@ -2168,9 +2166,7 @@ class PendingTaskExecutor:
                     keepalive_task = asyncio.ensure_future(keepalive_result)
             self._anima._status_slots["background"] = "task_exec"
             self._anima._task_slots["background"] = task_id
-            if pool_capable or (
-                self._task_isolated and self._task_runner_supervisor is not None
-            ):
+            if pool_capable or (self._task_isolated and self._task_runner_supervisor is not None):
                 # Worker lease also gates concurrent isolated children (pool size).
                 result = await self._run_task_in_worker(
                     task_desc,

--- a/core/supervisor/runner.py
+++ b/core/supervisor/runner.py
@@ -889,11 +889,7 @@ class AnimaRunner:
         consolidation_type = params.get("consolidation_type", "daily")
 
         # background lane isolation: run consolidation inside a task-runner child.
-        supervisor = (
-            self._scheduler_mgr._task_runner_supervisor
-            if self._scheduler_mgr is not None
-            else None
-        )
+        supervisor = self._scheduler_mgr._task_runner_supervisor if self._scheduler_mgr is not None else None
         background_isolated = bool(
             self._scheduler_mgr is not None and getattr(self._scheduler_mgr, "_background_isolated", False)
         )


### PR DESCRIPTION
マージ後にCI autofixが積んだruff整形コミットの取り込み（整形のみ）。#285の作り直し。

🤖 Generated with [Claude Code](https://claude.com/claude-code)