### PR TITLE
fix(pr-pipeline): persistent conflict reminders and full-text comment dispatch

### DIFF
--- a/core/i18n/strings/server.py
+++ b/core/i18n/strings/server.py
@@ -255,19 +255,33 @@ STRINGS: dict[str, dict[str, str]] = {
     },
     "github_gateway.minutes": {"ja": "{value}分", "en": "{value} minutes"},
     "github_gateway.seconds": {"ja": "{value}秒", "en": "{value} seconds"},
+    "github_gateway.conflict": {
+        "ja": (
+            "【要対応・マージコンフリクト継続検知】\n\n"
+            "- PR: {repo}#{number}\n- HEAD: {sha}\n- URL: {url}\n\n"
+            "baseブランチとのコンフリクトが残っています。重複通知でも無視せず、"
+            "natsumeのcanonical laneが実際に解消pushを完了するまで追跡してください。"
+        ),
+        "en": (
+            "[ACTION REQUIRED: merge conflict still present]\n\n"
+            "- PR: {repo}#{number}\n- HEAD: {sha}\n- URL: {url}\n\n"
+            "The base-branch conflict remains. Even if this notification repeats, track the canonical "
+            "natsume lane until the conflict-resolution push is actually complete."
+        ),
+    },
     "github_gateway.unknown_verdict": {"ja": "判定不明", "en": "Unknown verdict"},
     "github_gateway.frc_result": {
         "ja": (
             "【FRC結果検知】\n\n"
             "- 判定: {verdict}\n- PR: {repo}#{number}\n- HEAD: {head_sha}\n"
-            "- URL: {url}\n- 本文冒頭: {summary}\n\n"
+            "- URL: {url}\n- 本文全文:\n{summary}\n\n"
             "HOLDの場合は procedures/pr-event-detection-patrol.md に従って"
             "natsumeへの修正ディスパッチを実施してください。"
         ),
         "en": (
             "[FRC result detected]\n\n"
             "- Verdict: {verdict}\n- PR: {repo}#{number}\n- HEAD: {head_sha}\n"
-            "- URL: {url}\n- Body excerpt: {summary}\n\n"
+            "- URL: {url}\n- Full body:\n{summary}\n\n"
             "For HOLD, follow procedures/pr-event-detection-patrol.md and dispatch the fix to natsume."
         ),
     },

--- a/scripts/pr-review-dispatch.py
+++ b/scripts/pr-review-dispatch.py
@@ -1230,10 +1230,11 @@ def check_ci(state: dict) -> None:
 
 
 def check_conflicts(state: dict) -> None:
-    """Dispatch merge conflicts once per PR head; renotify after re-conflict."""
+    """Dispatch once per head and loudly remind Rin on every conflicting scan."""
     notified = state.setdefault("conflict_notified", {})
     open_keys: set[str] = set()
     dispatched = 0
