### PR TITLE
fix: make durable TaskExec recovery and stream cleanup reliable

### DIFF
--- a/core/platform/processing_lease.py
+++ b/core/platform/processing_lease.py
@@ -141,8 +141,28 @@ def write_processing_lease(
 
 
 def _read_proc_cmdline(pid: int) -> str:
-    raw = (Path("/proc") / str(pid) / "cmdline").read_bytes()
-    return raw.replace(b"\0", b" ").decode(errors="replace")
+    """Read a process command line on Linux and non-/proc platforms.
+
+    ``/proc`` is the preferred source because it does not add a runtime
+    dependency to the lease fast path.  macOS has no procfs, however, and
+    treating every existing PID there as live defeats the PID-reuse fence and
+    can leave an interrupted TaskExec descriptor stuck forever.  psutil is an
+    existing optional dependency used by the stronger process-start-time
+    fence, so use it as the portable fallback.
+    """
+    proc_path = Path("/proc") / str(pid) / "cmdline"
+    if proc_path.exists():
+        raw = proc_path.read_bytes()
+        return raw.replace(b"\0", b" ").decode(errors="replace")
+
+    try:
+        import psutil
+    except ImportError as exc:
+        raise OSError("process command line is unavailable") from exc
+    try:
+        return " ".join(psutil.Process(pid).cmdline())
+    except Exception as exc:
+        raise OSError("process command line is unavailable") from exc
 
 
 def _is_positive_int(value: Any) -> bool:
@@ -237,9 +257,6 @@ def _classify_v1(payload: dict[str, Any]) -> LeaseLiveness:
     if exists is None:
         return "unknown"
 
-    proc_root = Path("/proc")
-    if not proc_root.is_dir():
-        return "live"
     try:
         cmdline = _read_proc_cmdline(pid)
     except OSError:
@@ -290,9 +307,6 @@ def _classify_v2(
             return "dead"
     # If create_time is unavailable, fall through to cmdline checks.
 
-    proc_root = Path("/proc")
-    if not proc_root.is_dir():
-        return "live"
     try:
         cmdline = _read_proc_cmdline(int(task_pid))
     except OSError:

--- a/core/supervisor/streaming_handler.py
+++ b/core/supervisor/streaming_handler.py
@@ -164,6 +164,7 @@ class StreamingIPCHandler:
             """Read Agent SDK stream and enqueue IPCResponse chunks."""
             nonlocal full_response
             cycle_done_seen = False
+            terminal_response: IPCResponse | None = None
             try:
                 # Emit bootstrap_start if anima needs bootstrap
                 if was_bootstrapping:
@@ -225,17 +226,15 @@ class StreamingIPCHandler:
                                 )
                             )
 
-                        await _enqueue(
-                            IPCResponse(
-                                id=request.id,
-                                stream=True,
-                                done=True,
-                                result={
-                                    "response": full_response,
-                                    "replied_to": [],
-                                    "cycle_result": cycle_result,
-                                },
-                            )
+                        terminal_response = IPCResponse(
+                            id=request.id,
+                            stream=True,
+                            done=True,
+                            result={
+                                "response": full_response,
+                                "replied_to": [],
+                                "cycle_result": cycle_result,
+                            },
                         )
                         # Do not return here.  ``run_cycle_streaming`` owns
                         # ContextVar reset tokens and must be resumed once more
@@ -246,7 +245,10 @@ class StreamingIPCHandler:
                         # raises "token was created in a different Context".
                         # Draining the generator is safe: cycle_done is the
                         # protocol's final event and no further item is emitted
-                        # to the client.
+                        # to the client.  Hold the terminal response until
+                        # exhaustion too, otherwise the consumer can break and
+                        # cancel this producer while an upstream async
+                        # ``finally`` is still awaiting.
                         continue
 
                     elif event_type == "bootstrap_busy":
@@ -283,7 +285,9 @@ class StreamingIPCHandler:
                             )
                         )
 
