### PR TITLE
feat(dispatch): pr-N exclusive key for gh-* tasks + queue ack comment on PR (#303)

### DIFF
--- a/core/blocked_recovery.py
+++ b/core/blocked_recovery.py
@@ -59,6 +59,7 @@ def regenerate_pending_json(
         "submitted_at": now_iso(),
         "reply_to": task_desc_meta.get("reply_to", anima_name),
         "working_directory": task_desc_meta.get("working_directory", ""),
+        "exclusive_key": task_desc_meta.get("exclusive_key") or entry.meta.get("exclusive_key", ""),
         "model": model if isinstance(model, str) else "",
     }
     atomic_write_text(

--- a/core/i18n/strings/server.py
+++ b/core/i18n/strings/server.py
@@ -236,6 +236,10 @@ STRINGS: dict[str, dict[str, str]] = {
         "ja": "Gemini CLI 認証",
         "en": "Gemini CLI Auth",
     },
+    "github_gateway.queue_ack": {
+        "ja": "受領しました（task `{task_id}`）。同一PRの先行タスク `{holder_task_id}` の完了後に着手します。",
+        "en": "Received (task `{task_id}`). Will start after the preceding task `{holder_task_id}` on this PR completes.",
+    },
     "github_gateway.review_dispatch": {
         "ja": (
             "【PR新規コミット検出（push静穏確認済み）】\n\n"

--- a/core/tasks_dispatch.py
+++ b/core/tasks_dispatch.py
@@ -96,7 +96,9 @@ def _maybe_post_queue_ack(target_dir: Path, task_id: str, meta: dict) -> None:
     holder_task_id = _find_holder_task(manager, meta["exclusive_key"], task_id)
     if holder_task_id is None:
         return
-    body = f"受領しました（task `{task_id}`）。同一PRの先行タスク `{holder_task_id}` の完了後に着手します。"
+    from core.i18n import t
+
+    body = t("github_gateway.queue_ack", task_id=task_id, holder_task_id=holder_task_id)
     try:
         if _post_pr_comment(target_dir, repo, number, body):
             manager.update_meta(task_id, {"queue_ack_posted": True})

--- a/core/tasks_dispatch.py
+++ b/core/tasks_dispatch.py
@@ -17,6 +17,17 @@ from core.paths import get_animas_dir
 FAILING_CI_CONCLUSIONS = frozenset({"FAILURE", "CANCELLED", "TIMED_OUT", "STARTUP_FAILURE"})
 
 
+def pr_exclusive_key(meta: dict | None) -> str:
+    """Derive the ``pr-NNNN`` exclusion key so same-PR tasks run serially.
+
+    Matches the manual ``delegate_task`` convention (e.g. ``pr-3999``), so an
+    automated gh-ci/gh-review task and a hand-delegated task on the same PR
+    share one lock instead of racing on the same worktree.
+    """
+    number = (meta or {}).get("number")
+    return f"pr-{number}" if number else ""
+
+
 def dispatch_direct_task(
     *,
     target: str,
@@ -42,6 +53,9 @@ def dispatch_direct_task(
         raise ValueError(f"Anima directory not found: {target}")
 
     task_meta = {**(meta or {}), "origin": "github-event", "executor": "taskexec"}
+    exclusive_key = pr_exclusive_key(meta)
+    if exclusive_key:
+        task_meta["exclusive_key"] = exclusive_key
     if model:
         task_meta["model"] = model
     entry = TaskQueueManager(target_dir).add_task_if_absent(
@@ -71,7 +85,7 @@ def dispatch_direct_task(
         "reply_to": "",
         "source": "delegation",
         "working_directory": "",
-        "exclusive_key": "",
+        "exclusive_key": exclusive_key,
     }
     if model:
         task_desc["model"] = model

--- a/core/tasks_dispatch.py
+++ b/core/tasks_dispatch.py
@@ -7,12 +7,18 @@ from __future__ import annotations
 """Direct task dispatch for deterministic external events."""
 
 import json
+import logging
+import os
+import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
 
+from core.execution.github_identity import resolve_github_token_env
 from core.memory._io import atomic_write_text
 from core.memory.task_queue import TaskQueueManager
 from core.paths import get_animas_dir
+
+logger = logging.getLogger("animaworks.tasks_dispatch")
 
 FAILING_CI_CONCLUSIONS = frozenset({"FAILURE", "CANCELLED", "TIMED_OUT", "STARTUP_FAILURE"})
 
@@ -26,6 +32,76 @@ def pr_exclusive_key(meta: dict | None) -> str:
     """
     number = (meta or {}).get("number")
     return f"pr-{number}" if number else ""
+
+
+def _post_pr_comment(target_dir: Path, repo: str, number: str, body: str) -> bool:
+    """Post an issue/PR comment via ``gh api``. Returns True on success.
+
+    Never raises; callers rely on the boolean to decide whether to record
+    the queue ack.  Token resolution may return an empty dict, in which
+    case ``gh`` falls back to the host's default identity.
+    """
+    env = os.environ.copy()
+    env.update(resolve_github_token_env(target_dir))
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repo}/issues/{number}/comments", "-f", f"body={body}"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            env=env,
+        )
+    except Exception as exc:
+        logger.warning("gh api comment failed for %s#%s: %s", repo, number, exc)
+        return False
+    if result.returncode != 0:
+        logger.warning(
+            "gh api comment exited %s for %s#%s: %s",
+            result.returncode,
+            repo,
+            number,
+            (result.stderr or "").strip(),
+        )
+        return False
+    return True
+
+
+def _find_holder_task(manager: TaskQueueManager, exclusive_key: str, task_id: str) -> str | None:
+    """Return the oldest active task holding the same exclusive key (excluding *task_id*)."""
+    candidates = [
+        task
+        for task in manager.list_tasks()
+        if task.task_id != task_id
+        and task.status in ("pending", "in_progress", "blocked")
+        and (task.meta or {}).get("exclusive_key") == exclusive_key
+    ]
+    if not candidates:
+        return None
+    candidates.sort(key=lambda task: task.ts)
+    return candidates[0].task_id
+
+
+def _maybe_post_queue_ack(target_dir: Path, task_id: str, meta: dict) -> None:
+    """Best-effort PR ack so the requester sees the task was received."""
+    if not meta.get("exclusive_key"):
+        return
+    repo = meta.get("repo")
+    number = meta.get("number")
+    if not repo or not number:
+        return
+    if meta.get("queue_ack_posted"):
+        return
+    manager = TaskQueueManager(target_dir)
+    holder_task_id = _find_holder_task(manager, meta["exclusive_key"], task_id)
+    if holder_task_id is None:
+        return
+    body = f"受領しました（task `{task_id}`）。同一PRの先行タスク `{holder_task_id}` の完了後に着手します。"
+    try:
+        if _post_pr_comment(target_dir, repo, number, body):
+            manager.update_meta(task_id, {"queue_ack_posted": True})
+    except Exception as exc:
+        logger.warning("queue ack post failed for task %s: %s", task_id, exc)
 
 
 def dispatch_direct_task(
@@ -70,6 +146,8 @@ def dispatch_direct_task(
     )
     if entry is None:
         return False
+
+    _maybe_post_queue_ack(target_dir, task_id, task_meta)
 
     task_desc = {
         "task_type": "llm",

--- a/core/tooling/handler_delegation.py
+++ b/core/tooling/handler_delegation.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json as _json
 import logging
 import os
+import re
 import uuid
 from datetime import UTC, datetime
 from pathlib import Path
@@ -19,6 +20,15 @@ from core.i18n import t
 from core.memory._io import atomic_write_text
 from core.tooling.handler_base import _error_result, build_outgoing_origin_chain
 from core.tooling.org_helpers import OrgHelpersMixin
+
+_PR_REF = re.compile(r"(?:#|/pull/)(\d{2,7})\b")
+
+
+def _pr_key_from_text(text: str) -> str:
+    """Fallback ``pr-NNNN`` exclusion key from a PR reference in the task text."""
+    match = _PR_REF.search(text)
+    return f"pr-{match.group(1)}" if match else ""
+
 
 if TYPE_CHECKING:
     from core.memory.activity import ActivityLogger
@@ -160,7 +170,7 @@ class DelegationMixin(OrgHelpersMixin):
         instruction = args.get("instruction", "")
         summary = args.get("summary", "") or instruction[:100]
         deadline = args.get("deadline", "")
-        exclusive_key = args.get("exclusive_key", "")
+        exclusive_key = args.get("exclusive_key", "") or _pr_key_from_text(f"{summary}\n{instruction}")
         raw_criteria = args.get("acceptance_criteria")
         acceptance_criteria: list[str] = (
             [c for c in raw_criteria if isinstance(c, str)] if isinstance(raw_criteria, list) else []
@@ -245,7 +255,13 @@ class DelegationMixin(OrgHelpersMixin):
                 deadline=deadline,
                 relay_chain=[self._anima_name],
                 task_id=sub_task_id,
-                meta={"model": model} if model else None,
+                meta=(
+                    {
+                        **({"model": model} if model else {}),
+                        **({"exclusive_key": exclusive_key} if exclusive_key else {}),
+                    }
+                    or None
+                ),
             )
             persisted_sub = True
             own_tqm.add_delegated_task(

--- a/tests/unit/core/test_pr_exclusive_key.py
+++ b/tests/unit/core/test_pr_exclusive_key.py
@@ -39,6 +39,103 @@ def test_dispatch_direct_task_sets_exclusive_key(tmp_path: Path) -> None:
     assert entry is not None and entry.meta["exclusive_key"] == "pr-5008"
 
 
+def _dispatch_with_ack(
+    tmp_path: Path,
+    monkeypatch,
+    task_id: str,
+    meta: dict,
+) -> tuple[bool, list]:
+    anima_dir = tmp_path / "animas" / "natsume"
+    (anima_dir / "state" / "pending").mkdir(parents=True, exist_ok=True)
+    calls: list = []
+
+    def _fake_post(target_dir, repo, number, body):
+        calls.append((repo, number, body))
+        return True
+
+    monkeypatch.setattr("core.tasks_dispatch._post_pr_comment", _fake_post)
+    ok = dispatch_direct_task(
+        target="natsume",
+        task_id=task_id,
+        summary="CI failed",
+        instruction="fix it",
+        meta=meta,
+        animas_dir=tmp_path / "animas",
+    )
+    return ok, calls
+
+
+def test_dispatch_posts_queue_ack_when_key_held(tmp_path: Path, monkeypatch) -> None:
+    anima_dir = tmp_path / "animas" / "natsume"
+    (anima_dir / "state" / "pending").mkdir(parents=True)
+    manager = TaskQueueManager(anima_dir)
+    manager.add_task(
+        source="anima",
+        original_instruction="in-flight PR work",
+        assignee="natsume",
+        summary="in-flight PR work",
+        task_id="holder-1",
+        meta={"exclusive_key": "pr-5008"},
+    )
+    ok, calls = _dispatch_with_ack(
+        tmp_path,
+        monkeypatch,
+        task_id="gh-ci-o-r#5008-360895c3",
+        meta={"repo": "o/r", "number": 5008, "sha": "360895c3"},
+    )
+    assert ok
+    assert len(calls) == 1
+    repo, number, body = calls[0]
+    assert repo == "o/r"
+    assert number == 5008
+    assert "gh-ci-o-r#5008-360895c3" in body
+    assert "holder-1" in body
+    # ack recorded to prevent double posting
+    entry = manager.get_task_by_id("gh-ci-o-r#5008-360895c3")
+    assert entry is not None and entry.meta["queue_ack_posted"] is True
+
+
+def test_dispatch_no_ack_when_key_free(tmp_path: Path, monkeypatch) -> None:
+    ok, calls = _dispatch_with_ack(
+        tmp_path,
+        monkeypatch,
+        task_id="gh-ci-o-r#5008-360895c3",
+        meta={"repo": "o/r", "number": 5008, "sha": "360895c3"},
+    )
+    assert ok
+    assert calls == []
+
+
+def test_dispatch_ack_failure_does_not_block_dispatch(tmp_path: Path, monkeypatch) -> None:
+    anima_dir = tmp_path / "animas" / "natsume"
+    (anima_dir / "state" / "pending").mkdir(parents=True)
+    manager = TaskQueueManager(anima_dir)
+    manager.add_task(
+        source="anima",
+        original_instruction="in-flight PR work",
+        assignee="natsume",
+        summary="in-flight PR work",
+        task_id="holder-1",
+        meta={"exclusive_key": "pr-5008"},
+    )
+
+    def _boom(target_dir, repo, number, body):
+        raise RuntimeError("gh down")
+
+    monkeypatch.setattr("core.tasks_dispatch._post_pr_comment", _boom)
+    ok = dispatch_direct_task(
+        target="natsume",
+        task_id="gh-ci-o-r#5008-360895c3",
+        summary="CI failed",
+        instruction="fix it",
+        meta={"repo": "o/r", "number": 5008, "sha": "360895c3"},
+        animas_dir=tmp_path / "animas",
+    )
+    assert ok
+    task_desc = json.loads((anima_dir / "state" / "pending" / "gh-ci-o-r#5008-360895c3.json").read_text())
+    assert task_desc["exclusive_key"] == "pr-5008"
+
+
 def test_regenerate_pending_json_restores_exclusive_key(tmp_path: Path) -> None:
     anima_dir = tmp_path / "animas" / "natsume"
     (anima_dir / "state" / "pending").mkdir(parents=True)

--- a/tests/unit/core/test_pr_exclusive_key.py
+++ b/tests/unit/core/test_pr_exclusive_key.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from core.blocked_recovery import regenerate_pending_json
+from core.memory.task_queue import TaskQueueManager
+from core.tasks_dispatch import dispatch_direct_task, pr_exclusive_key
+from core.tooling.handler_delegation import _pr_key_from_text
+
+
+def test_pr_exclusive_key_from_meta() -> None:
+    assert pr_exclusive_key({"repo": "o/r", "number": 5008}) == "pr-5008"
+    assert pr_exclusive_key({"repo": "o/r"}) == ""
+    assert pr_exclusive_key(None) == ""
+
+
+def test_pr_key_from_text() -> None:
+    assert _pr_key_from_text("fix CI on PR #5008 now") == "pr-5008"
+    assert _pr_key_from_text("see https://github.com/o/r/pull/4985 please") == "pr-4985"
+    assert _pr_key_from_text("no reference here") == ""
+    assert _pr_key_from_text("item #1 of the list") == ""
+
+
+def test_dispatch_direct_task_sets_exclusive_key(tmp_path: Path) -> None:
+    anima_dir = tmp_path / "animas" / "natsume"
+    (anima_dir / "state" / "pending").mkdir(parents=True)
+    assert dispatch_direct_task(
+        target="natsume",
+        task_id="gh-ci-o-r#5008-360895c3",
+        summary="CI failed",
+        instruction="fix it",
+        meta={"repo": "o/r", "number": 5008, "sha": "360895c3"},
+        animas_dir=tmp_path / "animas",
+    )
+    task_desc = json.loads((anima_dir / "state" / "pending" / "gh-ci-o-r#5008-360895c3.json").read_text())
+    assert task_desc["exclusive_key"] == "pr-5008"
+    entry = TaskQueueManager(anima_dir).get_task_by_id("gh-ci-o-r#5008-360895c3")
+    assert entry is not None and entry.meta["exclusive_key"] == "pr-5008"
+
+
+def test_regenerate_pending_json_restores_exclusive_key(tmp_path: Path) -> None:
+    anima_dir = tmp_path / "animas" / "natsume"
+    (anima_dir / "state" / "pending").mkdir(parents=True)
+    manager = TaskQueueManager(anima_dir)
+    manager.add_task(
+        source="anima",
+        original_instruction="fix PR",
+        assignee="natsume",
+        summary="fix PR",
+        task_id="regen-1",
+        meta={"exclusive_key": "pr-5008"},
+    )
+    entry = manager.get_task_by_id("regen-1")
+    assert entry is not None
+    assert regenerate_pending_json(anima_dir, "natsume", entry)
+    task_desc = json.loads((anima_dir / "state" / "pending" / "regen-1.json").read_text())
+    assert task_desc["exclusive_key"] == "pr-5008"


### PR DESCRIPTION
## Summary
- gh-ci / gh-review / gh-cmd および delegate_task 由来のPRタスクに `pr-NNNN` の `exclusive_key` を自動付与し、同一PRの作業を直列化（手動 `delegate_task` の慣例と同じキー）。`regenerate_pending_json` でもキーを保持
- 同一PRの先行タスクがキーを握っている間に新しいgh-*タスクが投入されたら、PRへ「受領しました（task …）。先行タスク … の完了後に着手します。」を1回だけ投稿（`gh api`、bot名義は `github_identities` から解決）。失敗はwarningログのみで投入は止めない

対象は #303 の(1)のみ。(2) cancel API・(3) フォールバック再評価は別PR。

## Background
外部リポジトリのPRで、rebase依頼が1秒で投入されたにもかかわらず同一PRのロック待ちで18分以上無反応に見えた（Issue #303 参照）。

## Test plan
- [x] `pytest tests/unit/core/test_pr_exclusive_key.py tests/unit/server/test_github_gateway*.py` 52 passed
- [x] ruff check / format --check 緑
- [ ] 本番反映後、同一PRに連続でイベントを発生させ、ack が1回だけ投稿されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)