+    conflict_lines: list[str] = []
     for repo in REPOS:
         prs = json.loads(
             gh(
@@ -1265,10 +1266,11 @@ def check_conflicts(state: dict) -> None:
                 # UNKNOWN はGitHub側の算出待ち。次回巡回で確定値を見る。
                 continue
             sha = pr["headRefOid"][:8]
+            url = str(pr.get("url") or f"https://github.com/{repo}/pull/{pr['number']}")
+            conflict_lines.append(f"- {key} {sha}: {url}")
             if notified.get(key) == sha:
                 continue
             notified[key] = sha
-            url = str(pr.get("url") or f"https://github.com/{repo}/pull/{pr['number']}")
             base_id = _conflict_task_id(repo, pr["number"], sha)
             attempts = int(state.get("failed_task_retries", {}).get(base_id, 0))
             dispatch_task(
@@ -1291,6 +1293,15 @@ def check_conflicts(state: dict) -> None:
     state["conflict_notified"] = {key: value for key, value in notified.items() if key in open_keys}
     if dispatched:
         log(f"conflict task dispatch -> {FIXER}: {dispatched} PR(s)")
+    if conflict_lines:
+        send(
+            DISPATCHER,
+            "【要対応・マージコンフリクト継続検知】\n\n"
+            + "\n".join(conflict_lines)
+            + "\n\n同じ通知が繰り返されても無視しないこと。"
+            f"{FIXER}のcanonical laneが解消pushを完了し、mergeable=MERGEABLEになるまで追跡せよ。",
+        )
+        log(f"conflict reminder -> {DISPATCHER}: {len(conflict_lines)} PR(s)")
 
 
 def check_human_waits(state: dict) -> None:

--- a/server/github_gateway.py
+++ b/server/github_gateway.py
@@ -209,6 +209,24 @@ class GitHubWebhookManager:
             await asyncio.to_thread(self._remove_pr_state, key)
             return
 
+        if pr.get("mergeable") is False or str(pr.get("mergeable_state") or "").lower() in {
+            "conflicting",
+            "dirty",
+        }:
+            await asyncio.to_thread(
+                self._send,
+                self._config.dispatcher_anima,
+                t(
+                    "github_gateway.conflict",
+                    repo=repo,
+                    number=number,
+                    sha=str((pr.get("head") or {}).get("sha") or ""),
+                    url=str(pr.get("html_url") or f"https://github.com/{repo}/pull/{number}"),
+                ),
+                "conflict",
+                f"conflict:{key}",
+            )
+
         if action not in {"opened", "synchronize", "reopened", "ready_for_review"}:
             return
         if bool(pr.get("draft")) and action != "ready_for_review":
@@ -322,17 +340,6 @@ class GitHubWebhookManager:
             str(review.get("html_url") or ""),
             f"{emphasis}review {state}".strip(),
         )
-        if state == "CHANGES_REQUESTED":
-            await asyncio.to_thread(
-                self._dispatch_review_task_once,
-                repo,
-                number,
-                str(review_id),
-                author,
-                str(review.get("body") or ""),
-                str(review.get("html_url") or ""),
-                False,
-            )
 
     async def _handle_comment(self, event: str, repo: str, payload: dict[str, Any]) -> None:
         if payload.get("action") != "created":
@@ -397,13 +404,30 @@ class GitHubWebhookManager:
                 )
                 seen[dedupe_key] = _now_iso()
                 return
-            summary = body.replace("\n", " ")[:140]
+            dispatch_direct_task(
+                target=self._config.implementer_anima,
+                task_id=f"gh-comment-{dedupe_key.replace(':', '-')}",
+                summary=t("github_gateway.command_summary", repo=repo, number=number),
+                instruction=t(
+                    "github_gateway.command_task",
+                    repo=repo,
+                    number=number,
+                    body=body,
+                    url=url,
+                ),
+                meta={
+                    "repo": repo,
+                    "number": number,
+                    "url": url,
+                    "kind": kind,
+                    "author": author,
+                },
+            )
             content = (
                 "【外部レビューコメント検知】\n\n"
-                f"- [{kind}] {repo}#{number} {author}: {summary}\n  {url}\n\n"
-                "bot以外による新規コメントです。ACTION_REQUIRED判定と"
-                "natsumeへの修正ディスパッチを procedures/pr-event-detection-patrol.md "
-                "に従って実施してください。"
+                f"- [{kind}] {repo}#{number} {author}\n\n{body}\n\nURL: {url}\n\n"
+                "全文をnatsumeへ直接投入済みです。Rinも全文を独立判断し、"
+                "必要な追跡を procedures/pr-event-detection-patrol.md に従って実施してください。"
             )
             self._send(self._config.dispatcher_anima, content, "comment", dedupe_key)
             seen[dedupe_key] = _now_iso()
@@ -435,7 +459,6 @@ class GitHubWebhookManager:
                     verdict = "PASS"
                 else:
                     verdict = t("github_gateway.unknown_verdict")
-            summary = body.replace("\n", " ")[:200]
             content = t(
                 "github_gateway.frc_result",
                 verdict=verdict,
@@ -443,7 +466,7 @@ class GitHubWebhookManager:
                 number=number,
                 head_sha=head_sha,
                 url=url,
-                summary=summary,
+                summary=body,
             )
             self._send(self._config.dispatcher_anima, content, "frc-result", dedupe_key)
             seen[dedupe_key] = _now_iso()
@@ -476,7 +499,7 @@ class GitHubWebhookManager:
                     url=url or f"https://github.com/{repo}/pull/{number}",
                     author=author or "unknown",
                     bot_note=bot_note,
-                    body=body[:500],
+                    body=body,
                 ),
                 meta={
                     "repo": repo,

--- a/tests/unit/scripts/test_pr_review_dispatch_conflicts.py
+++ b/tests/unit/scripts/test_pr_review_dispatch_conflicts.py
@@ -37,6 +37,8 @@ def mod(tmp_path, monkeypatch):
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     module.REPOS = ["o/r"]
+    module.sent_messages = []
+    module.send = lambda target, content: module.sent_messages.append((target, content))
     return module
 
 
@@ -57,6 +59,17 @@ def test_conflicting_pr_notifies_once(mod):
     assert "procedures/pr-conflict-resolution.md" in sent[0]["instruction"]
     # 同一headのままの再巡回では再通知しない
     assert _run(mod, state, [_pr(1, "CONFLICTING")]) == []
+
+
+def test_conflicting_pr_reminds_rin_on_every_scan(mod):
+    state = mod.default_state()
+
+    _run(mod, state, [_pr(1, "CONFLICTING")])
+    _run(mod, state, [_pr(1, "CONFLICTING")])
+
+    assert len(mod.sent_messages) == 2
+    assert all(target == "rin" for target, _content in mod.sent_messages)
+    assert all("マージコンフリクト継続検知" in content for _target, content in mod.sent_messages)
 
 
 def test_new_head_still_conflicting_renotifies(mod):

--- a/tests/unit/server/test_github_gateway_unit.py
+++ b/tests/unit/server/test_github_gateway_unit.py
@@ -31,6 +31,8 @@ def _pr_payload(
     sha: str = SHA_1,
     draft: bool = False,
     title: str = "Webhook dispatch",
+    mergeable: bool | None = None,
+    mergeable_state: str = "unknown",
 ) -> dict[str, Any]:
     return {
         "action": action,
@@ -41,6 +43,9 @@ def _pr_payload(
             "draft": draft,
             "title": title,
             "head": {"sha": sha},
+            "mergeable": mergeable,
+            "mergeable_state": mergeable_state,
+            "html_url": f"https://github.test/pulls/{number}",
         },
     }
 
@@ -201,6 +206,17 @@ class TestConfigurationAndGating:
 
 
 class TestPullRequestDebounce:
+    async def test_conflict_notifies_rin_on_every_webhook_without_deduping(self, gateway) -> None:
+        manager, sends, _state_file = gateway
+        payload = _pr_payload(action="edited", mergeable=False, mergeable_state="dirty")
+
+        await manager.handle_event("pull_request", payload)
+        await manager.handle_event("pull_request", payload)
+
+        assert len(sends) == 2
+        assert all(item["to"] == "rin" and item["kind"] == "conflict" for item in sends)
+        assert all("マージコンフリクト継続検知" in item["content"] for item in sends)
+
     async def test_draft_is_ignored_until_ready_for_review(self, gateway) -> None:
         manager, _, state_file = gateway
         await manager.handle_event("pull_request", _pr_payload(draft=True))
@@ -311,11 +327,10 @@ class TestReviewAndCommentDispatch:
             "_send",
             lambda to, content, kind, key: sends.append({"to": to, "kind": kind}),
         )