-                if not cycle_done_seen:
+                if cycle_done_seen and terminal_response is not None:
+                    await _enqueue(terminal_response)
+                else:
                     # Stream ended without cycle_done — done=False切断パス
                     self._clear_stream_abort_state("stream ended without cycle_done (done=False)", thread_id)
                     await _enqueue(

--- a/core/supervisor/streaming_handler.py
+++ b/core/supervisor/streaming_handler.py
@@ -163,6 +163,7 @@ class StreamingIPCHandler:
         async def _stream_producer() -> None:
             """Read Agent SDK stream and enqueue IPCResponse chunks."""
             nonlocal full_response
+            cycle_done_seen = False
             try:
                 # Emit bootstrap_start if anima needs bootstrap
                 if was_bootstrapping:
@@ -204,6 +205,7 @@ class StreamingIPCHandler:
                         )
 
                     elif event_type == "cycle_done":
+                        cycle_done_seen = True
                         cycle_result = chunk.get("cycle_result", {})
                         full_response = cycle_result.get(
                             "summary",
@@ -235,7 +237,17 @@ class StreamingIPCHandler:
                                 },
                             )
                         )
-                        return
+                        # Do not return here.  ``run_cycle_streaming`` owns
+                        # ContextVar reset tokens and must be resumed once more
+                        # so its async-generator ``finally`` blocks execute in
+                        # this producer task's Context.  Returning immediately
+                        # leaves Python to close the generator later from an
+                        # ``async_generator_athrow`` task, where reset(token)
+                        # raises "token was created in a different Context".
+                        # Draining the generator is safe: cycle_done is the
+                        # protocol's final event and no further item is emitted
+                        # to the client.
+                        continue
 
                     elif event_type == "bootstrap_busy":
                         # Anima is already bootstrapping — forward as-is
@@ -271,19 +283,20 @@ class StreamingIPCHandler:
                             )
                         )
 
