### PR TITLE
chore(librarian): hide librarian from pixel workspace; add awlib MCP config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "awlib": {
+      "command": "/home/main/dev/animaworks/.venv/bin/animaworks",
+      "args": ["mcp", "--anima", "librarian"]
+    }
+  }
+}

--- a/server/static/workspace/pixel/modules/scene-layout.js
+++ b/server/static/workspace/pixel/modules/scene-layout.js
@@ -13,7 +13,7 @@ export function resolveBasePath() {
 
 function normalizedAnimas(animas) {
   return (Array.isArray(animas) ? animas : [])
-    .filter((entry) => entry?.name && !entry.is_human)
+    .filter((entry) => entry?.name && !entry.is_human && entry.name.toLowerCase() !== "librarian")
     .map((entry, index) => ({
       ...entry,
       id: String(entry.name).trim().toLowerCase(),


### PR DESCRIPTION
librarianは司書インフラでありフロアキャラではないためpixelワークスペースから非表示に。あわせてClaude Codeからlibrarianへアクセスするためのawlib MCPサーバー設定（.mcp.json）を追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)