### PR TITLE
feat(voice): RTC loopback AEC enables voice barge-in in VAD mode

### DIFF
--- a/server/static/modules/voice-playback.js
+++ b/server/static/modules/voice-playback.js
@@ -1,6 +1,10 @@
 /**
  * Audio playback queue for voice chat TTS output.
  * Decodes received audio chunks and plays them sequentially.
+ *
+ * Once RTC loopback AEC is up, output goes
+ * gain → MediaStreamDestination → RTCPeerConnection pair → <audio srcObject>,
+ * so Chrome-family AEC can use TTS as the echo reference.
  */
 export class VoicePlayback {
   constructor() {
@@ -13,10 +17,18 @@ export class VoicePlayback {
     this._onPlaybackStart = null;
     this._onPlaybackEnd = null;
     this._onCaption = null;
+    this._aecActive = false;
+    this._aecFailed = false;
+    this._aecStarting = false;
+    this._msDest = null;
+    this._pc1 = null;
+    this._pc2 = null;
+    this._aecAudio = null;
   }
 
   _ensureContext() {
     if (this._ctx && this._ctx.state === 'closed') {
+      this._teardownAec();
       this._ctx = null;
       this._gainNode = null;
     }
@@ -25,10 +37,106 @@ export class VoicePlayback {
       this._gainNode = this._ctx.createGain();
       this._gainNode.gain.value = this._volume;
       this._gainNode.connect(this._ctx.destination);
+      this._startAecLoopback();
     }
     if (this._ctx.state === 'suspended') {
       this._ctx.resume();
     }
+  }
+
+  get aecActive() {
+    return this._aecActive;
+  }
+
+  async _startAecLoopback() {
+    if (this._aecFailed || this._aecActive || this._aecStarting) return;
+    this._aecStarting = true;
+    const ctx = this._ctx;
+    const res = { pc1: null, pc2: null, msDest: null, audio: null };
+    try {
+      res.msDest = ctx.createMediaStreamDestination();
+      res.pc1 = new RTCPeerConnection();
+      res.pc2 = new RTCPeerConnection();
+      res.pc1.onicecandidate = (e) => {
+        if (e.candidate) res.pc2.addIceCandidate(e.candidate).catch(() => {});
+      };
+      res.pc2.onicecandidate = (e) => {
+        if (e.candidate) res.pc1.addIceCandidate(e.candidate).catch(() => {});
+      };
+
+      const gotTrack = new Promise((resolve, reject) => {
+        const t = setTimeout(() => reject(new Error('ontrack timeout')), 5000);
+        res.pc2.ontrack = (e) => {
+          clearTimeout(t);
+          resolve(e.streams[0] || new MediaStream([e.track]));
+        };
+      });
+
+      for (const track of res.msDest.stream.getAudioTracks()) {
+        res.pc1.addTrack(track, res.msDest.stream);
+      }
+
+      const offer = await res.pc1.createOffer();
+      await res.pc1.setLocalDescription(offer);
+      await _waitIce(res.pc1);
+      if (this._ctx !== ctx) throw new Error('aborted');
+      await res.pc2.setRemoteDescription(res.pc1.localDescription);
+      const answer = await res.pc2.createAnswer();
+      await res.pc2.setLocalDescription(answer);
+      await _waitIce(res.pc2);
+      if (this._ctx !== ctx) throw new Error('aborted');
+      await res.pc1.setRemoteDescription(res.pc2.localDescription);
+
+      const remote = await gotTrack;
+      if (this._ctx !== ctx || !this._gainNode) throw new Error('aborted');
+
+      res.audio = document.createElement('audio');
+      res.audio.style.display = 'none';
+      res.audio.autoplay = true;
+      res.audio.srcObject = remote;
+      document.body.appendChild(res.audio);
+      await res.audio.play();
+
+      if (this._ctx !== ctx || !this._gainNode) throw new Error('aborted');
+
+      // Switch off the direct destination so we never double-play.
+      this._gainNode.disconnect();
+      this._gainNode.connect(res.msDest);
+      this._msDest = res.msDest;
+      this._pc1 = res.pc1;
+      this._pc2 = res.pc2;
+      this._aecAudio = res.audio;
+      this._aecActive = true;
+    } catch (err) {
+      _disposeAecResources(res);
+      if (this._ctx !== ctx) return;
+      this._aecFailed = true;
+      console.warn('[VoicePlayback] AEC loopback failed, falling back to direct output:', err);
+      if (this._gainNode && !this._aecActive) {
+        try {
+          this._gainNode.disconnect();
+          this._gainNode.connect(this._ctx.destination);
+        } catch (_) {
+          // Already wired to destination, or context gone.
+        }
+      }
+    } finally {
+      this._aecStarting = false;
+    }
+  }
+
+  _teardownAec() {
+    this._aecActive = false;
+    _disposeAecResources({
+      pc1: this._pc1,
+      pc2: this._pc2,
+      audio: this._aecAudio,
+      msDest: this._msDest,
+    });
+    this._pc1 = null;
+    this._pc2 = null;
+    this._aecAudio = null;
+    this._msDest = null;
   }
 
   async enqueue(audioData, caption = null) {
@@ -110,9 +218,50 @@ export class VoicePlayback {
 
   destroy() {
     this.stop();
+    this._teardownAec();
     if (this._ctx) {
       this._ctx.close();
       this._ctx = null;
     }
+    this._gainNode = null;
+  }
+}
+
+function _waitIce(pc) {
+  if (pc.iceGatheringState === 'complete') return Promise.resolve();
+  return new Promise((resolve) => {
+    const done = () => {
+      pc.removeEventListener('icegatheringstatechange', onChange);
+      resolve();
+    };
+    const t = setTimeout(done, 2000);
+    const onChange = () => {
+      if (pc.iceGatheringState === 'complete') {
+        clearTimeout(t);
+        done();
+      }
+    };
+    pc.addEventListener('icegatheringstatechange', onChange);
+  });
+}
+
+function _disposeAecResources(res) {
+  if (!res) return;
+  if (res.pc1) {
+    try { res.pc1.close(); } catch (_) { /* already closed */ }
+  }
+  if (res.pc2) {
+    try { res.pc2.close(); } catch (_) { /* already closed */ }
+  }
+  if (res.audio) {
+    try {
+      res.audio.pause();
+      res.audio.srcObject = null;
+      res.audio.remove();
+    } catch (_) { /* already removed */ }
+  }
+  if (res.msDest) {
+    try { res.msDest.disconnect(); } catch (_) { /* already disconnected */ }
+    try { res.msDest.stream.getTracks().forEach((t) => t.stop()); } catch (_) { /* no tracks */ }
   }
 }

--- a/server/static/modules/voice-vad.js
+++ b/server/static/modules/voice-vad.js
@@ -38,6 +38,8 @@ export class VoiceVAD {
   constructor(options = {}) {
     this._onSpeechStart = options.onSpeechStart || (() => {});
     this._onSpeechEnd = options.onSpeechEnd || (() => {});
+    this._positiveSpeechThreshold = options.positiveSpeechThreshold;
+    this._minSpeechFrames = options.minSpeechFrames;
     this._myvad = null;
     this._active = false;
   }
@@ -57,7 +59,7 @@ export class VoiceVAD {
     }
 
     try {
-      this._myvad = await window.vad.MicVAD.new({
+      const vadOpts = {
         onnxWASMBasePath: _ORT_CDN,
         baseAssetPath: _VAD_CDN,
         onSpeechStart: () => {
@@ -66,7 +68,14 @@ export class VoiceVAD {
         onSpeechEnd: (audio) => {
           if (this._active) this._onSpeechEnd(audio);
         },
-      });
+      };
+      if (this._positiveSpeechThreshold != null) {
+        vadOpts.positiveSpeechThreshold = this._positiveSpeechThreshold;
+      }
+      if (this._minSpeechFrames != null) {
+        vadOpts.minSpeechFrames = this._minSpeechFrames;
+      }
+      this._myvad = await window.vad.MicVAD.new(vadOpts);
       this._myvad.start();
       this._active = true;
       return true;

--- a/server/static/modules/voice.js
+++ b/server/static/modules/voice.js
@@ -268,11 +268,14 @@ export class VoiceManager {
       return;
     }
     this._vad = new VoiceVAD({
-      // Half-duplex: the VAD hears the anima's own TTS from the speakers and
-      // would barge-in on it (AEC doesn't cover WebAudio output). Ignore
-      // speech while TTS audio is playing/queued plus a short echo tail.
-      // ponytail: voice barge-in disabled in vad mode; switch to PTT to interrupt.
+      // RTC loopback AEC lets VAD hear the user during TTS. Without it,
+      // ignore speech while output is playing/queued plus a short echo tail.
       onSpeechStart: () => {
+        if (this._playback.aecActive) {
+          if (this._outputActive()) this.interrupt();
+          this.startRecording();
+          return;
+        }
         if (this._outputActive()) return;
         this.startRecording();
       },


### PR DESCRIPTION
## Summary
- TTS再生経路を RTCPeerConnection ローカルループバック→\`<audio srcObject>\` に切替え、ブラウザAECがanimaのTTSをエコー参照に含められるようにする
- AEC有効時はVADモードでも再生中の発話でバージイン（interrupt→録音開始）
- ループバック構築失敗時はサイレントに従来経路（half-duplex＋タップ割り込み）へフォールバック
- VoiceVADに positiveSpeechThreshold / minSpeechFrames のチューニングノブを追加（デフォルト不変）

計画書: docs/plans/20260818_voice-aec-loopback-bargein.md（grok-4.6実装・PdMレビュー済み）

## Test plan
- node --check 3ファイル通過
- 実機E2E: ポップアップでmeiと会話→再生中に発話して割り込み確認（要ブラウザ・デプロイ後taka確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)