-                # Stream ended without cycle_done — done=False切断パス
-                self._clear_stream_abort_state("stream ended without cycle_done (done=False)", thread_id)
-                await _enqueue(
-                    IPCResponse(
-                        id=request.id,
-                        stream=True,
-                        done=True,
-                        result={
-                            "response": full_response,
-                            "replied_to": [],
-                        },
+                if not cycle_done_seen:
+                    # Stream ended without cycle_done — done=False切断パス
+                    self._clear_stream_abort_state("stream ended without cycle_done (done=False)", thread_id)
+                    await _enqueue(
+                        IPCResponse(
+                            id=request.id,
+                            stream=True,
+                            done=True,
+                            result={
+                                "response": full_response,
+                                "replied_to": [],
+                            },
+                        )
                     )
-                )
 
             except TimeoutError as e:
                 logger.error("Timeout in streaming process_message: %s", e)

--- a/templates/en/prompts/behavior_rules.md
+++ b/templates/en/prompts/behavior_rules.md
@@ -51,6 +51,8 @@ In either case:
 
 #### Recording to Task Queue
 - Do not use `submit_tasks` in normal chat. Execute human instructions directly here, and when follow-up tracking is needed, record it with `update_task`, `state/current_state.md`, or an explicit background execution workflow
+- If a human gives explicit completion criteria for work that can outlive one conversation stream, register it with `backlog_task` before starting and immediately call `update_task(status="in_progress")`. A conversation ending or an interim report must not complete or remove it; keep it durable until the completion criteria are proven, the task is explicitly blocked, or the human cancels it
+- Restore such continuing tasks from the task queue in the next conversation or Heartbeat and continue the already-approved scope without waiting for another "continue" message. Set `done` only after verifying evidence for every completion criterion
 - Record delegation between Anima in the task queue and update relay_chain
 - When a task is complete, update status via `update_task`
 

--- a/templates/ja/prompts/behavior_rules.md
+++ b/templates/ja/prompts/behavior_rules.md
@@ -51,6 +51,8 @@ Default: do not narrate routine, low-risk tool calls
 
 #### タスク記録の扱い
 - 通常チャットでは `submit_tasks` を使わない。人間からの指示・依頼はその場で直接実行し、後続管理が必要な場合は `update_task`、`state/current_state.md`、または明示的なバックグラウンド実行ワークフローで記録する
+- 人間が明示した完了条件が1回の会話ストリームを越える作業は、着手前に `backlog_task` で登録し、即座に `update_task(status="in_progress")` とする。会話の終了や中間報告でタスクを完了・削除せず、完了条件の達成、明示的なブロック、または中止指示まで永続させる
+- 上記の継続タスクは、次の会話またはHeartbeatでタスクキューから復元し、新たな人間の「進めて」を待たずに承認済み範囲を継続する。`done` への更新は完了条件の証跡を確認した後のみ行う
 - Anima間の委任もタスクキューに記録し、relay_chainを更新せよ
 - タスク完了時は `update_task` でステータスを更新せよ
 

--- a/templates/ko/prompts/behavior_rules.md
+++ b/templates/ko/prompts/behavior_rules.md
@@ -51,6 +51,8 @@ Default: do not narrate routine, low-risk tool calls
 
 #### 작업 큐 기록
 - 일반 채팅에서는 `submit_tasks`를 사용하지 마세요. 사람의 지시와 요청은 이 자리에서 직접 실행하고, 후속 추적이 필요하면 `update_task`, `state/current_state.md`, 또는 명시적인 백그라운드 실행 워크플로로 기록하세요
+- 사람이 명시한 완료 조건이 한 번의 대화 스트림을 넘을 수 있는 작업은 시작 전 `backlog_task`로 등록하고 즉시 `update_task(status="in_progress")`를 호출하세요. 대화 종료나 중간 보고로 완료·삭제하지 말고, 완료 조건이 검증되거나 명시적으로 차단되거나 취소될 때까지 영속적으로 유지하세요
+- 이런 계속 작업은 다음 대화 또는 Heartbeat에서 작업 큐로부터 복원하고, 새로운 "계속해" 메시지를 기다리지 말고 이미 승인된 범위를 계속하세요. 모든 완료 조건의 증거를 확인한 후에만 `done`으로 설정하세요
 - Anima 간의 위임도 작업 큐에 기록하고 relay_chain을 업데이트하세요
 - 작업 완료 시 `update_task`로 상태를 업데이트하세요
 

--- a/tests/unit/test_ipc_streaming_resilience.py
+++ b/tests/unit/test_ipc_streaming_resilience.py
@@ -15,6 +15,7 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+import contextvars
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -144,6 +145,50 @@ class TestStreamingHandlerBaseException:
         assert len(error_responses) == 1
         assert error_responses[0].error["code"] == "FATAL_STREAM_ERROR"
         assert "KeyboardInterrupt" in error_responses[0].error["message"]
+
+    @pytest.mark.asyncio
+    async def test_cycle_done_drains_generator_in_its_context(self):
+        """The upstream generator finalizes in the producer Context."""
+        from core.supervisor.streaming_handler import StreamingIPCHandler
+
+        scoped = contextvars.ContextVar("stream_scope", default="outer")
+        finalized = asyncio.Event()
+        reset_error: list[BaseException] = []
+
+        async def mock_stream(*args, **kwargs):
+            token = scoped.set("inner")
+            try:
+                yield {
+                    "type": "cycle_done",
+                    "cycle_result": {"summary": "complete"},
+                }
+            finally:
+                try:
+                    scoped.reset(token)
+                except BaseException as exc:  # capture the historical failure
+                    reset_error.append(exc)
+                finalized.set()
+
+        anima = MagicMock()
+        anima.process_message_stream = mock_stream
+        anima.needs_bootstrap = False
+        handler = StreamingIPCHandler(anima=anima, anima_name="test-anima", anima_dir="/tmp/test")
+        request = IPCRequest(
+            id="req-context",
+            method="process_message",
+            params={"message": "test", "stream": True},
+        )
+
+        responses = []
+        with patch("core.config.load_config") as mock_config:
+            mock_config.return_value.server.keepalive_interval = 30
+            async for response in handler.handle_stream(request):
+                responses.append(response)
+
+        await asyncio.wait_for(finalized.wait(), timeout=1)
+        assert reset_error == []
+        assert sum(response.done for response in responses) == 1
+        assert responses[-1].result["response"] == "complete"
 
 
 # ── B1: ProcessSupervisor RESTARTING state ──────────

--- a/tests/unit/test_ipc_streaming_resilience.py
+++ b/tests/unit/test_ipc_streaming_resilience.py
@@ -163,6 +163,10 @@ class TestStreamingHandlerBaseException:
                 }
             finally:
                 try:
