### PR TITLE
fix(fallback): cap implicit error-text classification at 400 chars

### DIFF
--- a/core/execution/fallback_activity.py
+++ b/core/execution/fallback_activity.py
@@ -180,6 +180,10 @@ def runtime_fallback_config(
     return retry_config
 
 
+# ponytail: length cap; longest real provider error text seen is ~330 chars
+_IMPLICIT_ERROR_MAX_CHARS = 400
+
+
 async def run_with_model_fallback(
     run: Callable[[ModelConfig], Awaitable[_T]],
     *,
@@ -227,6 +231,12 @@ async def run_with_model_fallback(
             reason, hint = classify_llm_error_message(f"{data.get('reason') or ''} {error_text}".strip())
             explicit_error = data.get("action") == "error" or bool(data.get("reason"))
             if reason is FailoverReason.UNKNOWN and not explicit_error:
+                return result
+            if not explicit_error and len(error_text) > _IMPLICIT_ERROR_MAX_CHARS:
+                # A provider failure returned as plain text is short (longest
+                # observed: ~330 chars, OpenAI policy refusal). A long reply that
+                # merely *mentions* a 403/"forbidden" is a real answer; registering
+                # it would block the shared provider for every anima.
                 return result
             if not hint.fallback_ok:
                 return result

--- a/tests/unit/core/test_chat_model_fallback.py
+++ b/tests/unit/core/test_chat_model_fallback.py
@@ -453,3 +453,34 @@ def test_preflight_fallback_records_activity_event() -> None:
         meta={**_fallback_meta(), "phase": "preflight"},
         safe=True,
     )
+
+
+@pytest.mark.asyncio
+async def test_reply_mentioning_403_is_not_an_auth_failure(tmp_path) -> None:
+    """A normal reply quoting an API 403 must not block the provider (#natsume-deepseek)."""
+    from core.execution import fallback_activity as fa
+
+    calls: list[str] = []
+    monkey = pytest.MonkeyPatch()
+    monkey.setattr(fa, "report_capacity_block", lambda *a, **k: calls.append("blocked"))
+    try:
+        cfg = ModelConfig(model="codex/gpt-5.6-luna", execution_mode="c", resolved_mode="C", fallback_models=["a:openai/deepseek-v4-flash"])
+        reply = CycleResult(
+            trigger="cron:x",
+            action="responded",
+            summary=(
+                "Chatwork統合監視で代表宛メンションを1件検知しました。room 373957118 の再取得は "
+                "Chatwork API HTTP 403 Forbidden で失敗したため本文の確定は保留。" + "対応内容の要約。" * 60
+            ),
+        )
+
+        async def run(_c):
+            return reply
+
+        result = await fa.run_with_model_fallback(
+            run, activity=MagicMock(), primary_config=cfg, active_config=cfg, channel="cron"
+        )
+    finally:
+        monkey.undo()
+    assert result is reply
+    assert calls == []


### PR DESCRIPTION
## 問題
mei/rin の正常応答（Chatwork/GitHub API の `HTTP 403 Forbidden` に言及）が `run_with_model_fallback` の暗黙エラー分類で AUTH と誤判定され、共有 rate guard に `openai:codex` の 1800s ブロックを登録。全 anima（特に実装担当 natsume）が 1日3〜5回・各30分以上 deepseek にフォールバックしていた（8/26: natsume の deepseek 呼び出し 310件 / フォールバック 17回、本物の codex 401 は 8/23 が最後）。

## 修正
暗黙（`action=error` でも `reason` 付きでもない）summary は 400 字以下のときだけ分類する。実プロバイダエラー文の最長は約330字（OpenAI ポリシー拒否）で、既存テストの想定も70字以下。明示エラーは従来通り長さ不問。

## テスト
`test_reply_mentioning_403_is_not_an_auth_failure` 追加（修正なしで失敗を確認）。fallback 関連 23件パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)