### PR TITLE
chore(tooling): raise foreground command timeout default 30s -> 120s

### DIFF
--- a/core/tooling/handler_files.py
+++ b/core/tooling/handler_files.py
@@ -106,6 +106,7 @@ def _build_fuzzy_cjk_latin_pattern(old: str) -> re.Pattern[str] | None:
 # ── Background command execution ──────────────────────────
 
 _BG_CMD_TIMEOUT_DEFAULT = 1800  # 30 minutes
+_FG_CMD_TIMEOUT_DEFAULT = 120
 _BG_CMD_OUTPUT_MAX_BYTES = 10 * 1024 * 1024  # 10 MB
 _PIPE_THREAD_JOIN_TIMEOUT = 5.0
 _PIPE_THREAD_REJOIN_TIMEOUT = 1.0
@@ -625,7 +626,7 @@ class FileToolsMixin:
                 ensure_ascii=False,
             )
 
-        timeout = args.get("timeout", 30)
+        timeout = args.get("timeout", _FG_CMD_TIMEOUT_DEFAULT)
 
         import platform as _platform
 

--- a/core/tooling/schemas/admin.py
+++ b/core/tooling/schemas/admin.py
@@ -90,7 +90,7 @@ CC_TOOLS: list[dict[str, Any]] = [
                 "command": {"type": "string", "description": "Shell command to run"},
                 "timeout": {
                     "type": "integer",
-                    "description": ("Timeout in seconds. Default: 30 (foreground), 1800 (background)."),
+                    "description": ("Timeout in seconds. Default: 120 (foreground), 1800 (background)."),
                 },
                 "background": {
                     "type": "boolean",


### PR DESCRIPTION
フォアグラウンドコマンドのデフォルトタイムアウトを30秒→120秒に引き上げ（スキーマ記述も同期）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)