+        monkeypatch.setattr(github_gateway, "dispatch_direct_task", MagicMock(return_value=True))
         await manager.start()
         try:
-            await manager.handle_event(
-                "issue_comment", _comment_payload(event="issue_comment", author=BOT_LOGIN)
-            )
+            await manager.handle_event("issue_comment", _comment_payload(event="issue_comment", author=BOT_LOGIN))
         finally:
             await manager.stop()
         assert len(sends) == 1
@@ -365,7 +380,12 @@ class TestReviewAndCommentDispatch:
         assert len(sends) == 1
         assert sends[0]["to"] == "rin"
         assert sends[0]["key"] == dedupe_key
-        assert "Please fix this edge case." in sends[0]["content"]
+        assert "Please fix this\nedge case." in sends[0]["content"]
+        task = github_gateway.dispatch_direct_task
+        task.assert_called_once()
+        assert task.call_args.kwargs["target"] == "natsume"
+        assert task.call_args.kwargs["task_id"] == f"gh-comment-{dedupe_key.replace(':', '-')}"
+        assert "Please fix this\nedge case." in task.call_args.kwargs["instruction"]
         state = json.loads(state_file.read_text(encoding="utf-8"))
         assert dedupe_key in state["seen_comments"]
 
@@ -388,9 +408,9 @@ class TestReviewAndCommentDispatch:
         assert f"{REPO}#17" in kwargs["instruction"]
         assert "force-push禁止" in kwargs["instruction"]
         state = json.loads(state_file.read_text(encoding="utf-8"))
-        assert f"{'review' if event == 'pull_request_review_comment' else 'issue'}-comment:101" in state[
-            "seen_comments"
-        ]
+        assert (
+            f"{'review' if event == 'pull_request_review_comment' else 'issue'}-comment:101" in state["seen_comments"]
+        )
 
     async def test_updated_comment_is_ignored(self, gateway) -> None:
         manager, sends, state_file = gateway
@@ -401,23 +421,26 @@ class TestReviewAndCommentDispatch:
         assert sends == []
         assert not state_file.exists()
 