+                    # Model an async context-manager exit after cycle_done.
+                    # Publishing the terminal response early would let the
+                    # consumer cancel the producer during this suspension.
+                    await asyncio.sleep(0.01)
                     scoped.reset(token)
                 except BaseException as exc:  # capture the historical failure
                     reset_error.append(exc)

--- a/tests/unit/test_ipc_streaming_resilience.py
+++ b/tests/unit/test_ipc_streaming_resilience.py
@@ -25,7 +25,6 @@ from core.exceptions import AnimaNotRunningError, ProcessError
 from core.supervisor.ipc import IPCRequest
 from core.supervisor.process_handle import ProcessHandle, ProcessState
 
-
 # ── A2: StreamingIPCHandler BaseException safety valve ──────────
 
 

--- a/tests/unit/test_templates.py
+++ b/tests/unit/test_templates.py
@@ -51,6 +51,8 @@ class TestBehaviorRulesTemplate:
         path = TEMPLATES_DIR / "behavior_rules.md"
         content = path.read_text(encoding="utf-8")
         assert "通常チャットでは `submit_tasks` を使わない" in content
+        assert "`backlog_task` で登録" in content
+        assert "完了条件の達成" in content
         assert "解決済み案件の再報告禁止" in content
 
     def test_existing_sections_preserved(self):
@@ -73,6 +75,8 @@ class TestBehaviorRulesTemplate:
             content = (TEMPLATES_ROOT / locale / "prompts" / "behavior_rules.md").read_text(encoding="utf-8")
             for token in required:
                 assert token in content, f"{locale} behavior_rules missing {token}"
+            assert "backlog_task" in content
+            assert 'update_task(status="in_progress")' in content
             assert "must be registered with `submit_tasks`" not in content
             assert "必ず `submit_tasks` でタスクキューに登録" not in content
             assert "반드시 `submit_tasks`로 태스크 큐에 등록" not in content


### PR DESCRIPTION
## Summary
- keep cross-conversation completion criteria durable via the existing task/goal loop behavior rules
- finish streaming generators in their producer Context before publishing the terminal IPC response, preventing cross-Context token reset failures even when async cleanup suspends
- validate TaskExec processing leases on non-procfs platforms via psutil so reused PIDs do not suppress descriptor recovery

## Existing durable runner audit
The current `main` already contains the persistent `GoalManager`, goal completion judge, independent background TaskExec lane, completion-declaration enforcement, missing-descriptor regeneration, processing-lease recovery, and restart restoration paths. This PR fixes the remaining stream-finalization and macOS lease-liveness gaps rather than duplicating those mechanisms.

## Verification
- focused streaming/lease/TaskExec suite: 116 passed
- broader durable objective/TaskExec suite: 185 passed
- ruff: passed
- git diff --check: passed
- independent Codex review: initial P1 fixed; follow-up found no actionable correctness issue

## Deployment safety
No server restart or production mutation is included. Restart must remain a separate gated operation after active TaskExec/LEAP work is protected and drained.