-    async def test_review_is_deduped_and_changes_requested_is_emphasized(self, gateway) -> None:
+    @pytest.mark.parametrize("review_state", ["commented", "approved", "changes_requested"])
+    async def test_every_external_review_is_deduped_and_sent_in_full(self, gateway, review_state: str) -> None:
         manager, sends, state_file = gateway
-        payload = _review_payload()
+        body = "Start\n" + "x" * 800 + "\nRequired fix at the end."
+        payload = _review_payload(state=review_state, body=body)
         await manager.handle_event("pull_request_review", payload)
         await manager.handle_event("pull_request_review", payload)
         assert len(sends) == 1
         assert sends[0]["key"] == "review:202"
-        assert "【CHANGES_REQUESTED】" in sends[0]["content"]
+        assert "Required fix at the end." in sends[0]["content"]
+        if review_state == "changes_requested":
+            assert "【CHANGES_REQUESTED】" in sends[0]["content"]
         direct_task = github_gateway.dispatch_direct_task
         direct_task.assert_called_once()
         task = direct_task.call_args.kwargs
-        assert task["task_id"] == "gh-review-example-org-example-repo#17-202"
-        assert "レビュアーが人間の場合" in task["instruction"]
-        assert task["meta"]["bot_derived"] is False
+        assert task["task_id"] == "gh-comment-review-202"
+        assert body in task["instruction"]
         state = json.loads(state_file.read_text(encoding="utf-8"))
         assert "review:202" in state["seen_comments"]
-        assert "202" in state["review_tasks"]
+        assert "202" not in state["review_tasks"]
 
     async def test_non_submitted_review_is_ignored(self, gateway) -> None:
         manager, sends, state_file = gateway
@@ -428,9 +451,7 @@ class TestReviewAndCommentDispatch:
         assert sends == []
         assert not state_file.exists()
 
-    async def test_reviewer_login_comments_are_ignored(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    async def test_reviewer_login_comments_are_ignored(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         shared_dir = tmp_path / "shared"
         state_file = shared_dir / github_gateway.STATE_FILENAME
         manager = GitHubWebhookManager(
@@ -447,9 +468,7 @@ class TestReviewAndCommentDispatch:
         monkeypatch.setattr(
             manager,
             "_send",
-            lambda to, content, kind, key: sends.append(
-                {"to": to, "content": content, "kind": kind, "key": key}
-            ),
+            lambda to, content, kind, key: sends.append({"to": to, "content": content, "kind": kind, "key": key}),
         )
         await manager.start()
         try:
@@ -498,9 +517,7 @@ class TestReviewAndCommentDispatch:
         monkeypatch.setattr(
             manager,
             "_send",
-            lambda to, content, kind, key: sends.append(
-                {"to": to, "content": content, "kind": kind, "key": key}
-            ),
+            lambda to, content, kind, key: sends.append({"to": to, "content": content, "kind": kind, "key": key}),
         )
         await manager.start()
         try:
@@ -526,9 +543,7 @@ class TestReviewAndCommentDispatch:
         else:
             direct_task.assert_not_called()
 
-    async def test_empty_reviewer_login_preserves_legacy_bot_only_behavior(
-        self, gateway
-    ) -> None:
+    async def test_empty_reviewer_login_preserves_legacy_bot_only_behavior(self, gateway) -> None:
         """reviewer_login empty: only bot_login reviews take FRC path."""
         manager, sends, _state_file = gateway
         # Non-bot review with APPROVED must NOT become FRC just from state.
@@ -678,9 +693,7 @@ class TestSharedStateLocking:
                 )
             fields = args[args.index("--json") + 1]
             if fields == "number,title,headRefOid,isDraft":
-                return json.dumps(
-                    [{"number": 17, "title": "PR", "headRefOid": SHA_1, "isDraft": False}]
-                )
+                return json.dumps([{"number": 17, "title": "PR", "headRefOid": SHA_1, "isDraft": False}])
             return json.dumps(
                 [
                     {


### PR DESCRIPTION
## 概要
PR放置立ち消え構造（2026-08-11監査）への対処。

- webhook: PRがconflicting/dirtyになった時点でrinへ即通知
- pr-review-dispatch: コンフリクト継続中は毎スキャンでrinへリマインド（head SHAごと一度きり通知の立ち消え対策）
- 外部レビューコメントを全文でnatsumeへ直接タスク投入（従来は140字要約→rin経由のみ）
- FRC結果通知を本文全文化
- コメント経路と重複していたCHANGES_REQUESTEDディスパッチを削除

## テスト
`test_pr_review_dispatch_conflicts.py` / `test_github_gateway_unit.py` 更新・パス確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)